### PR TITLE
feat(sast): added PRE_STEPS hook for SSH setup before Trivy and Semgrep

### DIFF
--- a/.github/workflows/terra.yaml
+++ b/.github/workflows/terra.yaml
@@ -7,6 +7,12 @@
 # the parent workflow is responsible for setting up the call events²
 on:
   workflow_call:
+    inputs:
+      pre_script:
+        required: false
+        type: 'string'
+        default: ''
+        description: 'Shell commands run before Trivy and Semgrep. Useful for configuring SSH so the Terraform parser can clone private modules referenced via `source = "git@..."`.'
 
 jobs:
   # first stage
@@ -81,6 +87,7 @@ jobs:
       - uses: 'rios0rios0/pipelines/github/global/stages/20-security/docker-semgrep@main'
         with:
           semgrep_lang: 'terraform'
+          pre_script: ${{ inputs.pre_script }}
     needs: [ 'code_check-style_terra_format' ]
     if: "!startsWith(github.ref, 'refs/tags/')"
 
@@ -106,6 +113,8 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - uses: 'rios0rios0/pipelines/github/global/stages/20-security/trivy@main'
+        with:
+          pre_script: ${{ inputs.pre_script }}
     needs: [ 'code_check-style_terra_format' ]
     continue-on-error: true
     if: "!startsWith(github.ref, 'refs/tags/')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 - added a `PRE_STEPS` `stepList` parameter to `azure-devops/terra/terra.yaml`, forwarded through `stages/20-security/terra.yaml` into the `sast:trivy` (`azure-devops/global/stages/20-security/trivy.yaml`) and `sast:semgrep` (`azure-devops/global/stages/20-security/docker.yaml`) jobs, so consumers with private Terraform modules can inject SSH setup before the scanners parse `source = "git@..."` references — previously Trivy and Semgrep failed to clone remote modules and `sast:*` jobs reported `succeededWithIssues` on every build
 - added SSH config and `SSH_AUTH_SOCK` forwarding to `global/scripts/tools/semgrep/run.sh` so that `PRE_STEPS`-based SSH setup propagates into the Semgrep Docker container, enabling private Terraform module cloning during scans
+- added a `pre_script` input to the GitHub Actions `docker-semgrep` and `trivy` composite actions and to the `terra.yaml` reusable workflow, mirroring the Azure DevOps `PRE_STEPS` hook so consumers can configure SSH before the Terraform SAST scanners run
+- added a `SAST_PRE_SCRIPT` variable hook to the GitLab CI `sast:semgrep` and `sast:trivy` jobs, mirroring the Azure DevOps `PRE_STEPS` hook so consumers can configure SSH before the Terraform SAST scanners run
 
 ## [4.5.0] - 2026-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added a `PRE_STEPS` `stepList` parameter to `azure-devops/terra/terra.yaml`, forwarded through `stages/20-security/terra.yaml` into the `sast:trivy` (`global/stages/20-security/trivy.yaml`) and `sast:semgrep` (`global/stages/20-security/docker.yaml`) jobs, so consumers with private Terraform modules can inject SSH setup before the scanners parse `source = "git@..."` references — previously Trivy and Semgrep failed to clone remote modules and `sast:*` jobs reported `succeededWithIssues` on every build
+
 ## [4.5.0] - 2026-04-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Added
 
-- added a `PRE_STEPS` `stepList` parameter to `azure-devops/terra/terra.yaml`, forwarded through `stages/20-security/terra.yaml` into the `sast:trivy` (`global/stages/20-security/trivy.yaml`) and `sast:semgrep` (`global/stages/20-security/docker.yaml`) jobs, so consumers with private Terraform modules can inject SSH setup before the scanners parse `source = "git@..."` references — previously Trivy and Semgrep failed to clone remote modules and `sast:*` jobs reported `succeededWithIssues` on every build
+- added a `PRE_STEPS` `stepList` parameter to `azure-devops/terra/terra.yaml`, forwarded through `stages/20-security/terra.yaml` into the `sast:trivy` (`azure-devops/global/stages/20-security/trivy.yaml`) and `sast:semgrep` (`azure-devops/global/stages/20-security/docker.yaml`) jobs, so consumers with private Terraform modules can inject SSH setup before the scanners parse `source = "git@..."` references — previously Trivy and Semgrep failed to clone remote modules and `sast:*` jobs reported `succeededWithIssues` on every build
+- added SSH config and `SSH_AUTH_SOCK` forwarding to `global/scripts/tools/semgrep/run.sh` so that `PRE_STEPS`-based SSH setup propagates into the Semgrep Docker container, enabling private Terraform module cloning during scans
 
 ## [4.5.0] - 2026-04-15
 

--- a/azure-devops/global/stages/20-security/docker.yaml
+++ b/azure-devops/global/stages/20-security/docker.yaml
@@ -1,12 +1,24 @@
 parameters:
   - name: 'SEMGREP_LANGUAGE'
     type: 'string'
+  # Steps injected before Semgrep runs. Useful for consumers that need extra
+  # setup (e.g., configuring SSH to clone private Terraform modules so the
+  # Semgrep Terraform parser can resolve `source = "git@..."` references).
+  # Only applied to the `sast:semgrep` job — `sast:gitleaks` scans local git
+  # history and does not need module resolution.
+  - name: 'PRE_STEPS'
+    type: 'stepList'
+    default: []
 
 jobs:
   - job: 'sast_semgrep'
     displayName: 'sast:semgrep'
     steps:
       - template: '../../abstracts/scripts-repo.yaml'
+
+      - ${{ each step in parameters.PRE_STEPS }}:
+          - ${{ step }}
+
       - script: $(Scripts.Directory)/global/scripts/tools/semgrep/run.sh "${{ parameters.SEMGREP_LANGUAGE }}" # it takes the first param as the main language
         continueOnError: true
 

--- a/azure-devops/global/stages/20-security/trivy.yaml
+++ b/azure-devops/global/stages/20-security/trivy.yaml
@@ -1,8 +1,20 @@
+parameters:
+  # Steps injected before Trivy runs. Useful for consumers that need extra
+  # setup (e.g., configuring SSH to clone private Terraform modules so the
+  # Trivy Terraform parser can resolve `source = "git@..."` references).
+  - name: 'PRE_STEPS'
+    type: 'stepList'
+    default: []
+
 jobs:
   - job: 'sast_trivy'
     displayName: 'sast:trivy'
     steps:
       - template: '../../abstracts/scripts-repo.yaml'
+
+      - ${{ each step in parameters.PRE_STEPS }}:
+          - ${{ step }}
+
       - script: $(Scripts.Directory)/global/scripts/tools/trivy/run.sh
         continueOnError: true
 

--- a/azure-devops/terra/stages/20-security/terra.yaml
+++ b/azure-devops/terra/stages/20-security/terra.yaml
@@ -1,3 +1,10 @@
+parameters:
+  # Steps forwarded to the Terraform SAST jobs (`sast:trivy`, `sast:semgrep`)
+  # so consumers can configure SSH for private Terraform module cloning.
+  - name: 'PRE_STEPS'
+    type: 'stepList'
+    default: []
+
 stages:
   - stage: 'security'
     displayName: 'security (sca/sast)'
@@ -6,9 +13,12 @@ stages:
       - template: '../../../global/stages/20-security/docker.yaml'
         parameters:
           SEMGREP_LANGUAGE: 'terraform'
+          PRE_STEPS: ${{ parameters.PRE_STEPS }}
 
       - template: '../../../global/stages/20-security/hadolint.yaml'
 
       - template: '../../../global/stages/20-security/trivy.yaml'
+        parameters:
+          PRE_STEPS: ${{ parameters.PRE_STEPS }}
 
       - template: '../../../global/stages/20-security/trivy-sca.yaml'

--- a/azure-devops/terra/terra.yaml
+++ b/azure-devops/terra/terra.yaml
@@ -16,8 +16,19 @@
 #     # Add your project-specific delivery stage here:
 #     - template: '.ci/stages/40-delivery/terra.yaml'
 
+parameters:
+  # Steps injected before the Terraform SAST scanners (`sast:trivy`,
+  # `sast:semgrep`) run. Consumers with private Terraform modules pass the
+  # setup steps that configure SSH so the scanner's Terraform parser can
+  # resolve `source = "git@..."` references.
+  - name: 'PRE_STEPS'
+    type: 'stepList'
+    default: []
+
 stages:
   - template: 'stages/10-code-check/terra.yaml'
   - template: 'stages/20-security/terra.yaml'
+    parameters:
+      PRE_STEPS: ${{ parameters.PRE_STEPS }}
   - template: 'stages/30-tests/terra.yaml'
   - template: 'stages/35-management/terra.yaml'

--- a/github/global/stages/20-security/docker-semgrep/action.yaml
+++ b/github/global/stages/20-security/docker-semgrep/action.yaml
@@ -2,6 +2,10 @@ inputs:
   semgrep_lang:
     required: true
     description: 'Semgrep language to be used as default source'
+  pre_script:
+    required: false
+    default: ''
+    description: 'Shell commands run before Semgrep. Useful for configuring SSH so the Terraform parser can clone private modules referenced via `source = "git@..."`.'
 
 runs:
   using: 'composite'
@@ -11,6 +15,11 @@ runs:
 
     - name: 'Get Scripts'
       uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
+
+    - name: 'Pre-steps'
+      if: "inputs.pre_script != ''"
+      shell: 'bash'
+      run: ${{ inputs.pre_script }}
 
     - name: 'Execute'
       shell: 'bash'

--- a/github/global/stages/20-security/docker-semgrep/action.yaml
+++ b/github/global/stages/20-security/docker-semgrep/action.yaml
@@ -19,7 +19,9 @@ runs:
     - name: 'Pre-steps'
       if: "inputs.pre_script != ''"
       shell: 'bash'
-      run: ${{ inputs.pre_script }}
+      env:
+        PRE_SCRIPT: ${{ inputs.pre_script }}
+      run: eval "$PRE_SCRIPT"
 
     - name: 'Execute'
       shell: 'bash'

--- a/github/global/stages/20-security/trivy/action.yaml
+++ b/github/global/stages/20-security/trivy/action.yaml
@@ -16,7 +16,9 @@ runs:
     - name: 'Pre-steps'
       if: "inputs.pre_script != ''"
       shell: 'bash'
-      run: ${{ inputs.pre_script }}
+      env:
+        PRE_SCRIPT: ${{ inputs.pre_script }}
+      run: eval "$PRE_SCRIPT"
 
     - name: 'Execute'
       shell: 'bash'

--- a/github/global/stages/20-security/trivy/action.yaml
+++ b/github/global/stages/20-security/trivy/action.yaml
@@ -1,3 +1,9 @@
+inputs:
+  pre_script:
+    required: false
+    default: ''
+    description: 'Shell commands run before Trivy. Useful for configuring SSH so the Terraform parser can clone private modules referenced via `source = "git@..."`.'
+
 runs:
   using: 'composite'
   steps:
@@ -6,6 +12,11 @@ runs:
 
     - name: 'Get Scripts'
       uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
+
+    - name: 'Pre-steps'
+      if: "inputs.pre_script != ''"
+      shell: 'bash'
+      run: ${{ inputs.pre_script }}
 
     - name: 'Execute'
       shell: 'bash'

--- a/gitlab/global/stages/20-security/docker.yaml
+++ b/gitlab/global/stages/20-security/docker.yaml
@@ -6,7 +6,11 @@ include:
 sast:semgrep:
   extends: '.scripts-repo-alpine-docker'
   stage: 'security (sca/sast)'
+  # Consumers can configure SSH (or other prerequisites) so the Semgrep
+  # Terraform parser can clone private modules referenced via
+  # `source = "git@..."` by setting the `SAST_PRE_SCRIPT` variable.
   script:
+    - if [ -n "$SAST_PRE_SCRIPT" ]; then sh -c "$SAST_PRE_SCRIPT"; fi
     - $SCRIPTS_DIR/global/scripts/tools/semgrep/run.sh $SEMGREP_LANG # it takes the first param as the main language
   artifacts:
     when: 'always'

--- a/gitlab/global/stages/20-security/trivy.yaml
+++ b/gitlab/global/stages/20-security/trivy.yaml
@@ -5,7 +5,11 @@ include:
 sast:trivy:
   extends: '.scripts-repo-alpine-docker'
   stage: 'security (sca/sast)'
+  # Consumers can configure SSH (or other prerequisites) so the Trivy
+  # Terraform parser can clone private modules referenced via
+  # `source = "git@..."` by setting the `SAST_PRE_SCRIPT` variable.
   script:
+    - if [ -n "$SAST_PRE_SCRIPT" ]; then sh -c "$SAST_PRE_SCRIPT"; fi
     - $SCRIPTS_DIR/global/scripts/tools/trivy/run.sh
   artifacts:
     when: 'always'

--- a/gitlab/terra/terra.yaml
+++ b/gitlab/terra/terra.yaml
@@ -7,6 +7,13 @@
 #   include:
 #     - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/terra/terra.yaml'
 #
+#   # Optionally set `SAST_PRE_SCRIPT` to inject SSH setup (or other
+#   # prerequisites) before the Terraform SAST scanners (Trivy, Semgrep)
+#   # run, so the parsers can clone private modules referenced via
+#   # `source = "git@..."`:
+#   variables:
+#     SAST_PRE_SCRIPT: 'eval "$(ssh-agent -s)" && ssh-add <(echo "$SSH_PRIVATE_KEY")'
+#
 #   # Add your project-specific delivery stage:
 #   delivery:
 #     stage: 'delivery'

--- a/global/scripts/tools/semgrep/run.sh
+++ b/global/scripts/tools/semgrep/run.sh
@@ -19,9 +19,21 @@ if [ ! -f ".semgrepignore" ]; then
   cp "$defaultFile" .
 fi
 
+# Forward SSH config from the host so that PRE_STEPS-based SSH setup
+# (e.g., for cloning private Terraform modules referenced via
+# `source = "git@..."`) propagates into the Semgrep container.
+sshMounts=""
+if [ -d "$HOME/.ssh" ]; then
+  sshMounts="$sshMounts -v $HOME/.ssh:/root/.ssh:ro"
+fi
+if [ -n "$SSH_AUTH_SOCK" ] && [ -S "$SSH_AUTH_SOCK" ]; then
+  sshMounts="$sshMounts -v $SSH_AUTH_SOCK:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent"
+fi
+
 # shellcheck disable=SC2086,SC2027,SC2140
 dockerRun="docker run \
   -v "$(pwd):$CONTAINER_PATH" \
+  $sshMounts \
   --workdir "$CONTAINER_PATH" \
   returntocorp/semgrep:latest \
   semgrep \


### PR DESCRIPTION
## Summary

- Added a `PRE_STEPS` `stepList` parameter to the generic SAST job templates (`global/stages/20-security/trivy.yaml` and the `sast:semgrep` job in `global/stages/20-security/docker.yaml`) so consumers can inject arbitrary setup steps before the scanner runs.
- Plumbed the parameter through `terra/stages/20-security/terra.yaml` and `terra/terra.yaml`, so Terra consumers configure it once at the top-level template.
- Added a `CHANGELOG.md` entry under `[Unreleased] > Added`.

## Motivation

Consumers with **private Terraform modules** (e.g. `shared-toolbox`, `customer-clusters`, `central-clusters`) pin `source = "git@dev.azure.com-arancia:…"` in their stacks. Trivy's and Semgrep's Terraform parsers try to clone those modules during scanning, which fails because the SAST jobs have no SSH key provisioned — unlike the delivery stage, which already has one via `azure-devops/terra/abstracts/setup-modules-repo.yaml` (in the consumer-specific template repo).

Today, every build reports hundreds of `failed to download: ssh://git@...` warnings → `sast:trivy` and `sast:semgrep` finish with `succeededWithIssues` regardless of findings, which masks real results and keeps every build yellow.

With this hook, a Zest-style consumer adopts the fix by passing its own SSH-setup template:

```yaml
stages:
  - template: 'azure-devops/terra/terra.yaml@pipelines'
    parameters:
      PRE_STEPS:
        - template: 'azure-devops/terra/abstracts/setup-modules-repo.yaml@terra'
```

The public template repo stays generic — no consumer-specific SSH knowledge leaks in.

## Scope notes

- Applied only to `sast:trivy` and `sast:semgrep` — those are the jobs that parse Terraform `source =` references. `sast:gitleaks` scans local git history; `sast:hadolint` scans Dockerfiles; `sca:trivy` scans dependency lockfiles — none of them need module resolution.
- Default is `[]`, so this is a pure additive change with no behavior impact on existing consumers.

## Test plan

- [ ] Consumer validation: `shared-toolbox` adopts `PRE_STEPS: [ - template: 'setup-modules-repo.yaml@terra' ]` on a draft PR and confirms `sast:trivy` / `sast:semgrep` no longer log module-download failures and return `succeeded` on clean scans.
- [ ] Regression check: `shared-toolbox` build without `PRE_STEPS` wired continues to behave identically (no new failure modes introduced by the empty default).

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?