### PR TITLE
fix(azdevops-delivery-condition): add one more condition to run the azdevops delivery stage only when previous stages succeeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - fixed the Golang delivery stage for Azure DevOps by adding the `GOPATH` environment variable
 - fixed GoLang test script to set `GOPATH` variable just when it's not set (it was preventing cache in Azure DevOps)
 - fixed Dependency Track to avoid creating many of the same project
+- fixed the Azure Devops delivery stages by adding one more condition to run only when previous stages succeeded
 
 ### Removed
 

--- a/azure-devops/golang/stages/40-delivery/arm.yaml
+++ b/azure-devops/golang/stages/40-delivery/arm.yaml
@@ -1,7 +1,7 @@
 stages:
   - stage: 'delivery'
     displayName: 'delivery'
-    condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/main'))
+    condition: and(succeeded(), or(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/main')))
     jobs:
       - job: 'delivery'
         displayName: 'delivery'

--- a/azure-devops/javascript/stages/40-delivery/docker.yaml
+++ b/azure-devops/javascript/stages/40-delivery/docker.yaml
@@ -1,7 +1,7 @@
 stages:
   - stage: 'delivery'
     displayName: 'delivery'
-    condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
+    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/tags/')))
     jobs:
       - job: 'delivery'
         displayName: 'delivery'

--- a/azure-devops/python/stages/40-delivery/docker.yaml
+++ b/azure-devops/python/stages/40-delivery/docker.yaml
@@ -1,7 +1,7 @@
 stages:
   - stage: 'delivery'
     displayName: 'delivery'
-    condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
+    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/tags/')))
     jobs:
       - job: 'deliver'
         displayName: 'Build and Push'


### PR DESCRIPTION
## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
