### PR TITLE
chore(java): changed actions/setup-java from v4 to v5

### DIFF
--- a/.github/workflows/java-maven.yaml
+++ b/.github/workflows/java-maven.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: 'actions/checkout@v6'
 
       - name: 'Setup Java'
-        uses: 'actions/setup-java@v4'
+        uses: 'actions/setup-java@v5'
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -105,7 +105,7 @@ jobs:
         uses: 'actions/checkout@v6'
 
       - name: 'Setup Java'
-        uses: 'actions/setup-java@v4'
+        uses: 'actions/setup-java@v5'
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -141,7 +141,7 @@ jobs:
         uses: 'actions/checkout@v6'
 
       - name: 'Setup Java'
-        uses: 'actions/setup-java@v4'
+        uses: 'actions/setup-java@v5'
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: 'actions/checkout@v6'
 
       - name: 'Setup Java'
-        uses: 'actions/setup-java@v4'
+        uses: 'actions/setup-java@v5'
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -105,7 +105,7 @@ jobs:
         uses: 'actions/checkout@v6'
 
       - name: 'Setup Java'
-        uses: 'actions/setup-java@v4'
+        uses: 'actions/setup-java@v5'
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -141,7 +141,7 @@ jobs:
         uses: 'actions/checkout@v6'
 
       - name: 'Setup Java'
-        uses: 'actions/setup-java@v4'
+        uses: 'actions/setup-java@v5'
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - added optional `NVD_API_KEY` secret support to OWASP Dependency-Check jobs across GitHub Actions, GitLab CI, and Azure DevOps Java pipelines
 - added NVD database caching to dependency-check jobs in GitHub Actions and Azure DevOps to avoid re-downloading on every run
 
+### Changed
+
+- changed `actions/setup-java` from v4 to v5 to support Node.js 24 runners
+
 ## [3.1.0] - 2026-03-12
 
 ### Added


### PR DESCRIPTION
## Summary

- Upgraded `actions/setup-java` from v4 to v5 across `java.yaml` and `java-maven.yaml` (6 occurrences)
- v4 runs on Node.js 20 which is deprecated and will be forced to Node.js 24 starting June 2, 2026
- v5 natively supports Node.js 24

## Test plan

- [x] Verify Java Gradle workflow runs successfully with `actions/setup-java@v5`
- [x] Verify Java Maven workflow runs successfully with `actions/setup-java@v5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)