### PR TITLE
feat(java): added optional NVD_API_KEY secret support

### DIFF
--- a/.github/workflows/java-docker.yaml
+++ b/.github/workflows/java-docker.yaml
@@ -4,6 +4,7 @@ on:
 jobs:
   java:
     uses: 'rios0rios0/pipelines/.github/workflows/java.yaml@main'
+    secrets: inherit
 
   # fourth stage
   delivery-docker:

--- a/.github/workflows/java-maven-docker.yaml
+++ b/.github/workflows/java-maven-docker.yaml
@@ -4,6 +4,7 @@ on:
 jobs:
   java-maven:
     uses: 'rios0rios0/pipelines/.github/workflows/java-maven.yaml@main'
+    secrets: inherit
 
   # fourth stage
   delivery-docker:

--- a/.github/workflows/java-maven.yaml
+++ b/.github/workflows/java-maven.yaml
@@ -2,6 +2,9 @@
 # the parent workflow is responsible for setting up the call events²
 on:
   workflow_call:
+    secrets:
+      NVD_API_KEY:
+        required: false
     outputs:
       tag_name:
         description: 'The tag name created by the release job'
@@ -110,6 +113,8 @@ jobs:
 
       - run: mvn org.owasp:dependency-check-maven:check
         shell: 'bash'
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
     needs: [ 'code_check-style_maven_verify' ]
     continue-on-error: true
     if: "!startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -2,6 +2,9 @@
 # the parent workflow is responsible for setting up the call events²
 on:
   workflow_call:
+    secrets:
+      NVD_API_KEY:
+        required: false
     outputs:
       tag_name:
         description: 'The tag name created by the release job'
@@ -110,6 +113,8 @@ jobs:
 
       - run: ./gradlew dependencyCheckAnalyze
         shell: 'bash'
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
     needs: [ 'code_check-style_checkstyle' ]
     continue-on-error: true
     if: "!startsWith(github.ref, 'refs/tags/')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added optional `NVD_API_KEY` secret support to OWASP Dependency-Check jobs across GitHub Actions, GitLab CI, and Azure DevOps Java pipelines
+
 ## [3.1.0] - 2026-03-12
 
 ### Added

--- a/azure-devops/java/stages/20-security/java.yaml
+++ b/azure-devops/java/stages/20-security/java.yaml
@@ -26,4 +26,6 @@ stages:
                 export OWASP_PATH="$(pwd)/.owasp"
                 ./gradlew dependencyCheckAnalyze
               displayName: 'Run OWASP Dependency-Check'
+              env:
+                NVD_API_KEY: $(NVD_API_KEY)
           continueOnError: true

--- a/gitlab/java/stages/20-security/gradle.yaml
+++ b/gitlab/java/stages/20-security/gradle.yaml
@@ -18,6 +18,7 @@ sca:dependency-check:
   script:
     - mkdir -p '.owasp'
     - export OWASP_PATH="$(pwd)/.owasp" # the Dependency Check data path must be absolute
+    # NVD_API_KEY is optional — set it as a CI/CD variable to avoid NVD rate limits
     - gradle dependencyCheckAnalyze
   artifacts:
     when: 'always'

--- a/gitlab/java/stages/20-security/maven.yaml
+++ b/gitlab/java/stages/20-security/maven.yaml
@@ -21,6 +21,7 @@ sca:dependency-check:
   script:
     - mkdir -p '.owasp'
     - export MAVEN_OPTS="$MAVEN_OPTS -DdependencyCheck.dataDirectory=$(pwd)/.owasp" # the Dependency Check data path must be absolute
+    # NVD_API_KEY is optional — set it as a CI/CD variable to avoid NVD rate limits
     - mvn dependency-check:check
   artifacts:
     when: 'always'


### PR DESCRIPTION
## Summary

- Added optional `NVD_API_KEY` secret to OWASP Dependency-Check jobs across all three CI/CD providers (GitHub Actions, GitLab CI, Azure DevOps)
- NVD now rate-limits unauthenticated requests, so providing an API key enables faster and more reliable scans
- The secret is fully optional — pipelines continue working without it

## Test plan

- [ ] Verify GitHub Actions Java (Gradle) workflow runs without `NVD_API_KEY` configured
- [ ] Verify GitHub Actions Java (Maven) workflow runs without `NVD_API_KEY` configured
- [ ] Verify GitHub Actions Java Docker wrapper workflows forward secrets correctly
- [ ] Verify GitLab CI dependency-check jobs pick up `NVD_API_KEY` when set as CI/CD variable
- [ ] Verify Azure DevOps dependency-check step works with and without `NVD_API_KEY` pipeline variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)