### PR TITLE
fix(go-pipeline): fixed Go Debian pipeline failing to add the .deb file to GitLab releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Fixed
 
+- fixed Go Debian pipeline failing to upload the `.deb` file to the GitLab releases
 - fixed Go pipeline for GitHub Actions missing permissions to install dependencies
 - added two missing linters to the `golangci-lint` pipeline
 - fixed the error in `global/scripts/golang/test/run.sh` where `cmd` and `internal` folders were both required at the same time

--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@ export SCRIPTS_DIR=/home/rios0rios0/Development/github.com/rios0rios0/pipelines
 $SCRIPTS_DIR/global/scripts/golangci-lint/run.sh # or any other script
 ```
 
+## Running Dev/Testing Branches
+
+In the dev branch of pipelines, you can use the following command to replace all of the references to the `main` branch:
+
+```bash
+export BRANCH=fix/golang
+find . -type f -name "*.yaml" -exec sed -i "/^[[:space:]]*-[[:space:]]\+remote:.*main/s/main/$BRANCH/g" {} +
+```
+
+After you push these changes to the dev/testing branch, update the references in your repository to point to the new branch:
+
+```yaml
+include:
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/$BRANCH/gitlab/golang/go-debian.yaml'
+```
+
 ## Contributing
 
 We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING.md) for more information.

--- a/gitlab/global/abstracts/default-image.yaml
+++ b/gitlab/global/abstracts/default-image.yaml
@@ -1,1 +1,2 @@
-image: 'docker:24.0.3' # this needs to be always a "docker:x.y" image
+default:
+  image: 'docker:24.0.3' # this needs to be always a "docker:x.y" image

--- a/gitlab/global/stages/40-delivery/release.yaml
+++ b/gitlab/global/stages/40-delivery/release.yaml
@@ -2,10 +2,15 @@ release:
   image: 'alpine:latest'
   stage: 'delivery'
   before_script:
-    - apk add --no-cache curl git jq
+    - |
+      # Install dependencies
+      apk add --no-cache curl git jq
+
+      # Load variables from the building stage
+      # This file contains build artifact information
+      [ -f artifacts.env ] && source artifacts.env
   script:
     - |
-      set -eux
       REGEX="^Merge (remote-tracking|remote|tracking)? ?branch '(origin\/)?chore\/bump-([0-9]+\.[0-9]+\.[0-9]+)'.*$"
 
       if echo "$CI_COMMIT_MESSAGE" | grep -Eq "$REGEX"; then
@@ -21,8 +26,22 @@ release:
             \"name\": \"Release $VERSION\",
             \"tag_name\": \"$VERSION\",
             \"description\": $RELEASE_NOTES,
-            \"ref\": \"$CI_COMMIT_SHA\"
-          }"
+            \"ref\": \"$CI_COMMIT_SHA\""
+
+          # Add the build artifact link if available
+          if [ ! -z "$BUILD_ARTIFACT" ]; then
+            DATA="$DATA,
+            \"assets\": {
+              \"links\": [
+                {
+                  \"name\": \"$BUILD_ARTIFACT\",
+                  \"url\": \"$PACKAGE_REGISTRY_URL/$BUILD_ARTIFACT\"
+                }
+              ]
+            }"
+          fi
+
+          DATA="$DATA}"
 
           curl -XPOST "$CI_API_V4_URL/projects/$CI_PROJECT_ID/releases" \
                --header "JOB-TOKEN: $CI_JOB_TOKEN" \

--- a/gitlab/golang/stages/40-delivery/deb.yaml
+++ b/gitlab/golang/stages/40-delivery/deb.yaml
@@ -1,20 +1,38 @@
+variables:
+  GORELEASER_VERSION: "1.21.2"
+
 delivery:qa:
   stage: 'delivery'
   image: 'golang:latest'
-  variables:
-    TAG: 'latest'
   script:
-    - apt-get update && apt-get install -y musl-tools
-    - curl -sL 'https://github.com/goreleaser/goreleaser/releases/download/v1.21.2/goreleaser_1.21.2_amd64.deb' -o /tmp/goreleaser.deb
-    - dpkg -i /tmp/goreleaser.deb
-    - curl --silent "https://gitlab.com/gitlab-org/incubation-engineering/mobile-devops/download-secure-files/-/raw/main/installer" | bash
-    - goreleaser --skip=publish --rm-dist
-    - export DEB_BINARY="${CI_PROJECT_NAME}_${TAG}_linux_amd64.deb"
-    - export PACKAGE_REGISTRY_URL="${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/generic/${CI_PROJECT_NAME}/${TAG}"
-    - 'curl --header "JOB-TOKEN: ${CI_JOB_TOKEN}" --upload-file build/dist/*.deb ${PACKAGE_REGISTRY_URL}/${DEB_BINARY}'
+    - |
+      set -eux
+      apt-get update && apt-get install -y musl-tools
+
+      # Install goreleaser
+      curl -sL "https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/goreleaser_${GORELEASER_VERSION}_amd64.deb" -o /tmp/goreleaser.deb
+      dpkg -i /tmp/goreleaser.deb
+
+      # Load repository secure files
+      curl --silent "https://gitlab.com/gitlab-org/incubation-engineering/mobile-devops/download-secure-files/-/raw/main/installer" | bash
+
+      # Build the Go project and create the .deb package
+      goreleaser --skip=publish,validate --clean
+
+      # Define variables
+      export BUILD_ARTIFACT="${CI_PROJECT_NAME}_latest_linux_amd64.deb"
+      export PACKAGE_REGISTRY_URL="${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/generic/${CI_PROJECT_NAME}/latest"
+
+      # Save variables to a file
+      echo "BUILD_ARTIFACT=${BUILD_ARTIFACT}" > artifacts.env
+      echo "PACKAGE_REGISTRY_URL=${PACKAGE_REGISTRY_URL}" >> artifacts.env
+
+      # Upload the .deb file to the GitLab package registry
+      curl --header "JOB-TOKEN: ${CI_JOB_TOKEN}" --upload-file build/dist/*.deb ${PACKAGE_REGISTRY_URL}/${BUILD_ARTIFACT}
   artifacts:
     paths:
       - 'build/dist/*.deb'
+      - 'artifacts.env'
     expire_in: '1 week'
   rules:
     - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"
@@ -25,13 +43,3 @@ delivery:prod:
     TAG: "$CI_COMMIT_TAG"
   rules:
     - if: "$CI_COMMIT_TAG"
-
-# TODO: this could be a global abstract for all binary releases
-update-release:
-  extends: 'delivery:prod'
-  image: 'registry.gitlab.com/gitlab-org/release-cli:latest'
-  script:
-    - export DEB_BINARY="${CI_PROJECT_NAME}_${TAG}_linux_amd64.deb"
-    - export PACKAGE_REGISTRY_URL="${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/generic/${CI_PROJECT_NAME}/${TAG}"
-    - release-cli update --tag-name $CI_COMMIT_TAG
-      --assets-link "{\"name\":\"${DEB_BINARY}\",\"url\":\"${PACKAGE_REGISTRY_URL}/${DEB_BINARY}\"}"


### PR DESCRIPTION
## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?

Side note: in [gitlab/global/abstracts/default-image.yaml](https://github.com/rios0rios0/pipelines/pull/72/files#diff-59ee5fd2135755be9a74fa760cdb5bcc7cda2131e327a9af3ef09103d45b2689), the `image` keyword is deprecated, so I've replaced it with `default`.