### PR TITLE
fix(script): fix test script that was not returning a non-zero exit code when the test fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - fixed the regex matching the merge commit messages
 - fixed the JS pipeline to output the right tag in the delivery step
 - fixed wrong java jre package
+- fixed Golang test script not exiting with a non-zero exit code when the test fails
 
 ## [1.0.0] - 2023-01-02
 

--- a/global/scripts/golang/test/run.sh
+++ b/global/scripts/golang/test/run.sh
@@ -16,8 +16,23 @@ touch coverage.xml
 dir="cmd"
 [ -d "$(pwd)/main" ] && dir="main"
 
-# run the tests
+# Run the tests
 go test -v -tags test,unit,integration -coverpkg ./$dir/... -covermode=count ./$dir/... -coverprofile=coverage.txt
+test_exit_code=$?
+
 go tool cover -func coverage.txt
+cover_exit_code=$?
+
 go install github.com/boumenot/gocover-cobertura@latest
+install_exit_code=$?
+
 gocover-cobertura < coverage.txt > coverage.xml
+cobertura_exit_code=$?
+
+# Exit with the highest exit code
+exit_code=$((test_exit_code > cover_exit_code ? test_exit_code : cover_exit_code))
+exit_code=$((exit_code > install_exit_code ? exit_code : install_exit_code))
+exit_code=$((exit_code > cobertura_exit_code ? exit_code : cobertura_exit_code))
+
+# Exit
+exit $exit_code


### PR DESCRIPTION
## :vertical_traffic_light: Quality checklist

- [ x] Did you add the changes in the `CHANGELOG.md`?
