### PR TITLE
fix(azure-devops): set DEPLOY_STRATEGY in go-lambda-sam template

### DIFF
--- a/azure-devops/golang/go-lambda-sam.yaml
+++ b/azure-devops/golang/go-lambda-sam.yaml
@@ -35,12 +35,14 @@ stages:
       LAMBDA_RUNTIME: ${{ parameters.LAMBDA_RUNTIME }}
       GOARCH: ${{ parameters.GOARCH }}
       BUILD_FLAGS: ${{ parameters.BUILD_FLAGS }}
+      DEPLOY_STRATEGY: 'sam'
       S3_BUCKET: ${{ parameters.S3_BUCKET }}
       S3_KEY_PREFIX: ${{ parameters.S3_KEY_PREFIX }}
       RESOLVE_S3: ${{ parameters.RESOLVE_S3 }}
   - template: 'stages/50-deployment/lambda.yaml'
     parameters:
       LAMBDA_FUNCTION_NAME: ''  # Not needed for SAM, uses stack name from samconfig.toml
+      DEPLOY_STRATEGY: 'sam'
       SAM_CONFIG_ENV: ${{ parameters.SAM_CONFIG_ENV }}
       LAMBDA_RUNTIME: ${{ parameters.LAMBDA_RUNTIME }}
       LAMBDA_HANDLER: ${{ parameters.LAMBDA_HANDLER }}

--- a/azure-devops/golang/stages/40-delivery/lambda.yaml
+++ b/azure-devops/golang/stages/40-delivery/lambda.yaml
@@ -17,6 +17,9 @@ parameters:
   - name: 'S3_KEY_PREFIX'
     type: 'string'
     default: ''
+  - name: 'DEPLOY_STRATEGY'
+    type: 'string'
+    default: 'zip'
   - name: 'RESOLVE_S3'
     type: 'boolean'
     default: false
@@ -30,6 +33,7 @@ stages:
         displayName: 'delivery'
         container: 'ghcr.io/rios0rios0/pipelines/golang:1.26-awscli'
         variables:
+          DEPLOY_STRATEGY: ${{ parameters.DEPLOY_STRATEGY }}
           GOPATH: "$(Pipeline.Workspace)/.go"
           LAMBDA_ARTIFACT_DIR: "$(Build.SourcesDirectory)/lambda-artifact"
         steps:

--- a/azure-devops/golang/stages/50-deployment/lambda.yaml
+++ b/azure-devops/golang/stages/50-deployment/lambda.yaml
@@ -20,6 +20,9 @@ parameters:
   - name: 'CREATE_IF_MISSING'
     type: 'boolean'
     default: false
+  - name: 'DEPLOY_STRATEGY'
+    type: 'string'
+    default: 'zip'
   - name: 'SAM_CONFIG_ENV'
     type: 'string'
     default: 'default'
@@ -32,6 +35,8 @@ stages:
       - job: 'deployment'
         displayName: 'deployment'
         container: 'ghcr.io/rios0rios0/pipelines/golang:1.26-awscli'
+        variables:
+          DEPLOY_STRATEGY: ${{ parameters.DEPLOY_STRATEGY }}
         steps:
           - task: 'DownloadPipelineArtifact@2'
             inputs:


### PR DESCRIPTION
## Summary

- The `go-lambda-sam.yaml` template delegates to the generic `stages/40-delivery/lambda.yaml` and `stages/50-deployment/lambda.yaml` stages, which use the `DEPLOY_STRATEGY` variable to conditionally run either the plain `go build` or the `sam build` path. However, the SAM template never set this variable, causing the wrong build step to execute and fail with a `ldflags` quoting error.
- Added `DEPLOY_STRATEGY` as a declared parameter (default: `zip`) in both delivery and deployment stage templates and propagated it as a job-level variable so the existing runtime conditions work correctly.
- `go-lambda-sam.yaml` now passes `DEPLOY_STRATEGY: 'sam'` to both stages, ensuring the correct SAM build/deploy path is taken.

## Context

When using `go-lambda-sam.yaml`, the pipeline was hitting the "Build Go Lambda Function" step (meant for ZIP deploys) instead of the "Build and Package with AWS SAM" step. This caused the build to fail with:

```
invalid value "'-w" for flag -ldflags: missing =<value> in <pattern>=<value>
```

The root cause is that `DEPLOY_STRATEGY` was never set to `sam`, so the condition `ne(variables['DEPLOY_STRATEGY'], 'sam')` evaluated to `true` and the wrong step ran.

## Changes

| File | Change |
|------|--------|
| `azure-devops/golang/stages/40-delivery/lambda.yaml` | Added `DEPLOY_STRATEGY` parameter + job variable |
| `azure-devops/golang/stages/50-deployment/lambda.yaml` | Added `DEPLOY_STRATEGY` parameter + job variable |
| `azure-devops/golang/go-lambda-sam.yaml` | Passes `DEPLOY_STRATEGY: 'sam'` to both stages |

## Test plan

- [ ] Verify existing `go-lambda.yaml` consumers are unaffected (parameter defaults to `zip`)
- [ ] Verify `go-lambda-sam.yaml` consumers now correctly skip the `go build` step and run `sam build` instead

Made with [Cursor](https://cursor.com)