### PR TITLE
feat(deployment): add patch step to update deployment with commit SHA and change rollout to wait for status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Changed
 
+- changed Azure DevOps JavaScript Kubernetes deployment step to patch `app.kubernetes.io/version` with `$(Build.SourceVersion)` and wait for `rollout status` (`--timeout=300s`) instead of forcing a restart
 - renamed the existing `lint` target in `makefiles/terra.mk` to `format` to accurately reflect its purpose (`terra format`)
 - added `config.sh` loading to CodeQL for GoLang across all pipelines (GitHub Actions, GitLab CI, Azure DevOps) to support project-level build configuration before analysis
 - added `test-lambda` target to Makefile so `test-lambda-templates.sh` is now part of `make test`

--- a/azure-devops/javascript/stages/50-deployment/steps/deployment.yaml
+++ b/azure-devops/javascript/stages/50-deployment/steps/deployment.yaml
@@ -25,9 +25,21 @@ steps:
       connectionType: 'Kubernetes Service Connection'
       kubernetesServiceEndpoint: "$(K8S_ENDPOINT)"
       namespace: "$(K8S_NAMESPACE)"
+      command: 'patch'
+      arguments: >
+        deployment $(K8S_DEPLOYMENT_NAME)
+        --type=strategic
+        -p '{"spec":{"template":{"metadata":{"labels":{"app.kubernetes.io/version":"$(Build.SourceVersion)"}}}}}'
+    displayName: 'Patch Deployment with Commit SHA'
+
+  - task: 'Kubernetes@1'
+    inputs:
+      connectionType: 'Kubernetes Service Connection'
+      kubernetesServiceEndpoint: "$(K8S_ENDPOINT)"
+      namespace: "$(K8S_NAMESPACE)"
       command: 'rollout'
-      arguments: "restart deployment/$(K8S_DEPLOYMENT_NAME)"
-    displayName: 'Restart Deployment'
+      arguments: "status deployment/$(K8S_DEPLOYMENT_NAME) --timeout=300s"
+    displayName: 'Wait for Rollout'
 
   - script: ${{ parameters.RUN_AFTER_DEPLOYMENT }}
     displayName: 'Run After'


### PR DESCRIPTION
## :vertical_traffic_light: Quality checklist

- [ ] Did you add the changes in the `CHANGELOG.md`?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies Azure DevOps Kubernetes deployment behavior, which can affect release correctness and timing if patching or rollout status checks fail. Change is localized to one deployment step template and is straightforward to validate in a pipeline run.
> 
> **Overview**
> Updates the Azure DevOps JavaScript Kubernetes deployment step to **patch the pod template label** `app.kubernetes.io/version` with `$(Build.SourceVersion)` for traceability.
> 
> Replaces the previous `rollout restart` with a **blocking** `kubectl rollout status` wait (`--timeout=300s`), and documents this behavior in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20292737ef8345add5279040edffd65189511074. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->