### PR TITLE
fix(azure-devops): corrected test-e2e.yaml path in javascript/yarn tests

### DIFF
--- a/azure-devops/javascript/stages/30-tests/yarn.yaml
+++ b/azure-devops/javascript/stages/30-tests/yarn.yaml
@@ -33,7 +33,7 @@ stages:
           pool:
             name: "${{ parameters.SELF_HOSTED_POOL }}"
         steps:
-          - template: 'jobs/test-e2e.yaml'
+          - template: 'steps/test-e2e.yaml'
             parameters:
               WORKING_DIRECTORY: "${{ parameters.WORKING_DIRECTORY }}"
               RUN_BEFORE_TESTS: ${{ parameters.RUN_BEFORE_TESTS }}


### PR DESCRIPTION
Follow-up to #345 — second bug in the same template. Referenced `jobs/test-e2e.yaml` instead of `steps/test-e2e.yaml`, breaking pipeline validation on any repo importing `javascript/yarn-docker.yaml@pipelines`.