### PR TITLE
feat(go-version): added new container to support Golang version 1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - added rebase-check quality gate to the code-check stage across all providers (GitHub Actions, GitLab CI, Azure DevOps) and all languages, failing the pipeline when a PR/MR branch is not rebased on the default branch
 - added `terra` CLI pipeline templates for all providers (GitHub Actions `terra.yaml`, GitLab CI `terra/terra.yaml`, Azure DevOps `terra/terra.yaml`) with code check, security, tests, and management stages using the [terra CLI](https://github.com/rios0rios0/terra) wrapper for Terraform/Terragrunt
 - added optional K8s deployment stage to `azure-devops/golang/go-docker.yaml` - automatically deploys with commit SHA label when `K8S_DEPLOYMENT_NAME` variable is set
+- added new container to support Golang version `1.26.0`
 
 ### Fixed
 
@@ -53,6 +54,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - rewrote `clone.sh` as idempotent installer with `PIPELINES_HOME` support, auto-directory creation, and `git pull` on subsequent runs
 - changed `cleanup.sh` to accept a `TOOL_NAME` variable, scoping report cleanup to `build/reports/<tool>/` instead of wiping the entire `build/reports/` directory
 - changed artifact publish paths across all providers (Azure DevOps `targetPath`, GitHub Actions `path`) to reference tool-specific subdirectories instead of the shared `build/reports/` root
+- changed Golang version to `1.26.0` on lambda files
 
 ## [3.0.0] - 2026-02-10
 

--- a/azure-devops/golang/stages/40-delivery/lambda.yaml
+++ b/azure-devops/golang/stages/40-delivery/lambda.yaml
@@ -28,7 +28,7 @@ stages:
     jobs:
       - job: 'delivery'
         displayName: 'delivery'
-        container: 'ghcr.io/rios0rios0/pipelines/golang:1.25-awscli'
+        container: 'ghcr.io/rios0rios0/pipelines/golang:1.26-awscli'
         variables:
           GOPATH: "$(Pipeline.Workspace)/.go"
           LAMBDA_ARTIFACT_DIR: "$(Build.SourcesDirectory)/lambda-artifact"

--- a/azure-devops/golang/stages/50-deployment/lambda.yaml
+++ b/azure-devops/golang/stages/50-deployment/lambda.yaml
@@ -31,7 +31,7 @@ stages:
     jobs:
       - job: 'deployment'
         displayName: 'deployment'
-        container: 'ghcr.io/rios0rios0/pipelines/golang:1.25-awscli'
+        container: 'ghcr.io/rios0rios0/pipelines/golang:1.26-awscli'
         steps:
           - task: 'DownloadPipelineArtifact@2'
             inputs:

--- a/global/containers/golang.1.26-awscli/Dockerfile
+++ b/global/containers/golang.1.26-awscli/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.26.0
+
+RUN apt-get update && apt-get install --yes --no-install-recommends unzip \
+	&& apt-get clean autoclean \
+	&& apt-get autoremove --yes \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/lib/{apt,dpkg,cache,log}
+
+ARG TARGETARCH
+
+RUN AWS_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") \
+	&& cd /tmp && wget "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_ARCH}.zip" \
+	&& unzip "awscli-exe-linux-${AWS_ARCH}.zip" && ./aws/install \
+	&& rm -rf * && aws --version
+
+RUN SAM_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "x86_64") \
+	&& cd /tmp && wget "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-${SAM_ARCH}.zip" \
+	&& unzip "aws-sam-cli-linux-${SAM_ARCH}.zip" -d "aws-sam-installation" && ./aws-sam-installation/install \
+	&& rm -rf * && sam --version


### PR DESCRIPTION
- changed Golang version to 1.26.0 on lambda files

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly a version bump and new container image; risk is limited to potential Go `1.26.0`/tooling compatibility changes in Lambda build/deploy steps.
> 
> **Overview**
> Updates the Azure DevOps Go Lambda delivery and deployment templates to run in a new `ghcr.io/rios0rios0/pipelines/golang:1.26-awscli` container (bumping from the prior `1.25` image).
> 
> Adds a corresponding `global/containers/golang.1.26-awscli/Dockerfile` based on Go `1.26.0` with AWS CLI and AWS SAM CLI installed, and records the new image/version bump in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf729a63c8ff4a64a30a8ce67043a725a6ad87c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->