### PR TITLE
feat(go1.25): added support for golang 1.25 with awscli latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - added `make test` and `make test-go-script` targets for automated testing
 - added complete test validation suite with `test-go-validation.sh` script
 - added optional RESOLVE_S3 flag to Azure DevOps Go SAM delivery to support bucket auto resolving
+- added support for building golang 1.25
 
 ### Changed
 

--- a/azure-devops/golang/stages/40-delivery/lambda.yaml
+++ b/azure-devops/golang/stages/40-delivery/lambda.yaml
@@ -31,7 +31,7 @@ stages:
     jobs:
       - job: 'delivery'
         displayName: 'delivery'
-        container: 'ghcr.io/rios0rios0/pipelines/golang:1.19-awscli'
+        container: 'ghcr.io/rios0rios0/pipelines/golang:1.25-awscli'
         variables:
           GOPATH: "$(Pipeline.Workspace)/.go"
           LAMBDA_ARTIFACT_DIR: "$(Build.SourcesDirectory)/lambda-artifact"

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ make build-and-push NAME=awscli TAG=latest
 make build-and-push NAME=bfg TAG=latest
 make build-and-push NAME=golang TAG=1.18-awscli
 make build-and-push NAME=golang TAG=1.19-awscli
+make build-and-push NAME=golang TAG=1.25-awscli
 make build-and-push NAME=python TAG=3.9-pdm-buster
 make build-and-push NAME=python TAG=3.10-pdm-bullseye
 make build-and-push NAME=tor-proxy TAG=latest

--- a/global/containers/golang.1.25-awscli/Dockerfile
+++ b/global/containers/golang.1.25-awscli/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.25
+
+RUN apt-get update && apt-get install --yes --no-install-recommends unzip \
+	&& apt-get clean autoclean \
+	&& apt-get autoremove --yes \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/lib/{apt,dpkg,cache,log}
+
+ARG AWS_CLI_FOLDER="aws"
+ARG AWS_CLI_ZIP_NAME="awscli-exe-linux-x86_64.zip"
+RUN cd /tmp && wget "https://awscli.amazonaws.com/$AWS_CLI_ZIP_NAME" \
+	&& unzip "$AWS_CLI_ZIP_NAME" && ./$AWS_CLI_FOLDER/install \
+	&& rm -rf * && aws --version
+
+ARG AWS_SAM_FOLDER="aws-sam-installation"
+ARG AWS_SAM_ZIP_NAME="aws-sam-cli-linux-x86_64.zip"
+RUN cd /tmp && wget "https://github.com/aws/aws-sam-cli/releases/latest/download/$AWS_SAM_ZIP_NAME" \
+	&& unzip "$AWS_SAM_ZIP_NAME" -d "$AWS_SAM_FOLDER" && ./$AWS_SAM_FOLDER/install \
+	&& rm -rf * && sam --version


### PR DESCRIPTION
## :vertical_traffic_light: Quality checklist

- [X] Did you add the changes in the `CHANGELOG.md`?

Added Go 1.25 support across Azure DevOps Lambda delivery by switching the delivery container to golang:1.25-awscli, building and publishing the new image via build.sh, and introducing global/containers/ golang.1.25-awscli/Dockerfile with AWS CLI/SAM installs.