### PR TITLE
fix(cache): corrected NVD data directory and cache key rotation

### DIFF
--- a/.github/workflows/java-maven.yaml
+++ b/.github/workflows/java-maven.yaml
@@ -111,18 +111,23 @@ jobs:
           java-version: '21'
           cache: 'maven'
 
+      - name: 'Get current week number'
+        id: 'week'
+        run: echo "week=$(date +%Y-%W)" >> "$GITHUB_OUTPUT"
+        shell: 'bash'
+
       - name: 'Cache NVD database'
         uses: 'actions/cache@v4'
         with:
           path: '.owasp'
-          key: owasp-nvd-${{ runner.os }}
+          key: owasp-nvd-${{ runner.os }}-${{ steps.week.outputs.week }}
           restore-keys: |
-            owasp-nvd-${{ runner.os }}
+            owasp-nvd-${{ runner.os }}-
 
       - name: 'Run OWASP Dependency-Check'
         run: |
           mkdir -p '.owasp'
-          export MAVEN_OPTS="$MAVEN_OPTS -DdependencyCheck.dataDirectory=$(pwd)/.owasp"
+          export MAVEN_OPTS="$MAVEN_OPTS -DdataDirectory=$(pwd)/.owasp"
           mvn org.owasp:dependency-check-maven:check
         shell: 'bash'
         env:

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -111,13 +111,18 @@ jobs:
           java-version: '21'
           cache: 'gradle'
 
+      - name: 'Get current week number'
+        id: 'week'
+        run: echo "week=$(date +%Y-%W)" >> "$GITHUB_OUTPUT"
+        shell: 'bash'
+
       - name: 'Cache NVD database'
         uses: 'actions/cache@v4'
         with:
           path: '.owasp'
-          key: owasp-nvd-${{ runner.os }}
+          key: owasp-nvd-${{ runner.os }}-${{ steps.week.outputs.week }}
           restore-keys: |
-            owasp-nvd-${{ runner.os }}
+            owasp-nvd-${{ runner.os }}-
 
       - name: 'Run OWASP Dependency-Check'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Fixed
 
-- fixed NVD database cache key in GitHub Actions using `github.run_id`, which prevented cache reuse across workflow runs
+- fixed NVD database cache for Dependency-Check: corrected Maven property from `-DdependencyCheck.dataDirectory` to `-DdataDirectory` and added weekly cache key rotation to prevent stale empty caches
 
 ## [3.1.0] - 2026-03-12
 

--- a/azure-devops/java/stages/20-security/java.yaml
+++ b/azure-devops/java/stages/20-security/java.yaml
@@ -21,9 +21,13 @@ stages:
           displayName: 'sca:dependency-check'
           steps:
             - template: '../../abstracts/gradle.yaml'
+            - script: echo "##vso[task.setvariable variable=WEEK_NUMBER]$(date +%Y-%W)"
+              displayName: 'Get current week number'
             - task: 'Cache@2'
               inputs:
-                key: "$(Agent.JobName)|owasp-nvd"
+                key: "$(Agent.JobName)|owasp-nvd|$(WEEK_NUMBER)"
+                restoreKeys: |
+                  $(Agent.JobName)|owasp-nvd
                 path: '.owasp'
               displayName: 'Cache NVD database'
               continueOnError: true

--- a/gitlab/java/stages/20-security/maven.yaml
+++ b/gitlab/java/stages/20-security/maven.yaml
@@ -20,7 +20,7 @@ sca:dependency-check:
       - '.owasp'
   script:
     - mkdir -p '.owasp'
-    - export MAVEN_OPTS="$MAVEN_OPTS -DdependencyCheck.dataDirectory=$(pwd)/.owasp" # the Dependency Check data path must be absolute
+    - export MAVEN_OPTS="$MAVEN_OPTS -DdataDirectory=$(pwd)/.owasp" # the Dependency Check data path must be absolute
     # NVD_API_KEY is optional — set it as a CI/CD variable to avoid NVD rate limits
     - mvn dependency-check:check
   artifacts:


### PR DESCRIPTION
## Summary
- Fixed Maven property from `-DdependencyCheck.dataDirectory` to `-DdataDirectory` so the NVD database is actually stored in `.owasp/` (was going to `~/.m2/` default location, leaving `.owasp/` empty at 195 bytes)
- Added weekly rotating cache key (`owasp-nvd-<os>-<year>-<week>`) with prefix-based `restore-keys` fallback to prevent `actions/cache@v4` from permanently caching an empty directory
- Applied the same fixes to GitHub Actions (Maven + Gradle), GitLab CI (Maven), and Azure DevOps (Gradle) templates

## Test plan
- [ ] Delete the stale empty cache in `rest-arch`: `gh cache delete owasp-nvd-Linux -R rios0rios0/rest-arch`
- [ ] Re-run the dependency-check job in [rest-arch PR #16](https://github.com/rios0rios0/rest-arch/pull/16)
- [ ] First run: full NVD download (~17 min), but cache saves the actual database (~200MB)
- [ ] Second run: cache hit with ~200MB, incremental NVD update (seconds, not minutes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)