### PR TITLE
fix(github): removed secrets context from job-level if in yarn and npm workflows

### DIFF
--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -196,7 +196,7 @@ jobs:
     container:
       image: 'sonarsource/sonar-scanner-cli:6.2.1'
     needs: ['tests-test_all']
-    if: "inputs.sonar_host != '' && secrets.sonar_token != '' && !startsWith(github.ref, 'refs/tags/')"
+    if: "inputs.sonar_host != '' && !startsWith(github.ref, 'refs/tags/')"
     continue-on-error: true
     steps:
       - name: 'Checkout code'

--- a/.github/workflows/yarn.yaml
+++ b/.github/workflows/yarn.yaml
@@ -206,7 +206,7 @@ jobs:
     container:
       image: 'sonarsource/sonar-scanner-cli:6.2.1'
     needs: ['tests-test_all']
-    if: "inputs.sonar_host != '' && secrets.sonar_token != '' && !startsWith(github.ref, 'refs/tags/')"
+    if: "inputs.sonar_host != '' && !startsWith(github.ref, 'refs/tags/')"
     continue-on-error: true
     steps:
       - name: 'Checkout code'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Fixed
 
+- fixed `yarn.yaml` and `npm.yaml` SonarQube job failing at workflow parse time by removing `secrets.sonar_token` from job-level `if` condition (GitHub Actions does not allow `secrets` context in reusable workflow job `if` expressions)
 - fixed `pdm.yaml` display names for `flake8` and `mypy` jobs from `style:` to `quality:` to match their job IDs
 - fixed missing `continue-on-error: true` on `mypy` and `safety` jobs to match Azure DevOps golden standard
 - fixed `pdm-docker.yaml` skipping all code check, security, and test stages when used standalone


### PR DESCRIPTION
## Summary

- fixed `yarn.yaml` and `npm.yaml` SonarQube job causing entire caller workflows to fail at parse time with zero jobs executed
- removed `secrets.sonar_token != ''` from job-level `if` condition — GitHub Actions does not allow the `secrets` context in job-level `if` expressions within reusable workflows
- the `inputs.sonar_host` input alone is sufficient to gate the SonarQube job; a missing token will fail at the step level, which is safe since the job has `continue-on-error: true`

## Test plan

- [ ] Verify `gitforge-dashboard` PR #16 triggers and runs all jobs after this is merged
- [ ] Verify SonarQube job is skipped when `sonar_host` is not provided
- [ ] Verify SonarQube job runs when `sonar_host` is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)