### PR TITLE
fix(ci): corrected v4 tag auto-update and synced golang 1.26.2

### DIFF
--- a/.github/workflows/update-major-version-tag.yaml
+++ b/.github/workflows/update-major-version-tag.yaml
@@ -19,8 +19,9 @@ jobs:
     name: 'update major version tag'
     runs-on: 'ubuntu-latest'
     if: >-
-      github.event_name == 'workflow_call' ||
-      (!github.event.release.prerelease &&
+      inputs.tag_name != '' ||
+      (github.event_name == 'release' &&
+      !github.event.release.prerelease &&
       contains(github.event.release.tag_name, '.'))
     steps:
       - uses: 'actions/checkout@v4'

--- a/.github/workflows/update-major-version-tag.yaml
+++ b/.github/workflows/update-major-version-tag.yaml
@@ -19,7 +19,7 @@ jobs:
     name: 'update major version tag'
     runs-on: 'ubuntu-latest'
     if: >-
-      inputs.tag_name != '' ||
+      (github.event_name != 'release' && inputs.tag_name != '') ||
       (github.event_name == 'release' &&
       !github.event.release.prerelease &&
       contains(github.event.release.tag_name, '.'))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- changed the GitLab CI and the global `golang.1.26-awscli` container Go version from `1.26.1` to `1.26.2` to align with the Azure DevOps bump in 4.4.1
+
+### Fixed
+
+- fixed `update-major-version-tag.yaml` silently skipping on every bump release — the previous `github.event_name == 'workflow_call'` guard never matched because reusable workflows inherit the caller's `event_name` (e.g. `push`), so the `v4` tag had been stuck at `4.1.0` since PR #327; now detects `workflow_call` via the `inputs.tag_name` presence check
+
 ## [4.4.1] - 2026-04-14
 
 ### Changed

--- a/gitlab/golang/abstracts/go.yaml
+++ b/gitlab/golang/abstracts/go.yaml
@@ -1,5 +1,5 @@
 .go:
-  image: 'golang:1.26.1-bookworm'
+  image: 'golang:1.26.2-bookworm'
   cache: # relative to the project directory ($CI_PROJECT_DIR)
     key: "$CI_JOB_NAME"
     paths:

--- a/global/containers/golang.1.26-awscli/Dockerfile
+++ b/global/containers/golang.1.26-awscli/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1
+FROM golang:1.26.2
 
 RUN apt-get update && apt-get install --yes --no-install-recommends unzip \
 	&& apt-get clean autoclean \


### PR DESCRIPTION
## Summary

- **Fixed** `update-major-version-tag.yaml` silently skipping on every bump release — the previous `github.event_name == 'workflow_call'` guard never matched because reusable workflows inherit the caller's `event_name` (e.g. `push`), not the literal `'workflow_call'`. As a result, the `v4` tag had been stuck at `4.1.0` since PR #327. Now detects `workflow_call` via `inputs.tag_name != ''`, with an added `github.event_name == 'release'` guard on the release-event branch for safety.
- **Bumped** `gitlab/golang/abstracts/go.yaml` and `global/containers/golang.1.26-awscli/Dockerfile` from `1.26.1` to `1.26.2` to align with the Azure DevOps bump from 4.4.1 (the autoupdate bot only touched one of the three files that historically move in lockstep).
- **Updated** `CHANGELOG.md` under `[Unreleased]` with the corresponding `Fixed` and `Changed` entries.

## Retroactive repair

The `v4` tag was force-updated manually to point at `4.4.1` (`c2356ef`) since the workflow fix only helps future bumps:

```bash
git tag -fa v4 -m "Update v4 to 4.4.1" 4.4.1
git push origin v4 --force
```

The existing `v4` GitHub Release has `targetCommitish: main` and automatically follows the tag, so no release edit was needed.

## Test plan

- [ ] CI passes on this branch
- [ ] On the next `chore/bump-x.y.z` merge, confirm the `delivery > update major version tag` job in `release.yaml` runs (instead of being skipped) and advances `vN` to the new release
- [ ] Next rebuild of `golang.1.26-awscli` container pulls `golang:1.26.2` successfully