### PR TITLE
refactor(golangci-lint): added rule exclusion for swagger coments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - added new language support for Java in Azure DevOps pipelines
 - added `checkstyle.xml` config file for Azure Devops Java pipeline
 - added a new rule to ignore the docs folder in `golangci-lint`
+- added a new rule to ignore the swagger comments to godot linter in `golangci-lint`
 
 ### Changed
 

--- a/global/scripts/golangci-lint/.golangci.yml
+++ b/global/scripts/golangci-lint/.golangci.yml
@@ -413,7 +413,7 @@ linters:
       - common-false-positives
     # Excluding configuration per-path, per-linter, per-text and per-source.
     rules:
-      - source: 'TODO'
+      - source: '// ?(TODO|@\w)'
         linters: [ godot ]
       - text: 'should have a package comment'
         linters: [ revive ]
@@ -436,6 +436,4 @@ linters:
           - noctx
           - wrapcheck
       - path: '.*/docs'
-        linters:
-          - gochecknoglobals
-          - gochecknoinits
+        linters: [gochecknoglobals, gochecknoinits, godot]


### PR DESCRIPTION
linter godot must ignore swagger comments and docs

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
