### PR TITLE
fix(sast-tools): isolated report cleanup per tool to prevent cross-to…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - fixed test execution for `terra` pipeline
 - fixed SonarQube failing on Azure DevOps and GitLab when projects have no test coverage by detecting missing coverage files and clearing coverage report path properties before running `sonar-scanner`
 - fixed JavaScript Azure DevOps SonarQube step failing when `cobertura-coverage` artifact does not exist by adding `continueOnError: true` to the download step
+- fixed SAST tool report cleanup deleting reports from other tools by isolating each tool's output into its own `build/reports/<tool>/` subdirectory
+- fixed `make sast` aggregate target aborting on the first tool failure by adding the `-` prefix to all SAST tool recipes in `makefiles/common.mk`
 
 ### Changed
 
@@ -49,6 +51,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - consolidated `.github/workflows/ci.yaml` into 2 focused jobs (`validate` + `lint-scripts`), removing superficial security and documentation checks
 - moved test scripts from root to `.github/tests/` directory to reduce clutter for downstream users
 - rewrote `clone.sh` as idempotent installer with `PIPELINES_HOME` support, auto-directory creation, and `git pull` on subsequent runs
+- changed `cleanup.sh` to accept a `TOOL_NAME` variable, scoping report cleanup to `build/reports/<tool>/` instead of wiping the entire `build/reports/` directory
+- changed artifact publish paths across all providers (Azure DevOps `targetPath`, GitHub Actions `path`) to reference tool-specific subdirectories instead of the shared `build/reports/` root
 
 ## [3.0.0] - 2026-02-10
 

--- a/azure-devops/global/stages/20-security/codeql.yaml
+++ b/azure-devops/global/stages/20-security/codeql.yaml
@@ -13,4 +13,4 @@ jobs:
       - task: 'PublishPipelineArtifact@1'
         inputs:
           artifactName: 'codeql'
-          targetPath: 'build/reports'
+          targetPath: 'build/reports/codeql'

--- a/azure-devops/global/stages/20-security/docker.yaml
+++ b/azure-devops/global/stages/20-security/docker.yaml
@@ -13,7 +13,7 @@ jobs:
       - task: 'PublishPipelineArtifact@1'
         inputs:
           artifactName: 'semgrep'
-          targetPath: 'build/reports'
+          targetPath: 'build/reports/semgrep'
 
   - job: 'sast_gitleaks'
     displayName: 'sast:gitleaks'
@@ -29,4 +29,4 @@ jobs:
       - task: 'PublishPipelineArtifact@1'
         inputs:
           artifactName: 'gitleaks'
-          targetPath: 'build/reports'
+          targetPath: 'build/reports/gitleaks'

--- a/azure-devops/global/stages/20-security/hadolint.yaml
+++ b/azure-devops/global/stages/20-security/hadolint.yaml
@@ -9,4 +9,4 @@ jobs:
       - task: 'PublishPipelineArtifact@1'
         inputs:
           artifactName: 'hadolint'
-          targetPath: 'build/reports'
+          targetPath: 'build/reports/hadolint'

--- a/azure-devops/global/stages/20-security/trivy-sca.yaml
+++ b/azure-devops/global/stages/20-security/trivy-sca.yaml
@@ -9,4 +9,4 @@ jobs:
       - task: 'PublishPipelineArtifact@1'
         inputs:
           artifactName: 'trivy-sca'
-          targetPath: 'build/reports'
+          targetPath: 'build/reports/trivy-sca'

--- a/azure-devops/global/stages/20-security/trivy.yaml
+++ b/azure-devops/global/stages/20-security/trivy.yaml
@@ -9,4 +9,4 @@ jobs:
       - task: 'PublishPipelineArtifact@1'
         inputs:
           artifactName: 'trivy'
-          targetPath: 'build/reports'
+          targetPath: 'build/reports/trivy'

--- a/github/global/stages/20-security/docker-gitleaks/action.yaml
+++ b/github/global/stages/20-security/docker-gitleaks/action.yaml
@@ -15,7 +15,7 @@ runs:
       uses: 'actions/upload-artifact@v6'
       with:
         name: 'gitleaks'
-        path: 'build/reports/gitleaks.json'
+        path: 'build/reports/gitleaks/'
         if-no-files-found: 'error'
         overwrite: 'true'
         retention-days: 10

--- a/github/global/stages/20-security/docker-semgrep/action.yaml
+++ b/github/global/stages/20-security/docker-semgrep/action.yaml
@@ -20,7 +20,7 @@ runs:
       uses: 'actions/upload-artifact@v6'
       with:
         name: 'semgrep'
-        path: 'build/reports/semgrep.json'
+        path: 'build/reports/semgrep/'
         if-no-files-found: 'error'
         overwrite: 'true'
         retention-days: 10

--- a/github/global/stages/20-security/hadolint/action.yaml
+++ b/github/global/stages/20-security/hadolint/action.yaml
@@ -15,7 +15,7 @@ runs:
       uses: 'actions/upload-artifact@v6'
       with:
         name: 'hadolint'
-        path: 'build/reports/hadolint.sarif'
+        path: 'build/reports/hadolint/'
         if-no-files-found: 'warn'
         overwrite: 'true'
         retention-days: 10

--- a/github/global/stages/20-security/trivy-sca/action.yaml
+++ b/github/global/stages/20-security/trivy-sca/action.yaml
@@ -15,7 +15,7 @@ runs:
       uses: 'actions/upload-artifact@v6'
       with:
         name: 'trivy-sca'
-        path: 'build/reports/trivy-sca.json'
+        path: 'build/reports/trivy-sca/'
         if-no-files-found: 'error'
         overwrite: 'true'
         retention-days: 10

--- a/github/global/stages/20-security/trivy/action.yaml
+++ b/github/global/stages/20-security/trivy/action.yaml
@@ -15,7 +15,7 @@ runs:
       uses: 'actions/upload-artifact@v6'
       with:
         name: 'trivy'
-        path: 'build/reports/trivy.sarif'
+        path: 'build/reports/trivy/'
         if-no-files-found: 'error'
         overwrite: 'true'
         retention-days: 10

--- a/github/golang/stages/20-security/govulncheck/action.yaml
+++ b/github/golang/stages/20-security/govulncheck/action.yaml
@@ -19,7 +19,7 @@ runs:
       uses: 'actions/upload-artifact@v6'
       with:
         name: 'govulncheck'
-        path: 'build/reports/govulncheck.json'
+        path: 'build/reports/govulncheck/'
         if-no-files-found: 'error'
         overwrite: 'true'
         retention-days: 10

--- a/global/scripts/languages/golang/govulncheck/run.sh
+++ b/global/scripts/languages/golang/govulncheck/run.sh
@@ -3,7 +3,7 @@
 if [ -z "$SCRIPTS_DIR" ]; then
   export SCRIPTS_DIR="$(echo $(dirname "$(realpath "$0")") | sed 's|\(.*pipelines\).*|\1|')"
 fi
-. "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
+TOOL_NAME="govulncheck" . "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
 
 fileName="$(pwd)/$REPORT_PATH/govulncheck.json"
 

--- a/global/scripts/shared/cleanup.sh
+++ b/global/scripts/shared/cleanup.sh
@@ -3,4 +3,13 @@
 if [ -z "$REPORT_PATH" ]; then
   export REPORT_PATH="build/reports"
 fi
-rm -rf "$REPORT_PATH" && mkdir -p "$REPORT_PATH"
+
+if [ -n "$TOOL_NAME" ]; then
+  # If tool name given, clean only that tool's subdirectory
+  TOOL_REPORT_PATH="$REPORT_PATH/$TOOL_NAME"
+  rm -rf "$TOOL_REPORT_PATH" && mkdir -p "$TOOL_REPORT_PATH"
+  export REPORT_PATH="$TOOL_REPORT_PATH"
+else
+  # If not given, clean entire report dir (legacy behaviour)
+  rm -rf "$REPORT_PATH" && mkdir -p "$REPORT_PATH"
+fi

--- a/global/scripts/tools/codeql/run.sh
+++ b/global/scripts/tools/codeql/run.sh
@@ -3,7 +3,7 @@
 if [ -z "$SCRIPTS_DIR" ]; then
   export SCRIPTS_DIR="$(echo $(dirname "$(realpath "$0")") | sed 's|\(.*pipelines\).*|\1|')"
 fi
-. "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
+TOOL_NAME="codeql" . "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
 
 CODEQL_LANGUAGE="${1:?Usage: run.sh <language> (e.g., go, python, java, javascript, csharp)}"
 fileName="$(pwd)/$REPORT_PATH/codeql.sarif"

--- a/global/scripts/tools/gitleaks/run.sh
+++ b/global/scripts/tools/gitleaks/run.sh
@@ -3,7 +3,7 @@
 if [ -z "$SCRIPTS_DIR" ]; then
   export SCRIPTS_DIR="$(echo $(dirname "$(realpath "$0")") | sed 's|\(.*pipelines\).*|\1|')"
 fi
-. "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
+TOOL_NAME="gitleaks" . "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
 
 chmod -R 777 "$REPORT_PATH" # DinD approach needs this line
 export CONTAINER_PATH="/opt/src"

--- a/global/scripts/tools/hadolint/run.sh
+++ b/global/scripts/tools/hadolint/run.sh
@@ -3,7 +3,7 @@
 if [ -z "$SCRIPTS_DIR" ]; then
   export SCRIPTS_DIR="$(echo $(dirname "$(realpath "$0")") | sed 's|\(.*pipelines\).*|\1|')"
 fi
-. "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
+TOOL_NAME="hadolint" . "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
 
 fileName="$(pwd)/$REPORT_PATH/hadolint.sarif"
 

--- a/global/scripts/tools/semgrep/run.sh
+++ b/global/scripts/tools/semgrep/run.sh
@@ -3,7 +3,7 @@
 if [ -z "$SCRIPTS_DIR" ]; then
   export SCRIPTS_DIR="$(echo $(dirname "$(realpath "$0")") | sed 's|\(.*pipelines\).*|\1|')"
 fi
-. "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
+TOOL_NAME="semgrep" . "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
 
 chmod -R 777 "$REPORT_PATH" # DinD approach needs this line
 export CONTAINER_PATH="/src" # for this tool, it must be this value

--- a/global/scripts/tools/trivy/run-sca.sh
+++ b/global/scripts/tools/trivy/run-sca.sh
@@ -3,7 +3,7 @@
 if [ -z "$SCRIPTS_DIR" ]; then
   export SCRIPTS_DIR="$(echo $(dirname "$(realpath "$0")") | sed 's|\(.*pipelines\).*|\1|')"
 fi
-. "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
+TOOL_NAME="trivy-sca" . "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
 
 fileName="$(pwd)/$REPORT_PATH/trivy-sca.json"
 

--- a/global/scripts/tools/trivy/run.sh
+++ b/global/scripts/tools/trivy/run.sh
@@ -3,7 +3,7 @@
 if [ -z "$SCRIPTS_DIR" ]; then
   export SCRIPTS_DIR="$(echo $(dirname "$(realpath "$0")") | sed 's|\(.*pipelines\).*|\1|')"
 fi
-. "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
+TOOL_NAME="trivy" . "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
 
 fileName="$(pwd)/$REPORT_PATH/trivy.sarif"
 

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -14,18 +14,18 @@ setup:
 	@curl -sSL https://raw.githubusercontent.com/rios0rios0/pipelines/main/clone.sh | bash
 
 codeql:
-	@$(SCRIPTS_DIR)/global/scripts/tools/codeql/run.sh "$(CODEQL_LANGUAGE)"
+	-@$(SCRIPTS_DIR)/global/scripts/tools/codeql/run.sh "$(CODEQL_LANGUAGE)"
 
 semgrep:
-	@$(SCRIPTS_DIR)/global/scripts/tools/semgrep/run.sh "$(SEMGREP_LANGUAGE)"
+	-@$(SCRIPTS_DIR)/global/scripts/tools/semgrep/run.sh "$(SEMGREP_LANGUAGE)"
 
 trivy:
-	@$(SCRIPTS_DIR)/global/scripts/tools/trivy/run.sh
+	-@$(SCRIPTS_DIR)/global/scripts/tools/trivy/run.sh
 
 hadolint:
-	@$(SCRIPTS_DIR)/global/scripts/tools/hadolint/run.sh
+	-@$(SCRIPTS_DIR)/global/scripts/tools/hadolint/run.sh
 
 gitleaks:
-	@$(SCRIPTS_DIR)/global/scripts/tools/gitleaks/run.sh
+	-@$(SCRIPTS_DIR)/global/scripts/tools/gitleaks/run.sh
 
 sast: codeql semgrep trivy hadolint gitleaks


### PR DESCRIPTION
…ol report deletion

Each SAST tool now writes reports to its own subdirectory under `build/reports/<tool>/`, and the cleanup script only removes that subdirectory instead of wiping the entire `build/reports` folder. Artifact publish paths in Azure DevOps and GitHub Actions were updated accordingly. Makefile targets now ignore non-zero exit codes so the aggregate `sast` target runs all tools to completion.

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
