### PR TITLE
fix(javascript): moved corepack enable before setup-node to support Yarn Berry

### DIFF
--- a/.github/workflows/javascript.yaml
+++ b/.github/workflows/javascript.yaml
@@ -25,6 +25,9 @@ jobs:
       - name: 'Checkout code'
         uses: 'actions/checkout@v6'
 
+      - name: 'Enable Corepack'
+        run: 'corepack enable'
+
       - name: 'Setup Node.js'
         uses: 'actions/setup-node@v4'
         with:
@@ -32,7 +35,6 @@ jobs:
           cache: 'yarn'
 
       - run: |
-          corepack enable
           yarn install --immutable
           yarn lint:ci
         shell: 'bash'
@@ -103,15 +105,16 @@ jobs:
       - name: 'Checkout code'
         uses: 'actions/checkout@v6'
 
+      - name: 'Enable Corepack'
+        run: 'corepack enable'
+
       - name: 'Setup Node.js'
         uses: 'actions/setup-node@v4'
         with:
           node-version: '20'
           cache: 'yarn'
 
-      - run: |
-          corepack enable
-          yarn npm audit --recursive --severity high
+      - run: 'yarn npm audit --recursive --severity high'
         shell: 'bash'
     needs: [ 'code_check-style_eslint' ]
     continue-on-error: true
@@ -126,6 +129,9 @@ jobs:
       - name: 'Checkout code'
         uses: 'actions/checkout@v6'
 
+      - name: 'Enable Corepack'
+        run: 'corepack enable'
+
       - name: 'Setup Node.js'
         uses: 'actions/setup-node@v4'
         with:
@@ -133,7 +139,6 @@ jobs:
           cache: 'yarn'
 
       - run: |
-          corepack enable
           yarn install --immutable
           yarn test:ci
         shell: 'bash'
@@ -147,6 +152,9 @@ jobs:
       - name: 'Checkout code'
         uses: 'actions/checkout@v6'
 
+      - name: 'Enable Corepack'
+        run: 'corepack enable'
+
       - name: 'Setup Node.js'
         uses: 'actions/setup-node@v4'
         with:
@@ -154,7 +162,6 @@ jobs:
           cache: 'yarn'
 
       - run: |
-          corepack enable
           yarn install --immutable
           yarn build
         shell: 'bash'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - fixed SonarQube failing on Azure DevOps and GitLab when projects have no test coverage by detecting missing coverage files and clearing coverage report path properties before running `sonar-scanner`
 - fixed `dependency-track` execution
 - fixed `global/scripts/tools/sonarqube/run.sh` by adding `coverage.txt` in coverage file patterns
+- fixed Yarn Berry compatibility in `javascript.yaml` by moving `corepack enable` before `actions/setup-node` cache step, which failed when projects declared `packageManager: yarn@4.x` in `package.json`
 - fixed `make sast` aggregate target aborting on the first tool failure by adding the `-` prefix to all SAST tool recipes in `makefiles/common.mk`
 - fixed `makefiles/terra.mk` `format` target error message that incorrectly suggested running `make lint` instead of `make format`
 - fixed changelog validation crashing when the changelog has no versioned sections (only `[Unreleased]`), caused by `grep -v` returning exit code 1 under `bash -e -o pipefail`


### PR DESCRIPTION
## Summary

- Moved `corepack enable` to a dedicated step **before** `actions/setup-node@v4` in all 4 jobs with custom Node.js steps
- This fixes the `yarn cache dir` failure when projects declare `packageManager: yarn@4.x` in `package.json`

## Root Cause

`actions/setup-node@v4` with `cache: 'yarn'` internally runs `yarn cache dir` using the system Yarn 1. When a project has `"packageManager": "yarn@4.12.0"` in `package.json`, Yarn 1 rejects it with:

> error This project's package.json defines "packageManager": "yarn@4.12.0". However the current global version of Yarn is 1.22.22.

By enabling corepack first, the correct Yarn version is available when `setup-node` runs the cache step.

## Affected Jobs

- `code_check-style_eslint`
- `security-sca_yarn_audit`
- `tests-test_all`
- `tests-test_build`

## Backward Compatibility

This change is backward-compatible. Projects without a `packageManager` field will still use system Yarn 1 via corepack.

## Test plan

- [ ] Point a Yarn Berry project (`gitforge-dashboard`) at this branch and verify all 4 jobs pass
- [ ] Verify existing Yarn 1 projects are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)