### PR TITLE
feat(helm): added code check, security stages and dual-tag delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added code check stage (10) to Helm Azure DevOps pipeline with `helm lint` and `helm template` validation
+- added security stage (20) to Helm Azure DevOps pipeline with Semgrep, Gitleaks, Hadolint, and Trivy
+
+### Changed
+
+- changed Helm chart delivery to always push `0.0.0-latest` and additionally push the tag-derived version on tag builds, matching Docker's dual-tag strategy
+
 ## [3.2.0] - 2026-03-14
 
 ### Added

--- a/azure-devops/global/stages/40-delivery/helm.yaml
+++ b/azure-devops/global/stages/40-delivery/helm.yaml
@@ -25,28 +25,38 @@ steps:
   - bash: |
       set -euo pipefail
 
+      CHART_DIR="${{ parameters.CHART_DIRECTORY }}"
+      REGISTRY="oci://${{ parameters.HELM_REGISTRY_SERVER }}/charts"
+
+      package_and_push() {
+        local version="$1"
+
+        if ! [[ "$version" =~ ^[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+          echo "Error: version '$version' is not a valid SemVer version."
+          echo "When building from a tag, use tags like '1.2.3' or 'v1.2.3'."
+          exit 1
+        fi
+
+        package_output=$(helm package "$CHART_DIR" --version "$version")
+        chart_archive=$(echo "$package_output" | awk '/Successfully packaged chart/ {print $NF}' | tail -n1)
+
+        if [ -z "$chart_archive" ]; then
+          echo "Error: failed to determine packaged chart archive path from helm output:"
+          echo "$package_output"
+          exit 1
+        fi
+
+        echo "Pushing chart version '$version'..."
+        helm push "$chart_archive" "$REGISTRY"
+        rm -f "$chart_archive"
+      }
+
       if [[ "$(Build.SourceBranch)" == refs/tags/* ]]; then
         RAW_TAG="$(Build.SourceBranchName)"
         # Normalize tag by stripping a leading "v" if present (e.g., v1.2.3 -> 1.2.3)
         CHART_VERSION="${RAW_TAG#v}"
-      else
-        CHART_VERSION="0.0.0-latest"
+        package_and_push "$CHART_VERSION"
       fi
 
-      # Validate that CHART_VERSION is a valid SemVer string before calling helm
-      if ! [[ "$CHART_VERSION" =~ ^[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
-        echo "Error: CHART_VERSION '$CHART_VERSION' is not a valid SemVer version."
-        echo "When building from a tag, use tags like '1.2.3' or 'v1.2.3'."
-        exit 1
-      fi
-      package_output=$(helm package ${{ parameters.CHART_DIRECTORY }} --version "$CHART_VERSION")
-      chart_archive=$(echo "$package_output" | awk '/Successfully packaged chart/ {print $NF}' | tail -n1)
-
-      if [ -z "$chart_archive" ]; then
-        echo "Error: failed to determine packaged chart archive path from helm output:"
-        echo "$package_output"
-        exit 1
-      fi
-
-      helm push "$chart_archive" oci://${{ parameters.HELM_REGISTRY_SERVER }}/charts
+      package_and_push "0.0.0-latest"
     displayName: 'Package and Push Helm Chart'

--- a/azure-devops/helm/helm-chart.yaml
+++ b/azure-devops/helm/helm-chart.yaml
@@ -1,2 +1,4 @@
 stages:
+  - template: 'stages/10-code-check/helm.yaml'
+  - template: 'stages/20-security/helm.yaml'
   - template: 'stages/40-delivery/helm.yaml'

--- a/azure-devops/helm/stages/10-code-check/helm.yaml
+++ b/azure-devops/helm/stages/10-code-check/helm.yaml
@@ -1,0 +1,20 @@
+stages:
+  - stage: 'code_check'
+    displayName: 'code check (style/quality)'
+    condition: not(startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
+    jobs:
+      - template: '../../../global/stages/10-code-check/basic-checks.yaml'
+
+      - job: 'style_helm_lint'
+        displayName: 'style:helm-lint'
+        steps:
+          - task: HelmInstaller@1
+            displayName: 'Install Helm'
+            inputs:
+              helmVersionToInstall: 'latest'
+
+          - script: helm lint .
+            displayName: 'Run Helm lint'
+
+          - script: helm template . > /dev/null
+            displayName: 'Run Helm template validation'

--- a/azure-devops/helm/stages/20-security/helm.yaml
+++ b/azure-devops/helm/stages/20-security/helm.yaml
@@ -1,0 +1,14 @@
+stages:
+  - stage: 'security'
+    displayName: 'security (sca/sast)'
+    condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')))
+    jobs:
+      - template: '../../../global/stages/20-security/docker.yaml'
+        parameters:
+          SEMGREP_LANGUAGE: 'kubernetes'
+
+      - template: '../../../global/stages/20-security/hadolint.yaml'
+
+      - template: '../../../global/stages/20-security/trivy.yaml'
+
+      - template: '../../../global/stages/20-security/trivy-sca.yaml'


### PR DESCRIPTION
## Summary

- Added **code check stage (10)** to Helm Azure DevOps pipeline with `helm lint` and `helm template` validation
- Added **security stage (20)** with Semgrep (`p/kubernetes`), Gitleaks, Hadolint, and Trivy
- Changed Helm delivery to always push `0.0.0-latest` and additionally push the tag-derived version on tag builds, matching Docker's dual-tag strategy

## Test plan

- [ ] Verify PR build runs stages 10 + 20 (lint, template validation, Semgrep, Gitleaks, Hadolint, Trivy) and skips delivery
- [ ] Verify main branch build pushes only `0.0.0-latest`
- [ ] Verify tag build (e.g., `v1.2.3`) pushes both `1.2.3` and `0.0.0-latest`
- [ ] Verify tag builds skip stages 10 + 20

🤖 Generated with [Claude Code](https://claude.com/claude-code)