### PR TITLE
hotfix(govulncheck): used absolute path to govulncheck binary installed via `go install`

### DIFF
--- a/azure-devops/golang/stages/20-security/go.yaml
+++ b/azure-devops/golang/stages/20-security/go.yaml
@@ -19,10 +19,12 @@ stages:
 
       - job: 'sca_govulncheck'
         displayName: 'sca:govulncheck'
+        variables:
+          GOPATH: "$(Pipeline.Workspace)/.go"
         steps:
           - template: '../../abstracts/go.yaml'
           - script: |
               go install golang.org/x/vuln/cmd/govulncheck@latest
-              govulncheck ./...
+              "$(go env GOPATH)/bin/govulncheck" ./...
             displayName: 'Run govulncheck'
         continueOnError: true

--- a/global/scripts/languages/golang/govulncheck/run.sh
+++ b/global/scripts/languages/golang/govulncheck/run.sh
@@ -8,13 +8,14 @@ fi
 fileName="$(pwd)/$REPORT_PATH/govulncheck.json"
 
 # Install govulncheck if not already available
-if ! command -v govulncheck > /dev/null 2>&1; then
+GOVULNCHECK_BIN="$(go env GOPATH)/bin/govulncheck"
+if [ ! -f "$GOVULNCHECK_BIN" ]; then
   echo "Installing govulncheck..."
   go install golang.org/x/vuln/cmd/govulncheck@latest
 fi
 
 echo "Running govulncheck SCA vulnerability scan..."
-govulncheck -json ./... > "$fileName" 2>&1 || EXIT_CODE=$?
+"$GOVULNCHECK_BIN" -json ./... > "$fileName" 2>&1 || EXIT_CODE=$?
 
 echo "govulncheck analysis complete. Results written to: $fileName"
 exit ${EXIT_CODE:-0}


### PR DESCRIPTION
- the `govulncheck` binary was not found in the system PATH after installation with `go install`, causing "command not found" errors in CI pipelines. Resolved by referencing the binary via its full path using `$(go env GOPATH)/bin/govulncheck` and explicitly setting GOPATH in the Azure DevOps pipeline variables.

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?

BEFORE
<img width="828" height="508" alt="image" src="https://github.com/user-attachments/assets/9b85cd91-9ade-4ed0-9bac-ef58e68fc50c" />

AFTER
<img width="750" height="487" alt="image" src="https://github.com/user-attachments/assets/a340eedd-3daf-451c-bef8-801e6a0123a0" />

