### PR TITLE
fix: update stale action ref from deleted branch to main

### DIFF
--- a/.github/workflows/python-docker.yaml
+++ b/.github/workflows/python-docker.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - run: ls -la dist
 
-      - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker@fix/github-docker'
+      - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker@main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tags: |


### PR DESCRIPTION
## Summary

- Fix `python-docker.yaml` referencing deleted branch `@fix/github-docker` → `@main`

All repos using this shared workflow (e.g. `fnk0c/database-sync`) fail at `delivery > docker`:

```
Unable to resolve action rios0rios0/pipelines@fix/github-docker, unable to find version fix/github-docker
```


Made with [Cursor](https://cursor.com)