### PR TITLE
fix(basic-checks): fixed changelog validation crash when no versioned sections exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,16 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
-### Changed
-
-- renamed `rebase-check` step to `basic-checks` across all pipeline vendors (GitHub Actions, GitLab CI, Azure DevOps)
-- added end-to-end testing instructions to `CONTRIBUTING.md` showing how to point a consuming repository at a feature branch for each platform
-
 ### Added
 
 - added changelog validation to the basic checks step, verifying that `CHANGELOG.md` is modified and entries are under the `[Unreleased]` section
 - added `global/scripts/shared/changelog-check.sh` standalone script for changelog validation
-
 - added JavaScript/Node.js (npm) pipeline for GitHub Actions with `javascript-npm.yaml` (testing/quality) and `javascript-npm-docker.yaml` (Docker delivery) reusable workflows
 - added Java (Maven) pipeline for GitHub Actions with `java-maven.yaml` (testing/quality) and `java-maven-docker.yaml` (Docker delivery) reusable workflows
 - added PHP (Composer) pipeline for GitHub Actions with `php.yaml` (testing/quality) and `php-docker.yaml` (Docker delivery) reusable workflows
@@ -52,20 +46,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - added optional K8s deployment stage to `azure-devops/golang/go-docker.yaml` - automatically deploys with commit SHA label when `K8S_DEPLOYMENT_NAME` variable is set
 - added new container to support Golang version `1.26.0`
 
-### Fixed
-
-- fixed `makefiles/terra.mk` `format` target error message that incorrectly suggested running `make lint` instead of `make format`
-- fixed `dependency-track` execution
-- fixed test execution for `terra` pipeline
-- fixed SonarQube failing on Azure DevOps and GitLab when projects have no test coverage by detecting missing coverage files and clearing coverage report path properties before running `sonar-scanner`
-- fixed JavaScript Azure DevOps SonarQube step failing when `cobertura-coverage` artifact does not exist by adding `continueOnError: true` to the download step
-- fixed SAST tool report cleanup deleting reports from other tools by isolating each tool's output into its own `build/reports/<tool>/` subdirectory
-- fixed `make sast` aggregate target aborting on the first tool failure by adding the `-` prefix to all SAST tool recipes in `makefiles/common.mk`
-- fixed `global/scripts/tools/sonarqube/run.sh` by adding `coverage.txt` in coverage file patterns
-- fixed Python CycloneDX BOM generation using an independent `BOM_PATH` variable instead of `$PREFIX$REPORT_PATH`, causing `dependency-track` upload to fail with "No such file or directory" because the BOM was written to a different path than expected
-
 ### Changed
 
+- renamed `rebase-check` step to `basic-checks` across all pipeline vendors (GitHub Actions, GitLab CI, Azure DevOps)
+- added end-to-end testing instructions to `CONTRIBUTING.md` showing how to point a consuming repository at a feature branch for each platform
 - changed Azure DevOps JavaScript Kubernetes deployment step to patch `app.kubernetes.io/version` with `$(Build.SourceVersion)` and wait for `rollout status` (`--timeout=300s`) instead of forcing a restart
 - renamed the existing `lint` target in `makefiles/terra.mk` to `format` to accurately reflect its purpose (`terra format`)
 - added `config.sh` loading to CodeQL for GoLang across all pipelines (GitHub Actions, GitLab CI, Azure DevOps) to support project-level build configuration before analysis
@@ -76,6 +60,19 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - changed `cleanup.sh` to accept a `TOOL_NAME` variable, scoping report cleanup to `build/reports/<tool>/` instead of wiping the entire `build/reports/` directory
 - changed artifact publish paths across all providers (Azure DevOps `targetPath`, GitHub Actions `path`) to reference tool-specific subdirectories instead of the shared `build/reports/` root
 - changed Golang version to `1.26.0` on lambda files
+
+### Fixed
+
+- fixed changelog validation crashing when the changelog has no versioned sections (only `[Unreleased]`), caused by `grep -v` returning exit code 1 under `bash -e -o pipefail`
+- fixed `makefiles/terra.mk` `format` target error message that incorrectly suggested running `make lint` instead of `make format`
+- fixed `dependency-track` execution
+- fixed test execution for `terra` pipeline
+- fixed SonarQube failing on Azure DevOps and GitLab when projects have no test coverage by detecting missing coverage files and clearing coverage report path properties before running `sonar-scanner`
+- fixed JavaScript Azure DevOps SonarQube step failing when `cobertura-coverage` artifact does not exist by adding `continueOnError: true` to the download step
+- fixed SAST tool report cleanup deleting reports from other tools by isolating each tool's output into its own `build/reports/<tool>/` subdirectory
+- fixed `make sast` aggregate target aborting on the first tool failure by adding the `-` prefix to all SAST tool recipes in `makefiles/common.mk`
+- fixed `global/scripts/tools/sonarqube/run.sh` by adding `coverage.txt` in coverage file patterns
+- fixed Python CycloneDX BOM generation using an independent `BOM_PATH` variable instead of `$PREFIX$REPORT_PATH`, causing `dependency-track` upload to fail with "No such file or directory" because the BOM was written to a different path than expected
 
 ## [3.0.0] - 2026-02-10
 

--- a/github/global/stages/10-code-check/basic-checks/action.yaml
+++ b/github/global/stages/10-code-check/basic-checks/action.yaml
@@ -87,7 +87,7 @@ runs:
           exit 1
         fi
 
-        NEXT_VERSION_LINE=$(echo "$CHANGELOG_CONTENT" | grep -n '^##\s*\[' | grep -v '\[Unreleased\]' | head -1 | cut -d: -f1)
+        NEXT_VERSION_LINE=$(echo "$CHANGELOG_CONTENT" | grep -n '^##\s*\[' | grep -v '\[Unreleased\]' | head -1 | cut -d: -f1 || true)
 
         DIFF_LINES=$(git diff "origin/$TARGET_BRANCH"...HEAD -- 'CHANGELOG.md' 2>/dev/null || true)
         HUNK_POSITIONS=$(echo "$DIFF_LINES" | grep '^@@' | sed 's/.*+\([0-9]*\).*/\1/' || true)


### PR DESCRIPTION
## Summary
- Fixed the `quality:basic-checks` CI step crashing silently when a project's `CHANGELOG.md` has no versioned sections (only `[Unreleased]`).
- Root cause: `grep -v '\[Unreleased\]'` returns exit code 1 when there are no matches, which propagates through `pipefail` and triggers `set -e` to terminate the script.
- Fix: appended `|| true` to the grep pipeline on line 90 of `basic-checks/action.yaml`.
- Also cleaned up duplicate `### Changed` sections and a stray blank line in `CHANGELOG.md`.

## Test plan
- [ ] Verify that a project with only `## [Unreleased]` in its CHANGELOG passes the basic-checks step
- [ ] Verify that a project with versioned sections still correctly validates entry placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)