### PR TITLE
feat(ignore-docs): added a new rule to ignore docs folder in golangci-lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - added `arm-parameters.yaml` to generically construct `ARM` `parameters` from `library variables`
 - added new language support for Java in Azure DevOps pipelines
 - added `checkstyle.xml` config file for Azure Devops Java pipeline
+- added a new rule to ignore the docs folder in `golangci-lint`
 
 ### Changed
 

--- a/global/scripts/golangci-lint/.golangci.yml
+++ b/global/scripts/golangci-lint/.golangci.yml
@@ -435,3 +435,7 @@ linters:
           - gosec
           - noctx
           - wrapcheck
+      - path: '.*/docs'
+        linters:
+          - gochecknoglobals
+          - gochecknoinits


### PR DESCRIPTION
## :vertical_traffic_light: Quality checklist

- [X] Did you add the changes in the `CHANGELOG.md`?
