### PR TITLE
fix(azdevops-golang-delivery): avoid that the task `Getting Function …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - fixed Golang delivery stage for azure devops to only execute a task when previous tasks are successful
 - fixed the `Getting Function Outbound IP Addresses` task in Golang delivery stage to retrieve only the last function app
 - fixed cache keys in the Golang delivery stage for azure devops
+- fixed `Getting Function Outbound IP Addresses` task for Azure Devops Golang to avoid failing if there's no function deployed
 
 ### Removed
 

--- a/azure-devops/golang/stages/40-delivery/arm.yaml
+++ b/azure-devops/golang/stages/40-delivery/arm.yaml
@@ -100,9 +100,14 @@ stages:
 
                 resourceGroupName=$(ENVIRONMENT)-rg-$(AZM_FUNCTION_NAME)-$(AZM_LOCATION)
                 echo "##vso[task.setvariable variable=resourceGroupName]$resourceGroupName"
-                functionAppName=$(az functionapp list --resource-group $resourceGroupName --query "[].name" --output tsv | tail -n 1)
 
-                outboundIpAddresses=$(az webapp show --resource-group $resourceGroupName --name $functionAppName --query outboundIpAddresses --output tsv)
+                resourceGroupExists=$(az group exists --name $resourceGroupName)
+                if [ "$resourceGroupExists" = true ]; then
+                  functionAppName=$(az functionapp list --resource-group $resourceGroupName --query "[].name" --output tsv | tail -n 1)
+                  outboundIpAddresses=$(az webapp show --resource-group $resourceGroupName --name $functionAppName --query outboundIpAddresses --output tsv)
+                else
+                  outboundIpAddresses="''"
+                fi
                 echo "##vso[task.setvariable variable=outboundIpAddresses]$outboundIpAddresses"
 
           # TODO: this should be the deployment stage


### PR DESCRIPTION
…Outbound IP Addresses` fails if there's no function deployed

fix(azdevops-golang-delivery): avoid that the task `Getting Function Outbound IP Addresses` fails if there's no function deployed

test pipe

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
