### PR TITLE
fix(github): used dot-separated API level in Zig Android target triples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - fixed missing `continue-on-error: true` on `mypy` and `safety` jobs to match Azure DevOps golden standard
 - fixed `pdm-docker.yaml` skipping all code check, security, and test stages when used standalone
 - fixed Zig setup action failing with HTTP 404 when downloading Zig 0.15.2 by upgrading `mlugg/setup-zig` from v1 to v2
+- fixed Zig 0.15.x Android cross-compilation by using dot-separated API level format (`android.28`) instead of concatenated (`android28`)
 
 ## [3.4.0] - 2026-03-20
 

--- a/global/scripts/languages/golang/cross-compile/run.sh
+++ b/global/scripts/languages/golang/cross-compile/run.sh
@@ -44,8 +44,8 @@ vet_target() {
         return 1
         ;;
     esac
-    CC="zig cc -target ${zig_arch}-linux-android28" \
-    CXX="zig c++ -target ${zig_arch}-linux-android28" \
+    CC="zig cc -target ${zig_arch}-linux-android.28" \
+    CXX="zig c++ -target ${zig_arch}-linux-android.28" \
     CGO_ENABLED=1 GOOS="$os" GOARCH="$arch" go vet ./... 2>&1
   else
     CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go vet ./... 2>&1

--- a/global/scripts/languages/golang/goreleaser/.goreleaser.yaml
+++ b/global/scripts/languages/golang/goreleaser/.goreleaser.yaml
@@ -23,14 +23,14 @@ builds:
         goarch: 'arm64'
         env:
           - CGO_ENABLED=1
-          - CC=zig cc -target aarch64-linux-android28
-          - CXX=zig c++ -target aarch64-linux-android28
+          - CC=zig cc -target aarch64-linux-android.28
+          - CXX=zig c++ -target aarch64-linux-android.28
       - goos: 'android'
         goarch: 'amd64'
         env:
           - CGO_ENABLED=1
-          - CC=zig cc -target x86_64-linux-android28
-          - CXX=zig c++ -target x86_64-linux-android28
+          - CC=zig cc -target x86_64-linux-android.28
+          - CXX=zig c++ -target x86_64-linux-android.28
 archives:
   - formats: ['tar.gz']
     name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}'


### PR DESCRIPTION
## Summary

- Fixed Zig 0.15.x `UnknownApplicationBinaryInterface` error by changing Android target triple format from `android28` to `android.28` (dot-separated ABI version)
- Updated both the cross-compile type-check script and the GoReleaser template
- The concatenated format was never validated because the prior `setup-zig` v1 404 error prevented Zig from installing

## Test plan

- [ ] CI cross-compile matrix passes for `android/amd64` and `android/arm64`
- [ ] Downstream repo ([gitforge](https://github.com/rios0rios0/gitforge)) builds successfully with the updated pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)