### PR TITLE
fix(github): upgraded mlugg/setup-zig from v1 to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - fixed `pdm.yaml` display names for `flake8` and `mypy` jobs from `style:` to `quality:` to match their job IDs
 - fixed missing `continue-on-error: true` on `mypy` and `safety` jobs to match Azure DevOps golden standard
 - fixed `pdm-docker.yaml` skipping all code check, security, and test stages when used standalone
+- fixed Zig setup action failing with HTTP 404 when downloading Zig 0.15.2 by upgrading `mlugg/setup-zig` from v1 to v2
 
 ## [3.4.0] - 2026-03-20
 

--- a/github/golang/stages/10-code-check/cross-compile/action.yaml
+++ b/github/golang/stages/10-code-check/cross-compile/action.yaml
@@ -22,7 +22,7 @@ runs:
 
     - name: 'Setup Zig'
       if: inputs.goos == 'android' || inputs.goos == ''
-      uses: 'mlugg/setup-zig@v1'
+      uses: 'mlugg/setup-zig@v2'
 
     - uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
 

--- a/github/golang/stages/40-delivery/binary/action.yaml
+++ b/github/golang/stages/40-delivery/binary/action.yaml
@@ -32,7 +32,7 @@ runs:
         cache-dependency-path: 'go.sum'
 
     - name: 'Setup Zig'
-      uses: 'mlugg/setup-zig@v1'
+      uses: 'mlugg/setup-zig@v2'
 
     - uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
 


### PR DESCRIPTION
## Summary

- Upgraded `mlugg/setup-zig` from `@v1` to `@v2` in the Go cross-compile check and binary delivery composite actions
- The v1 action constructs download URLs pointing to `/builds/` (nightly/dev only), but Zig 0.15.2 is a released version served from `/download/0.15.2/` — causing HTTP 404 on all mirrors
- Resolves CI failures in downstream repos (e.g., [gitforge PR #64](https://github.com/rios0rios0/gitforge/actions/runs/23442078439/job/68195528239?pr=64))

## Test plan

- [ ] Verify `android/amd64` and `android/arm64` cross-compile matrix jobs pass on a downstream Go repo
- [ ] Verify GoReleaser binary delivery still works with Zig for Android targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)