### PR TITLE
refactor(go-cache): moved dependency compiling to before the

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - changed `docker.yaml` Azure's Golang delivery stage to use global `docker.yaml` template and remove unnecessary execution of `./config.sh` script since it's already done by the `go1.23.4.yaml` template
 - changed `docker.yaml` Azure's Javascript delivery stage to use global `docker.yaml` template since it was being repeated
 - changed cache strategy for JS projects using Azure DevOps pipelines
+- changed `go1.23.4.yaml` to compile the dependencies files before search for cache
 
 ### Fixed
 

--- a/azure-devops/golang/abstracts/go1.23.4.yaml
+++ b/azure-devops/golang/abstracts/go1.23.4.yaml
@@ -1,4 +1,10 @@
 steps:
+  - task: 'GoTool@0'
+    inputs:
+      version: '1.23.4'
+      architecture: 'amd64'
+      goArguments: 'mod tidy'
+
   - task: 'Cache@2'
     inputs:
       key: "$(Agent.JobName)|$(Agent.OS)|go.sum"
@@ -9,9 +15,3 @@ steps:
   - template: '../../global/abstracts/scripts-repo.yaml'
   - script: $(Scripts.Directory)/global/scripts/golang/init/run.sh
     displayName: 'Load Custom Configuration'
-
-  - task: 'GoTool@0'
-    inputs:
-      version: '1.23.4'
-      architecture: 'amd64'
-      goArguments: 'mod tidy'


### PR DESCRIPTION
moved dependency compiling to before the cache search to assure the changes on the `go.sum`, used on the cache key

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
