### PR TITLE
feat(java): added NVD database caching to dependency-check jobs

### DIFF
--- a/.github/workflows/java-maven.yaml
+++ b/.github/workflows/java-maven.yaml
@@ -111,7 +111,19 @@ jobs:
           java-version: '21'
           cache: 'maven'
 
-      - run: mvn org.owasp:dependency-check-maven:check
+      - name: 'Cache NVD database'
+        uses: 'actions/cache@v4'
+        with:
+          path: '.owasp'
+          key: owasp-nvd-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            owasp-nvd-${{ runner.os }}-
+
+      - name: 'Run OWASP Dependency-Check'
+        run: |
+          mkdir -p '.owasp'
+          export MAVEN_OPTS="$MAVEN_OPTS -DdependencyCheck.dataDirectory=$(pwd)/.owasp"
+          mvn org.owasp:dependency-check-maven:check
         shell: 'bash'
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -111,7 +111,19 @@ jobs:
           java-version: '21'
           cache: 'gradle'
 
-      - run: ./gradlew dependencyCheckAnalyze
+      - name: 'Cache NVD database'
+        uses: 'actions/cache@v4'
+        with:
+          path: '.owasp'
+          key: owasp-nvd-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            owasp-nvd-${{ runner.os }}-
+
+      - name: 'Run OWASP Dependency-Check'
+        run: |
+          mkdir -p '.owasp'
+          export OWASP_PATH="$(pwd)/.owasp"
+          ./gradlew dependencyCheckAnalyze
         shell: 'bash'
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Added
 
 - added optional `NVD_API_KEY` secret support to OWASP Dependency-Check jobs across GitHub Actions, GitLab CI, and Azure DevOps Java pipelines
+- added NVD database caching to dependency-check jobs in GitHub Actions and Azure DevOps to avoid re-downloading on every run
 
 ## [3.1.0] - 2026-03-12
 

--- a/azure-devops/java/stages/20-security/java.yaml
+++ b/azure-devops/java/stages/20-security/java.yaml
@@ -21,6 +21,12 @@ stages:
           displayName: 'sca:dependency-check'
           steps:
             - template: '../../abstracts/gradle.yaml'
+            - task: 'Cache@2'
+              inputs:
+                key: "$(Agent.JobName)|owasp-nvd"
+                path: '.owasp'
+              displayName: 'Cache NVD database'
+              continueOnError: true
             - script: |
                 mkdir -p '.owasp'
                 export OWASP_PATH="$(pwd)/.owasp"


### PR DESCRIPTION
## Summary

- Added `actions/cache@v4` for the `.owasp` directory in GitHub Actions Gradle (`java.yaml`) and Maven (`java-maven.yaml`) workflows to cache the NVD database between runs
- Added `Cache@2` task for the `.owasp` directory in the Azure DevOps Gradle dependency-check job
- Configured `OWASP_PATH` (Gradle) and `-DdependencyCheck.dataDirectory` (Maven) to ensure tools read/write from the cached location
- GitLab CI already had this caching in place and required no changes

## Test plan

- [ ] Verify GitHub Actions Gradle workflow caches and restores `.owasp` directory across runs
- [ ] Verify GitHub Actions Maven workflow caches and restores `.owasp` directory across runs
- [ ] Verify Azure DevOps Gradle workflow caches and restores `.owasp` directory across runs
- [ ] Confirm second run of dependency-check is significantly faster due to cached NVD data

🤖 Generated with [Claude Code](https://claude.com/claude-code)