### PR TITLE
fix(azure-devops): removed duplicated jobs: key in javascript/yarn tests stage

### DIFF
--- a/azure-devops/javascript/stages/30-tests/yarn.yaml
+++ b/azure-devops/javascript/stages/30-tests/yarn.yaml
@@ -17,25 +17,24 @@ stages:
     displayName: 'tests'
     condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')))
     jobs:
-      jobs:
-        - job: 'test_all'
-          displayName: 'test:all'
-          steps:
-            - template: 'steps/test-all.yaml'
-              parameters:
-                WORKING_DIRECTORY: "${{ parameters.WORKING_DIRECTORY }}"
-                RUN_BEFORE_TESTS: ${{ parameters.RUN_BEFORE_TESTS }}
-                RUN_AFTER_TESTS: ${{ parameters.RUN_AFTER_TESTS }}
+      - job: 'test_all'
+        displayName: 'test:all'
+        steps:
+          - template: 'steps/test-all.yaml'
+            parameters:
+              WORKING_DIRECTORY: "${{ parameters.WORKING_DIRECTORY }}"
+              RUN_BEFORE_TESTS: ${{ parameters.RUN_BEFORE_TESTS }}
+              RUN_AFTER_TESTS: ${{ parameters.RUN_AFTER_TESTS }}
 
-        - job: 'test_e2e'
-          displayName: 'test:e2e'
-          continueOnError: true
-          ${{ if ne(parameters.SELF_HOSTED_POOL, '') }}:
-            pool:
-              name: "${{ parameters.SELF_HOSTED_POOL }}"
-          steps:
-            - template: 'jobs/test-e2e.yaml'
-              parameters:
-                WORKING_DIRECTORY: "${{ parameters.WORKING_DIRECTORY }}"
-                RUN_BEFORE_TESTS: ${{ parameters.RUN_BEFORE_TESTS }}
-                RUN_AFTER_TESTS: ${{ parameters.RUN_AFTER_TESTS }}
+      - job: 'test_e2e'
+        displayName: 'test:e2e'
+        continueOnError: true
+        ${{ if ne(parameters.SELF_HOSTED_POOL, '') }}:
+          pool:
+            name: "${{ parameters.SELF_HOSTED_POOL }}"
+        steps:
+          - template: 'jobs/test-e2e.yaml'
+            parameters:
+              WORKING_DIRECTORY: "${{ parameters.WORKING_DIRECTORY }}"
+              RUN_BEFORE_TESTS: ${{ parameters.RUN_BEFORE_TESTS }}
+              RUN_AFTER_TESTS: ${{ parameters.RUN_AFTER_TESTS }}


### PR DESCRIPTION
## Summary

- `azure-devops/javascript/stages/30-tests/yarn.yaml` had a duplicated `jobs:` mapping at lines 19-20 — under `stage: tests`, it declared `jobs:` twice nested, which is invalid pipeline YAML.
- Any downstream repo importing `azure-devops/javascript/yarn-docker.yaml@pipelines` fails validation with:
  ```
  /azure-devops/javascript/stages/30-tests/yarn.yaml@pipelines (Line: 20, Col: 7): A mapping was not expected
  ```
- Removed the inner `jobs:` and de-dented the two job definitions so the file parses cleanly.
- Other language stages under `*/stages/30-tests/*.yaml` (`golang/go.yaml`, `python/pytest.yaml`) do not have this issue, so this is a localized JS-template bug.

## Test plan

- [ ] Discovered while wiring the \`toolbox/backstage-app\` build pipeline in the Zest Security AzureDevOps org. Once this PR lands, queueing that pipeline should pass validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)