### PR TITLE
fix(terraform-tests): fixed terra test execution

### DIFF
--- a/global/scripts/tools/dependency-track/run.sh
+++ b/global/scripts/tools/dependency-track/run.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+# Set DEBUG=1 to print curl validation logs (URLs, project UUID, and form params).
 
 # read and sanitize project name
 bomFile="$PREFIX$REPORT_PATH/bom.json"
@@ -7,15 +8,25 @@ projectVersion=$(cat "$bomFile" | jq -r '.metadata.component.version')
 
 export requestApiKey="X-Api-Key: $DEPENDENCY_TRACK_TOKEN"
 
+# normalize base URL (strip trailing slash and trailing /api to avoid /api/api)
+baseUrl="${DEPENDENCY_TRACK_HOST_URL%/}"
+baseUrl="${baseUrl%/api}"
+
 # get project UUID from the JSON response
-projectUuid=$(curl --insecure --fail --request 'GET' "$DEPENDENCY_TRACK_HOST_URL/api/v1/project/latest/$projectName" \
+getProjectUrl="$baseUrl/api/v1/project/latest/$projectName"
+[ -n "${DEBUG:-}" ] && echo "[DEBUG] GET project: url=$getProjectUrl projectName=$projectName" >&2
+projectUuid=$(curl --insecure --fail --request 'GET' "$getProjectUrl" \
   -H 'Content-Type: application/json' -H "$requestApiKey" | jq -r '.uuid')
+[ -n "${DEBUG:-}" ] && echo "[DEBUG] GET project response: projectUuid=${projectUuid:-<empty>}" >&2
 
 requestContentType="Content-Type: multipart/form-data"
 
+bomUploadUrl="$baseUrl/api/v1/bom"
+
 # check if project UUID is not empty
 if [ -n "$projectUuid" ]; then
-  curl --insecure --fail --request 'POST' "$DEPENDENCY_TRACK_HOST_URL/api/v1/bom" \
+  [ -n "${DEBUG:-}" ] && echo "[DEBUG] POST bom (existing project): url=$bomUploadUrl projectUuid=$projectUuid projectVersion=$projectVersion bomFile=$bomFile" >&2
+  curl --insecure --fail --request 'POST' "$bomUploadUrl" \
     -H "$requestContentType" -H "$requestApiKey" \
     -F "project=$projectUuid" \
     -F "projectVersion=$projectVersion" \
@@ -23,7 +34,8 @@ if [ -n "$projectUuid" ]; then
     -F 'isLatest=true' \
     -F "bom=@$bomFile"
 else
-  curl --insecure --fail --request 'POST' "$DEPENDENCY_TRACK_HOST_URL/api/v1/bom" \
+  [ -n "${DEBUG:-}" ] && echo "[DEBUG] POST bom (new project): url=$bomUploadUrl projectName=$projectName projectVersion=$projectVersion bomFile=$bomFile" >&2
+  curl --insecure --fail --request 'POST' "$bomUploadUrl" \
     -H "$requestContentType" -H "$requestApiKey" \
     -F "projectName=$projectName" \
     -F "projectVersion=$projectVersion" \

--- a/makefiles/terra.mk
+++ b/makefiles/terra.mk
@@ -24,9 +24,11 @@ lint:
 test:
 	@if [ -d "modules" ]; then \
 		for module in modules/*/; do \
-			if [ -d "$$module" ]; then \
+			if [ -d "$$module/tests" ]; then \
 				echo "Testing $$module..."; \
 				(cd "$$module" && terraform init -upgrade && terraform test) || exit 1; \
+			else \
+				echo "Skipping $${module%/} (no tests/ directory)."; \
 			fi; \
 		done; \
 		echo "All module tests passed."; \


### PR DESCRIPTION
## :vertical_traffic_light: Quality checklist

- [ ] Did you add the changes in the `CHANGELOG.md`?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI helper scripts/Make targets; main risk is misconfigured URLs or altered test selection causing scans/tests to be skipped or fail unexpectedly.
> 
> **Overview**
> Makes the Dependency-Track upload script more robust by normalizing `DEPENDENCY_TRACK_HOST_URL` (avoiding `/api/api`) and adding optional `DEBUG=1` logging around the GET/POST curl calls.
> 
> Updates `terra.mk`’s `make test` to execute `terraform test` only for modules that contain a `tests/` directory, and explicitly skip modules without tests instead of attempting to run tests everywhere.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6a15d66c0611a00d5ec69efcc766f790baf5db5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->