### PR TITLE
fix(golang): gracefully skipped Android cross-compile when cgo toolchain is unavailable

### DIFF
--- a/global/scripts/languages/golang/cross-compile/run.sh
+++ b/global/scripts/languages/golang/cross-compile/run.sh
@@ -32,7 +32,11 @@ for target in "${TARGETS[@]}"; do
   fi
 
   output=$(CGO_ENABLED="$cgo_enabled" GOOS="$os" GOARCH="$arch" go vet ./... 2>&1) || {
-    if [[ "$cgo_enabled" -eq 1 ]] && echo "$output" | grep -q "requires external (cgo) linking"; then
+    if [[ "$cgo_enabled" -eq 1 ]] && { \
+      [[ "$output" == *"requires external (cgo) linking"* ]] || \
+      [[ "$output" == *"C compiler"* ]] || \
+      [[ "$output" == *"exec: \""*"\": executable file not found"* ]]; \
+    }; then
       echo "SKIP: ${os}/${arch} (requires cgo; no C cross-compiler available)"
     else
       echo "$output"


### PR DESCRIPTION
## Summary

- Android targets (`android/amd64`, `android/arm64`) require external (cgo) linking, which fails when `CGO_ENABLED=0`
- Enabled `CGO_ENABLED=1` for Android targets and gracefully skip with a `SKIP` message when no C cross-compiler is available
- Non-Android targets remain unchanged (`CGO_ENABLED=0`) and real type-checking errors still fail the build

## Test plan

- [ ] Verify cross-compile script passes on CI (Android targets show `SKIP` instead of `FAIL`)
- [ ] Verify non-Android targets still report `FAIL` on real type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)