### PR TITLE
feat(docker): added re-tag on release to skip rebuild

### DIFF
--- a/.github/workflows/dotnet-docker.yaml
+++ b/.github/workflows/dotnet-docker.yaml
@@ -12,4 +12,14 @@ jobs:
     steps:
       - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker@main'
     needs: [ 'dotnet' ]
-    if: "!failure() && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/'))"
+    if: "!failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'"
+
+  delivery-docker-retag:
+    name: 'delivery > docker retag'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker-retag@main'
+        with:
+          github_token: '${{ secrets.GITHUB_TOKEN }}'
+    needs: [ 'dotnet' ]
+    if: "!failure() && startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/go-docker.yaml
+++ b/.github/workflows/go-docker.yaml
@@ -23,4 +23,14 @@ jobs:
     steps:
       - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker@main'
     needs: [ 'go' ]
-    if: "!failure() && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/'))"
+    if: "!failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'"
+
+  delivery-docker-retag:
+    name: 'delivery > docker retag'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker-retag@main'
+        with:
+          github_token: '${{ secrets.GITHUB_TOKEN }}'
+    needs: [ 'go' ]
+    if: "!failure() && startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/java-docker.yaml
+++ b/.github/workflows/java-docker.yaml
@@ -13,4 +13,14 @@ jobs:
     steps:
       - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker@main'
     needs: [ 'java' ]
-    if: "!failure() && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/'))"
+    if: "!failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'"
+
+  delivery-docker-retag:
+    name: 'delivery > docker retag'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker-retag@main'
+        with:
+          github_token: '${{ secrets.GITHUB_TOKEN }}'
+    needs: [ 'java' ]
+    if: "!failure() && startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/java-maven-docker.yaml
+++ b/.github/workflows/java-maven-docker.yaml
@@ -13,4 +13,14 @@ jobs:
     steps:
       - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker@main'
     needs: [ 'java-maven' ]
-    if: "!failure() && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/'))"
+    if: "!failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'"
+
+  delivery-docker-retag:
+    name: 'delivery > docker retag'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker-retag@main'
+        with:
+          github_token: '${{ secrets.GITHUB_TOKEN }}'
+    needs: [ 'java-maven' ]
+    if: "!failure() && startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/javascript-docker.yaml
+++ b/.github/workflows/javascript-docker.yaml
@@ -12,4 +12,14 @@ jobs:
     steps:
       - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker@main'
     needs: [ 'javascript' ]
-    if: "!failure() && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/'))"
+    if: "!failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'"
+
+  delivery-docker-retag:
+    name: 'delivery > docker retag'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker-retag@main'
+        with:
+          github_token: '${{ secrets.GITHUB_TOKEN }}'
+    needs: [ 'javascript' ]
+    if: "!failure() && startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/javascript-npm-docker.yaml
+++ b/.github/workflows/javascript-npm-docker.yaml
@@ -12,4 +12,14 @@ jobs:
     steps:
       - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker@main'
     needs: [ 'javascript-npm' ]
-    if: "!failure() && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/'))"
+    if: "!failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'"
+
+  delivery-docker-retag:
+    name: 'delivery > docker retag'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker-retag@main'
+        with:
+          github_token: '${{ secrets.GITHUB_TOKEN }}'
+    needs: [ 'javascript-npm' ]
+    if: "!failure() && startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/php-docker.yaml
+++ b/.github/workflows/php-docker.yaml
@@ -12,4 +12,14 @@ jobs:
     steps:
       - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker@main'
     needs: [ 'php' ]
-    if: "!failure() && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/'))"
+    if: "!failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'"
+
+  delivery-docker-retag:
+    name: 'delivery > docker retag'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker-retag@main'
+        with:
+          github_token: '${{ secrets.GITHUB_TOKEN }}'
+    needs: [ 'php' ]
+    if: "!failure() && startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/python-docker.yaml
+++ b/.github/workflows/python-docker.yaml
@@ -3,7 +3,7 @@ on:
 
 jobs:
   python-build:
-    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: 'ubuntu-latest'
     outputs:
       wheel-path: ${{ steps.build-wheel.outputs.wheel-path }}
@@ -50,9 +50,17 @@ jobs:
 
       - run: ls -la dist
 
-      - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker@fix/github-docker'
+      - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker@main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ github.ref_type == 'tag' && github.ref_name || 'latest' }}
+
+  delivery-docker-retag:
+    name: 'delivery > docker retag'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker-retag@main'
+        with:
+          github_token: '${{ secrets.GITHUB_TOKEN }}'
+    if: "!failure() && startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/ruby-docker.yaml
+++ b/.github/workflows/ruby-docker.yaml
@@ -12,4 +12,14 @@ jobs:
     steps:
       - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker@main'
     needs: [ 'ruby' ]
-    if: "!failure() && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/'))"
+    if: "!failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'"
+
+  delivery-docker-retag:
+    name: 'delivery > docker retag'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker-retag@main'
+        with:
+          github_token: '${{ secrets.GITHUB_TOKEN }}'
+    needs: [ 'ruby' ]
+    if: "!failure() && startsWith(github.ref, 'refs/tags/')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,15 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - added code check stage (10) to Helm Azure DevOps pipeline with `helm lint` and `helm template` validation
 - added security stage (20) to Helm Azure DevOps pipeline with Semgrep, Gitleaks, Hadolint, and Trivy
 - added cross-compilation check step to Go pipeline that builds for linux, darwin, and windows (amd64 + arm64) to catch platform-specific type errors at PR time
+- added `docker-retag` composite action for GitHub Actions that re-tags an existing `:latest` image with a release tag using `crane`, avoiding a full Docker rebuild on tag events
+- added OCI image labels (`org.opencontainers.image.revision`, `org.opencontainers.image.ref.name`, `org.opencontainers.image.source`) to GitHub Actions Docker builds to match Azure DevOps and enable digest verification
 
 ### Changed
 
 - changed Helm chart delivery to always push `0.0.0-latest` and additionally push the tag-derived version on tag builds, matching Docker's dual-tag strategy
+- changed all GitHub Actions `*-docker.yaml` workflows to use `docker-retag` action on tag events instead of rebuilding the Docker image from scratch
+- changed GitLab CI `delivery:prod` job to use `crane copy` for re-tagging instead of a full Docker rebuild on tag events
+- changed Azure DevOps global Docker delivery template to attempt `crane`-based re-tagging on tag events before falling back to a full build
 
 ## [3.2.0] - 2026-03-14
 

--- a/azure-devops/global/stages/40-delivery/docker.yaml
+++ b/azure-devops/global/stages/40-delivery/docker.yaml
@@ -43,6 +43,19 @@ steps:
       fi
       imageName="${{ parameters.CONTAINER_REGISTRY_SERVER }}/$dockerImageName"
 
+      if [[ "$(Build.SourceBranch)" == refs/tags/* ]]; then
+        echo "Tag event detected, attempting to re-tag :latest as :$(Build.SourceBranchName)"
+        curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_x86_64.tar.gz" \
+          | tar xz -C /usr/local/bin crane
+        if crane copy "$imageName:latest" "$imageName:$(Build.SourceBranchName)"; then
+          containerImageTagName="$imageName:$(Build.SourceBranchName)"
+          echo "##vso[task.setvariable variable=CONTAINER_IMAGE;isOutput=true]$containerImageTagName"
+          echo "Successfully re-tagged $imageName:latest as $containerImageTagName"
+          exit 0
+        fi
+        echo "##vso[task.logissue type=warning]Re-tag failed, falling back to full build"
+      fi
+
       TAGS="$imageName:latest"
       if [[ "$(Build.SourceBranch)" == refs/tags/* ]]; then
         TAGS="$TAGS -t $imageName:$(Build.SourceBranchName)"

--- a/github/global/stages/40-delivery/docker-retag/action.yaml
+++ b/github/global/stages/40-delivery/docker-retag/action.yaml
@@ -1,0 +1,65 @@
+inputs:
+  github_token:
+    type: 'string'
+    required: true
+  source_tag:
+    type: 'string'
+    required: false
+    default: 'latest'
+  target_tag:
+    type: 'string'
+    required: false
+    default: ''
+  image:
+    type: 'string'
+    required: false
+    default: ''
+  expected_revision:
+    type: 'string'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Login to Registry'
+      uses: 'docker/login-action@v3'
+      with:
+        registry: 'ghcr.io'
+        username: '${{ github.actor }}'
+        password: '${{ inputs.github_token }}'
+
+    - name: 'Install crane'
+      shell: 'bash'
+      run: |
+        curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_x86_64.tar.gz" \
+          | tar xz -C /usr/local/bin crane
+
+    - name: 'Re-tag Image'
+      shell: 'bash'
+      run: |
+        IMAGE="${{ inputs.image }}"
+        if [ -z "$IMAGE" ]; then
+          IMAGE="ghcr.io/${{ github.repository }}"
+        fi
+
+        TARGET_TAG="${{ inputs.target_tag }}"
+        if [ -z "$TARGET_TAG" ]; then
+          TARGET_TAG="${{ github.ref_name }}"
+        fi
+
+        SOURCE="${IMAGE}:${{ inputs.source_tag }}"
+        TARGET="${IMAGE}:${TARGET_TAG}"
+
+        EXPECTED_REV="${{ inputs.expected_revision }}"
+        if [ -n "$EXPECTED_REV" ]; then
+          ACTUAL_REV=$(crane config "$SOURCE" | jq -r '.config.Labels["org.opencontainers.image.revision"] // empty')
+          if [ -n "$ACTUAL_REV" ] && [ "$ACTUAL_REV" != "$EXPECTED_REV" ]; then
+            echo "::error::Revision mismatch: image has $ACTUAL_REV, expected $EXPECTED_REV"
+            exit 1
+          fi
+        fi
+
+        echo "Copying $SOURCE -> $TARGET"
+        crane copy "$SOURCE" "$TARGET"
+        echo "Successfully re-tagged $SOURCE as $TARGET"

--- a/github/global/stages/40-delivery/docker/action.yaml
+++ b/github/global/stages/40-delivery/docker/action.yaml
@@ -23,3 +23,7 @@ runs:
         context: '.'
         push: true
         tags: '${{ inputs.tags }}'
+        labels: |
+          org.opencontainers.image.revision=${{ github.sha }}
+          org.opencontainers.image.ref.name=${{ github.ref_name }}
+          org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}

--- a/gitlab/global/stages/40-delivery/docker.yaml
+++ b/gitlab/global/stages/40-delivery/docker.yaml
@@ -14,8 +14,16 @@ delivery:qa:
     - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"
 
 delivery:prod:
-  extends: 'delivery:qa'
+  stage: 'delivery'
+  image: 'alpine:latest'
   variables:
-    TAG: "$CI_COMMIT_TAG"
+    REGISTRY_PATH: "$CI_REGISTRY_IMAGE"
+    IMAGE_SUFFIX: ''
+  before_script:
+    - apk add --no-cache curl
+    - curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_x86_64.tar.gz" | tar xz crane
+    - ./crane auth login "$CI_REGISTRY" -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD"
+  script:
+    - ./crane copy "$REGISTRY_PATH$IMAGE_SUFFIX:latest" "$REGISTRY_PATH$IMAGE_SUFFIX:$CI_COMMIT_TAG"
   rules:
     - if: "$CI_COMMIT_TAG"


### PR DESCRIPTION
## Summary

- Added a `docker-retag` composite action for GitHub Actions that uses `crane copy` to re-tag an existing `:latest` image with the release tag, avoiding a full Docker rebuild on tag events
- Added OCI labels (`revision`, `ref.name`, `source`) to GitHub Actions Docker builds to enable digest verification and match Azure DevOps
- Changed all 9 `*-docker.yaml` GitHub Actions workflows to split into build-on-main + retag-on-tag jobs
- Changed GitLab CI `delivery:prod` from a full rebuild to a `crane copy` re-tag
- Changed Azure DevOps global Docker template to attempt `crane`-based re-tagging on tag events, with automatic fallback to a full build if re-tag fails

## Test plan

- [ ] Push a bump commit to a test repo using GitHub Actions → verify `:latest` is built with OCI labels → push tag → verify `delivery-docker-retag` runs and the tagged image has the same digest as `:latest`
- [ ] Repeat the flow on a GitLab CI consumer → verify `delivery:prod` uses `crane copy` instead of rebuilding
- [ ] Repeat the flow on an Azure DevOps consumer → verify tag triggers crane re-tag, and multi-platform manifest is preserved
- [ ] Delete `:latest` from a test registry, push a tag → verify Azure DevOps falls back to full build (GitHub Actions / GitLab will fail as expected — no fallback in v1)
- [ ] Verify YAML syntax passes CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)