### PR TITLE
feat: Add OCI image labels to Azure DevOps Docker builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Added
 
+- added OCI image labels to Azure DevOps Docker builds for traceability (`org.opencontainers.image.revision`, `org.opencontainers.image.ref.name`, `org.opencontainers.image.created`, `org.opencontainers.image.source`)
 - added `go-library.yaml` pipeline with Azure DevOps to deliver Go libraries
 - added `make test` and `make test-go-script` targets for automated testing
 - added a generic configuration to run `cyclonedx` for Python projects

--- a/azure-devops/global/stages/40-delivery/docker.yaml
+++ b/azure-devops/global/stages/40-delivery/docker.yaml
@@ -66,6 +66,10 @@ steps:
       docker buildx build ${{ parameters.DOCKER_BUILD_ARGS }} \
         --platform linux/amd64,linux/arm64 \
         --tag $TAGS \
+        --label "org.opencontainers.image.revision=$(Build.SourceVersion)" \
+        --label "org.opencontainers.image.ref.name=$(Build.SourceBranchName)" \
+        --label "org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+        --label "org.opencontainers.image.source=$(Build.Repository.Uri)" \
         $CACHE_FROM \
         $CACHE_TO \
         --file ${{ parameters.DOCKER_FILE }} \


### PR DESCRIPTION
## Summary

Add standard OCI image labels to all Docker images built through Azure DevOps pipelines for better traceability and provenance tracking.

## Changes

- Modified `azure-devops/global/stages/40-delivery/docker.yaml` to inject OCI labels via `--label` flags
- Updated `CHANGELOG.md` with feature documentation

## OCI Labels Added

All Docker images now automatically include:
- `org.opencontainers.image.revision` - Git commit SHA
- `org.opencontainers.image.ref.name` - Branch/tag name  
- `org.opencontainers.image.created` - Build timestamp (ISO 8601)
- `org.opencontainers.image.source` - Repository URI

## Benefits

✅ **Zero per-service configuration** - All services get OCI labels automatically  
✅ **No Dockerfile changes needed** - Labels added at build time via `--label` flags  
✅ **Consistent across all services** - Standardized metadata for all Docker images  
✅ **Runtime traceability** - Inspect any container to see exact build metadata  
✅ **Production debugging** - Easy identification of deployed code versions  

## Technical Implementation

- Labels injected at build time using `docker buildx --label` flags
- Uses Azure DevOps predefined variables (`Build.SourceVersion`, `Build.SourceBranchName`, etc.)
- Backward compatible - existing services automatically inherit labels on next build
- No changes required in consuming repositories

## Verification

After this change is merged, you can verify OCI labels on any built image:

```bash
docker inspect <image> | jq '.[0].Config.Labels'
```

Example output:
```json
{
  "org.opencontainers.image.revision": "7eeb4f1abc...",
  "org.opencontainers.image.ref.name": "main",
  "org.opencontainers.image.created": "2026-02-05T12:34:56Z",
  "org.opencontainers.image.source": "https://dev.azure.com/..."
}
```