### PR TITLE
refactor(python): standardize GitHub Actions Python workflows to PDM naming

### DIFF
--- a/github/python/pdm-docker.yaml
+++ b/github/python/pdm-docker.yaml
@@ -1,0 +1,1 @@
+../../.github/workflows/pdm-docker.yaml

--- a/github/python/pdm.yaml
+++ b/github/python/pdm.yaml
@@ -1,0 +1,1 @@
+../../.github/workflows/pdm.yaml

--- a/github/python/python-docker.yaml
+++ b/github/python/python-docker.yaml
@@ -1,1 +1,0 @@
-../../.github/workflows/python-docker.yaml

--- a/github/python/python.yaml
+++ b/github/python/python.yaml
@@ -1,1 +1,0 @@
-../../.github/workflows/python.yaml


### PR DESCRIPTION
## Summary

- Renamed `python.yaml` → `pdm.yaml` and `python-docker.yaml` → `pdm-docker.yaml` to follow the toolchain-based naming convention (matching Azure DevOps/GitLab)
- Refactored `pdm.yaml` to use composite actions (`pdm-lint`, `safety`, `tests/all`) instead of inline container-based steps, migrating from `python:3.10-pdm-bullseye` to `actions/setup-python@v6` with Python 3.13
- Restructured `pdm-docker.yaml` to call `pdm.yaml` via `uses:` and add delivery jobs, matching the Go `-docker.yaml` composition pattern
- Fixed job display names (`quality:` instead of `style:` for flake8/mypy), added `continue-on-error: true` for mypy/safety, and updated all documentation (CLAUDE.md, README.md, CHANGELOG.md, copilot-instructions.md)

## Test plan

- [ ] Verify `pdm.yaml` and `pdm-docker.yaml` symlinks in `github/python/` resolve correctly
- [ ] Test a downstream Python/PDM project calling `pdm-docker.yaml@main`
- [ ] Confirm composite actions (`pdm-lint`, `safety`, `tests/all`) execute properly in GitHub Actions
- [ ] Verify old `python.yaml` / `python-docker.yaml` references no longer exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)