### PR TITLE
fix(helm): replace mutable latest tag with SHA-based chart versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- changed Helm chart builds from mutable `0.0.0-latest` to immutable `0.0.0-<commit>` versioning, ensuring each push produces a unique, traceable chart version
+
 ### Fixed
 
 - fixed JavaScript Azure DevOps SonarQube step downloading the wrong artifact name `cobertura-coverage` instead of `coverage-cobertura` as published by the test stage

--- a/azure-devops/global/stages/40-delivery/helm.yaml
+++ b/azure-devops/global/stages/40-delivery/helm.yaml
@@ -51,12 +51,13 @@ steps:
         rm -f "$chart_archive"
       }
 
+      SHORT_SHA=$(echo "$(Build.SourceVersion)" | cut -c1-7)
+
       if [[ "$(Build.SourceBranch)" == refs/tags/* ]]; then
         RAW_TAG="$(Build.SourceBranchName)"
-        # Normalize tag by stripping a leading "v" if present (e.g., v1.2.3 -> 1.2.3)
         CHART_VERSION="${RAW_TAG#v}"
         package_and_push "$CHART_VERSION"
+      else
+        package_and_push "0.0.0-${SHORT_SHA}"
       fi
-
-      package_and_push "0.0.0-latest"
     displayName: 'Package and Push Helm Chart'


### PR DESCRIPTION
- change non-tag Helm chart version from `0.0.0-latest` to `0.0.0-sha-<SHORT_SHA>` for immutable, traceable builds
- extract SHORT_SHA from Build.SourceVersion (first 7 characters)


Made-with: Cursor

## :vertical_traffic_light: Quality checklist

- [X] Did you add the changes in the `CHANGELOG.md`?
