### PR TITLE
fix(azdevops-delivery): fix Golang and Javascript Delivery stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - fixed the `Getting Function Outbound IP Addresses` task in Golang delivery stage to retrieve only the last function app
 - fixed cache keys in the Golang delivery stage for azure devops
 - fixed `Getting Function Outbound IP Addresses` task for Azure Devops Golang to avoid failing if there's no function or resource group deployed
+- fixed the `Download Build Artifact` task in the delivery stage for Javascript in Azure DevOps to download the artifact to the correct directory
+- fixed the Golang delivery stage for Azure DevOps by adding the `GOPATH` environment variable
 
 ### Removed
 

--- a/azure-devops/golang/stages/10-code-check/go.yaml
+++ b/azure-devops/golang/stages/10-code-check/go.yaml
@@ -5,6 +5,8 @@ stages:
     jobs:
       - job: 'style_golangci_lint'
         displayName: 'style:golangci-lint'
+        variables:
+          GOPATH: "$(Pipeline.Workspace)/.go"
         steps:
           - task: 'GoTool@0'
             inputs:

--- a/azure-devops/golang/stages/30-tests/go.yaml
+++ b/azure-devops/golang/stages/30-tests/go.yaml
@@ -5,6 +5,8 @@ stages:
     jobs:
       - job: 'test_all'
         displayName: 'test:all'
+        variables:
+          GOPATH: "$(Pipeline.Workspace)/.go"
         steps:
           - task: 'GoTool@0'
             inputs:

--- a/azure-devops/golang/stages/35-management/go.yaml
+++ b/azure-devops/golang/stages/35-management/go.yaml
@@ -18,6 +18,7 @@ stages:
         variables:
           PREFIX: ''
           REPORT_PATH: 'build/reports'
+          GOPATH: "$(Pipeline.Workspace)/.go"
         steps:
           - task: 'GoTool@0'
             inputs:

--- a/azure-devops/golang/stages/40-delivery/arm.yaml
+++ b/azure-devops/golang/stages/40-delivery/arm.yaml
@@ -7,6 +7,7 @@ stages:
         displayName: 'delivery'
         variables:
           MIGRATIONS_CACHE: "$(Build.SourcesDirectory)/.migration"
+          GOPATH: "$(Pipeline.Workspace)/.go"
           SEEDERS_CACHE: "$(Build.SourcesDirectory)/.seeder"
           AZURE_DEPLOY_CACHE: "$(Build.SourcesDirectory)/.azuredeploy"
           PIPELINE_FIREWALL_NAME: 'PipelineFirewall_$(date +"%Y%m%d%H%M%S")'

--- a/azure-devops/javascript/abstracts/execute-command-opensearch-dashboards.yaml
+++ b/azure-devops/javascript/abstracts/execute-command-opensearch-dashboards.yaml
@@ -35,11 +35,15 @@ steps:
     continueOnError: true
 
   - script: |
+      set -e
+
       cd $(Agent.TempDirectory)/OpenSearch-Dashboards/plugins/${{ parameters.PLUGIN_NAME }}
       yarn && yarn osd bootstrap
     displayName: 'Install Dependencies'
 
   - script: |
+      set -e
+
       cd $(Agent.TempDirectory)/OpenSearch-Dashboards/plugins/${{ parameters.PLUGIN_NAME }}
       ${{ parameters.COMMANDS }}
     displayName: 'Execute Commands'

--- a/azure-devops/javascript/stages/40-delivery/docker.yaml
+++ b/azure-devops/javascript/stages/40-delivery/docker.yaml
@@ -7,14 +7,16 @@ stages:
         displayName: 'delivery'
         variables:
           DOCKER_CACHE_DIR: '$(Agent.TempDirectory)/docker-cache'
+          BUILD_ARTIFACT_NAME: 'build'
+          BUILD_ARTIFACT_PATH: 'build'
         steps:
           - template: '../../abstracts/execute-command-opensearch-dashboards.yaml'
             parameters:
               TAG_NAME: '2.18.0'
               PLUGIN_NAME: 'app'
               COMMANDS: 'yarn build'
-              ARTIFACT_NAME: 'build'
-              ARTIFACT_PATH: 'build'
+              ARTIFACT_NAME: '$(BUILD_ARTIFACT_NAME)'
+              ARTIFACT_PATH: '$(BUILD_ARTIFACT_PATH)'
 
           - task: 'Cache@2'
             inputs:
@@ -23,12 +25,11 @@ stages:
             displayName: 'Cache Docker Buildx'
             continueOnError: true
 
-          - task: 'DownloadBuildArtifacts@0'
+          - task: 'DownloadPipelineArtifact@2'
             inputs:
-              buildType: 'current'
-              downloadType: 'single'
-              artifactName: 'build'
-              downloadPath: '.'
+              artifactName: '$(BUILD_ARTIFACT_NAME)'
+              targetPath: 'build'
+            displayName: 'Download Build Artifact'
 
           - task: 'Docker@2'
             inputs:
@@ -49,10 +50,13 @@ stages:
                 echo "##vso[task.setvariable variable=DOCKER_CONTAINER_TAG;isOutput=true]latest"
               fi
 
-              docker buildx build --platform linux/amd64,linux/arm64 \
+              docker buildx build \
+                --platform linux/amd64,linux/arm64 \
                 --cache-from=type=local,src=$(DOCKER_CACHE_DIR) \
                 --cache-to=type=local,dest=$(DOCKER_CACHE_DIR),mode=max \
-                --file .ci/40-delivery/app.Dockerfile --tag $TAGS --push .
+                --file .ci/40-delivery/app.Dockerfile \
+                --tag $TAGS \
+                --push .
             name: 'build'
             displayName: 'Docker Build and Push'
         continueOnError: false


### PR DESCRIPTION
change download of artifact for javascript to download into the 'build' directory, also a GOPATH env variable was specified in the delivery stage of golang to avoid error

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
