### PR TITLE
feat(shellcheck): added ShellCheck tool with auto-installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added ShellCheck tool at `global/scripts/tools/shellcheck/run.sh` with auto-installation when the binary is not available locally, following the same pattern as Hadolint
+
 ## [4.3.0] - 2026-04-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Added
 
 - added ShellCheck tool at `global/scripts/tools/shellcheck/run.sh` with auto-installation when the binary is not available locally, following the same pattern as Hadolint
+- added ShellCheck platform integration stage files for GitHub Actions, GitLab CI, and Azure DevOps under `20-security`
 
 ## [4.3.0] - 2026-04-01
 

--- a/azure-devops/global/stages/20-security/shellcheck.yaml
+++ b/azure-devops/global/stages/20-security/shellcheck.yaml
@@ -1,0 +1,12 @@
+jobs:
+  - job: 'sast_shellcheck'
+    displayName: 'sast:shellcheck'
+    steps:
+      - template: '../../abstracts/scripts-repo.yaml'
+      - script: $(Scripts.Directory)/global/scripts/tools/shellcheck/run.sh
+        continueOnError: true
+
+      - task: 'PublishPipelineArtifact@1'
+        inputs:
+          artifactName: 'shellcheck'
+          targetPath: 'build/reports/shellcheck'

--- a/github/global/stages/20-security/shellcheck/action.yaml
+++ b/github/global/stages/20-security/shellcheck/action.yaml
@@ -1,0 +1,22 @@
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Checkout code'
+      uses: 'actions/checkout@v6'
+
+    - name: 'Get Scripts'
+      uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
+
+    - name: 'Execute'
+      shell: 'bash'
+      run: $SCRIPTS_DIR/global/scripts/tools/shellcheck/run.sh
+
+    - name: 'Upload Report'
+      uses: 'actions/upload-artifact@v6'
+      with:
+        name: 'shellcheck'
+        path: 'build/reports/shellcheck/'
+        if-no-files-found: 'warn'
+        overwrite: 'true'
+        retention-days: 10
+      if: always()

--- a/gitlab/global/stages/20-security/shellcheck.yaml
+++ b/gitlab/global/stages/20-security/shellcheck.yaml
@@ -1,0 +1,14 @@
+include:
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/abstracts/default-variables.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/abstracts/scripts-repo-alpine-docker.yaml'
+
+sast:shellcheck:
+  extends: '.scripts-repo-alpine-docker'
+  stage: 'security (sca/sast)'
+  script:
+    - $SCRIPTS_DIR/global/scripts/tools/shellcheck/run.sh
+  artifacts:
+    when: 'always'
+    paths:
+      - "$REPORT_PATH/shellcheck.json"
+  dependencies: [] # prevent from fetching artifacts

--- a/global/scripts/tools/shellcheck/run.sh
+++ b/global/scripts/tools/shellcheck/run.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env sh
+
+if [ -z "$SCRIPTS_DIR" ]; then
+  SCRIPTS_DIR="$(echo "$(dirname "$(realpath "$0")")" | sed 's|\(.*pipelines\).*|\1|')"
+  export SCRIPTS_DIR
+fi
+TOOL_NAME="shellcheck" . "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
+
+fileName="$(pwd)/$REPORT_PATH/shellcheck.json"
+
+# Find all shell scripts in the project
+SHELL_SCRIPTS=$(find "$(pwd)" -name "*.sh" \
+  -not -path "*/.git/*" \
+  -not -path "*/node_modules/*" \
+  -not -path "*/vendor/*" \
+  -not -path "*/.codeql-db/*")
+
+if [ -z "$SHELL_SCRIPTS" ]; then
+  echo "No shell scripts found, skipping ShellCheck analysis."
+  echo "[]" > "$fileName"
+  echo "Empty report written to: $fileName"
+  exit 0
+fi
+
+# Install ShellCheck if not already available
+if ! command -v shellcheck > /dev/null 2>&1; then
+  echo "Downloading ShellCheck..."
+  SHELLCHECK_VERSION=$(curl -fsSL https://api.github.com/repos/koalaman/shellcheck/releases/latest | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+
+  ARCH=$(uname -m)
+  case "$ARCH" in
+    x86_64)  ARCH="x86_64" ;;
+    aarch64) ARCH="aarch64" ;;
+    armv6l)  ARCH="armv6hf" ;;
+    *)
+      echo "Unsupported architecture: $ARCH" >&2
+      exit 1
+      ;;
+  esac
+
+  curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/$SHELLCHECK_VERSION/shellcheck-$SHELLCHECK_VERSION.linux.$ARCH.tar.xz" -o /tmp/shellcheck.tar.xz
+  tar -xJf /tmp/shellcheck.tar.xz -C /tmp
+  mv "/tmp/shellcheck-$SHELLCHECK_VERSION/shellcheck" /tmp/shellcheck
+  chmod +x /tmp/shellcheck
+  rm -rf /tmp/shellcheck.tar.xz "/tmp/shellcheck-$SHELLCHECK_VERSION"
+  export PATH="/tmp:$PATH"
+fi
+
+echo "Running ShellCheck analysis..."
+echo "Checking scripts:"
+echo "$SHELL_SCRIPTS" | while read -r f; do echo "  - $f"; done
+
+# shellcheck disable=SC2086
+shellcheck --format=json1 --severity=warning $SHELL_SCRIPTS > "$fileName" 2>&1 || EXIT_CODE=$?
+
+echo "ShellCheck analysis complete. Results written to: $fileName"
+exit ${EXIT_CODE:-0}

--- a/global/scripts/tools/shellcheck/run.sh
+++ b/global/scripts/tools/shellcheck/run.sh
@@ -9,13 +9,13 @@ TOOL_NAME="shellcheck" . "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
 fileName="$(pwd)/$REPORT_PATH/shellcheck.json"
 
 # Find all shell scripts in the project
-SHELL_SCRIPTS=$(find "$(pwd)" -name "*.sh" \
+SCRIPT_LIST=$(find "$(pwd)" -name "*.sh" \
   -not -path "*/.git/*" \
   -not -path "*/node_modules/*" \
   -not -path "*/vendor/*" \
   -not -path "*/.codeql-db/*")
 
-if [ -z "$SHELL_SCRIPTS" ]; then
+if [ -z "$SCRIPT_LIST" ]; then
   echo "No shell scripts found, skipping ShellCheck analysis."
   echo "[]" > "$fileName"
   echo "Empty report written to: $fileName"
@@ -48,10 +48,14 @@ fi
 
 echo "Running ShellCheck analysis..."
 echo "Checking scripts:"
-echo "$SHELL_SCRIPTS" | while read -r f; do echo "  - $f"; done
+echo "$SCRIPT_LIST" | while read -r f; do echo "  - $f"; done
 
-# shellcheck disable=SC2086
-shellcheck --format=json1 --severity=warning $SHELL_SCRIPTS > "$fileName" 2>&1 || EXIT_CODE=$?
+find "$(pwd)" -name "*.sh" \
+  -not -path "*/.git/*" \
+  -not -path "*/node_modules/*" \
+  -not -path "*/vendor/*" \
+  -not -path "*/.codeql-db/*" \
+  -print0 | xargs -0 shellcheck --format=json1 --severity=warning > "$fileName" || EXIT_CODE=$?
 
 echo "ShellCheck analysis complete. Results written to: $fileName"
 exit ${EXIT_CODE:-0}

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -4,11 +4,11 @@
 #   SCRIPTS_DIR ?= $(HOME)/Development/github.com/rios0rios0/pipelines
 #   -include $(SCRIPTS_DIR)/makefiles/common.mk
 #
-# Targets provided: setup codeql semgrep trivy hadolint gitleaks sast
+# Targets provided: setup codeql semgrep trivy hadolint shellcheck gitleaks sast
 # Requires: SCRIPTS_DIR to be set. SEMGREP_LANGUAGE and CODEQL_LANGUAGE should be set by a language
 #           .mk file (e.g. golang.mk) or manually before including this file.
 
-.PHONY: setup codeql semgrep trivy hadolint gitleaks sast
+.PHONY: setup codeql semgrep trivy hadolint shellcheck gitleaks sast
 
 setup:
 	@curl -sSL https://raw.githubusercontent.com/rios0rios0/pipelines/main/clone.sh | bash
@@ -25,7 +25,10 @@ trivy:
 hadolint:
 	-@$(SCRIPTS_DIR)/global/scripts/tools/hadolint/run.sh
 
+shellcheck:
+	-@$(SCRIPTS_DIR)/global/scripts/tools/shellcheck/run.sh
+
 gitleaks:
 	-@$(SCRIPTS_DIR)/global/scripts/tools/gitleaks/run.sh
 
-sast: codeql semgrep trivy hadolint gitleaks
+sast: codeql semgrep trivy hadolint shellcheck gitleaks


### PR DESCRIPTION
## Summary
- Added `global/scripts/tools/shellcheck/run.sh` with auto-installation when the binary is not available locally, following the same pattern as Hadolint (download from GitHub releases, support x86_64/aarch64/armv6)
- Added `shellcheck` target to `makefiles/common.mk` and included it in the `sast` aggregate target
- Any project including `common.mk` can now run `make shellcheck` with zero pre-installation required

## Test plan
- [ ] Run `make shellcheck` on a project with `.sh` files and no shellcheck installed -- verify auto-install and report generation
- [ ] Run `make shellcheck` on a project with shellcheck already installed -- verify it uses the existing binary
- [ ] Run `make sast` and verify shellcheck is included in the pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)