### PR TITLE
feat(github): added Claude Code workflows

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -1,0 +1,15 @@
+name: 'Claude Code Review'
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    uses: 'rios0rios0/.github/.github/workflows/claude-code-review.yaml@main'
+    secrets: inherit
+    permissions:
+      contents: 'read'
+      pull-requests: 'write'
+      issues: 'write'
+      id-token: 'write'

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -1,0 +1,22 @@
+name: 'Claude Code'
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    uses: 'rios0rios0/.github/.github/workflows/claude.yaml@main'
+    secrets: inherit
+    permissions:
+      contents: 'write'
+      pull-requests: 'write'
+      issues: 'write'
+      id-token: 'write'
+      actions: 'read'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Added
 
+- added Claude Code workflow (`claude.yaml`) for AI-assisted issue and PR comment handling via `@claude` mentions
+- added Claude Code Review workflow (`claude-code-review.yaml`) for automated PR code review on open/sync/reopen events
 - added Zig as C cross-compiler for Android targets in Go cross-compile check and GoReleaser binary delivery
 - added coverage reporting to `npm.yaml` via `davelosert/vitest-coverage-report-action@v2`, `dorny/test-reporter@v1`, and `actions/upload-artifact@v4`, matching `yarn.yaml` features
 - added optional SonarQube management stage to `npm.yaml` with `sonar_host` input and `sonar_token` secret, matching `yarn.yaml` features


### PR DESCRIPTION
## Summary

- Added `claude.yaml` workflow for AI-assisted issue and PR comment handling via `@claude` mentions, delegating to the org-level reusable workflow at `rios0rios0/.github`
- Added `claude-code-review.yaml` workflow for automated PR code review on open/sync/reopen events, delegating to the org-level reusable workflow
- Updated `CHANGELOG.md` with the new entries

## Test plan

- [ ] Verify `claude.yaml` triggers on issue comments, PR review comments, issue open/assign, and PR review submitted events
- [ ] Verify `claude-code-review.yaml` triggers on PR open, synchronize, ready_for_review, and reopen events
- [ ] Confirm both workflows correctly reference the org-level reusable workflows at `rios0rios0/.github`
- [ ] Test `@claude` mention in a PR comment to validate end-to-end functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)