### PR TITLE
feat(golang): added Android build targets to cross-compile and GoReleaser

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -7,7 +7,7 @@ on:
         type: 'boolean'
         required: false
         default: false
-        description: 'Enable cross-compilation check for all 6 OS/arch targets'
+        description: 'Enable cross-compilation check for all 8 OS/arch targets'
 
 # it wasn't needed to set up anything for GoLang because 'ubuntu-latest' has all dependencies
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Added
 
+- added Android (`android/amd64`, `android/arm64`) as build targets to Go cross-compile validation and GoReleaser binary template
 - added workflow to auto-update major version tags (e.g., `v3`) when a new SemVer release is published, enabling downstream repos to pin to stable `@v3` refs
 - added Python composite actions (`pdm-lint`, `safety`, `tests/all`) under `github/python/stages/`, replacing inline workflow steps and matching Go's composite action pattern
 

--- a/global/scripts/languages/golang/cross-compile/run.sh
+++ b/global/scripts/languages/golang/cross-compile/run.sh
@@ -13,6 +13,8 @@ TARGETS=(
   "darwin/arm64"
   "windows/amd64"
   "windows/arm64"
+  "android/amd64"
+  "android/arm64"
 )
 
 FAILED=0

--- a/global/scripts/languages/golang/goreleaser/.goreleaser.yaml
+++ b/global/scripts/languages/golang/goreleaser/.goreleaser.yaml
@@ -14,6 +14,7 @@ builds:
       - linux
       - darwin
       - windows
+      - android
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
## Summary

- Added `android/amd64` and `android/arm64` to the Go cross-compile validation script (`go vet` type-checking) and GoReleaser binary template
- Grows the build matrix from 6 to 8 OS/arch targets
- All builds already use `CGO_ENABLED=0`, so pure Go programs compile for Android without the Android NDK

## Test plan

- [ ] Verify `make cross-compile` passes with the two new Android targets in a downstream Go project
- [ ] Verify GoReleaser produces `android/amd64` and `android/arm64` `tar.gz` archives on a tagged release
- [ ] Confirm GitLab CI binary delivery (GoReleaser v1.21.2) handles the `android` goos without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)