### PR TITLE
fix(javascript): correct SonarQube coverage artifact name from cobert…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed JavaScript Azure DevOps SonarQube step downloading the wrong artifact name `cobertura-coverage` instead of `coverage-cobertura` as published by the test stage
+
 ## [3.3.0] - 2026-03-18
 
 ### Added

--- a/azure-devops/javascript/stages/35-management/steps/sonarqube.yaml
+++ b/azure-devops/javascript/stages/35-management/steps/sonarqube.yaml
@@ -20,7 +20,7 @@ steps:
 
   - task: 'DownloadPipelineArtifact@2'
     inputs:
-      artifactName: 'cobertura-coverage'
+      artifactName: 'coverage-cobertura'
       targetPath: "${{ parameters.WORKING_DIRECTORY }}/coverage"
     displayName: 'Download Cobertura Coverage File'
     continueOnError: true


### PR DESCRIPTION
…ura-coverage to coverage-cobertura

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
