### PR TITLE
fix(deprecated-tenv): 'tenv' is deprecated (since v1.64.0) due to duplicate feature in another linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - changed cache strategy for JS projects using Azure DevOps pipelines
 - changed `execute-command-opensearch-dashboards.yaml` yarn cache keys to use the `yarn.lock` of OSD and plugin
 - changed `azure-devops/global/stages/50-deployment/database.yaml` cache keys to include subfolders
+- changed GoLangCI-Lint configuration file because `tenv` is deprecated (since `v1.64.0`) due to duplicate feature in another linter
 
 ### Fixed
 

--- a/global/scripts/golangci-lint/.golangci.yml
+++ b/global/scripts/golangci-lint/.golangci.yml
@@ -204,12 +204,6 @@ linters-settings:
     # Default: ""
     context: "scope"
 
-  tenv:
-    # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
-    # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
-    # Default: false
-    all: true
-
 
 linters:
   disable-all: true
@@ -278,7 +272,7 @@ linters:
     - spancheck # checks for mistakes with OpenTelemetry/Census spans
     - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
     - stylecheck # is a replacement for golint
-    - tenv # detects using os.Setenv instead of t.Setenv since Go1.17
+    - usetesting # reports uses of functions with replacement inside the testing package
     - testableexamples # checks if examples are testable (have an expected output)
     - testifylint # checks usage of github.com/stretchr/testify
     - testpackage # makes you use a separate _test package


### PR DESCRIPTION
```
golangci/golangci-lint info checking GitHub for latest tag
golangci/golangci-lint info found version: 1.64.8 for v1.64.8/linux/amd64
golangci/golangci-lint info installed ./bin/golangci-lint
level=warning msg="The linter 'tenv' is deprecated (since v1.64.0) due to: Duplicate feature in another linter. Replaced by usetesting."
```

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
