### PR TITLE
fix(trivy): kept SARIF best-effort alongside JSON primary to avoid SIGSEGV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Fixed
 
 - fixed `global/scripts/tools/trivy/run.sh` crashing with a nil-URL `SIGSEGV` in `pkg/report/sarif.go:103` when Terraform `source =` pins reference an SSH remote like `git@host:path/repo?ref=x` (Go's `net/url` rejects the colon in the first path segment). The script now produces `trivy.json` as the primary report via `--format json` (aligned with `trivy-sca.json`, `govulncheck.json`, and the other tool outputs), and additionally runs `trivy convert --format sarif` best-effort to preserve `trivy.sarif` for consumers that publish to GitHub Code Scanning. Convert failures are swallowed so the SIGSEGV no longer fails the job; consumers fall back to `trivy.json` when the SARIF conversion hits the broken path.
+- fixed `gitlab/global/stages/20-security/trivy.yaml` collecting only `trivy.sarif` as an artifact, which would produce missing-artifact warnings for GitLab consumers now that `trivy.json` is the primary output; the job now collects both `trivy.json` (always produced) and `trivy.sarif` (best-effort).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed `global/scripts/tools/trivy/run.sh` crashing with a nil-URL `SIGSEGV` in `pkg/report/sarif.go:103` when Terraform `source =` pins reference an SSH remote like `git@host:path/repo?ref=x` (Go's `net/url` rejects the colon in the first path segment). Switched `--format sarif` to `--format json` and the output filename to `trivy.json`; the existing `trivy-sca.json`, `govulncheck.json`, and `semgrep.json` reports are already JSON, so this aligns the Trivy IaC report with the rest of the tool scripts. SARIF was only useful for consumers that publish to GitHub Code Scanning, and no consumer currently wires that upload path.
+
 ### Added
 
 - added a `PRE_STEPS` `stepList` parameter to `azure-devops/terra/terra.yaml`, forwarded through `stages/20-security/terra.yaml` into the `sast:trivy` (`azure-devops/global/stages/20-security/trivy.yaml`) and `sast:semgrep` (`azure-devops/global/stages/20-security/docker.yaml`) jobs, so consumers with private Terraform modules can inject SSH setup before the scanners parse `source = "git@..."` references — previously Trivy and Semgrep failed to clone remote modules and `sast:*` jobs reported `succeededWithIssues` on every build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Fixed
 
-- fixed `global/scripts/tools/trivy/run.sh` crashing with a nil-URL `SIGSEGV` in `pkg/report/sarif.go:103` when Terraform `source =` pins reference an SSH remote like `git@host:path/repo?ref=x` (Go's `net/url` rejects the colon in the first path segment). Switched `--format sarif` to `--format json` and the output filename to `trivy.json`; the existing `trivy-sca.json`, `govulncheck.json`, and `semgrep.json` reports are already JSON, so this aligns the Trivy IaC report with the rest of the tool scripts. SARIF was only useful for consumers that publish to GitHub Code Scanning, and no consumer currently wires that upload path.
+- fixed `global/scripts/tools/trivy/run.sh` crashing with a nil-URL `SIGSEGV` in `pkg/report/sarif.go:103` when Terraform `source =` pins reference an SSH remote like `git@host:path/repo?ref=x` (Go's `net/url` rejects the colon in the first path segment). The script now produces `trivy.json` as the primary report via `--format json` (aligned with `trivy-sca.json`, `govulncheck.json`, and the other tool outputs), and additionally runs `trivy convert --format sarif` best-effort to preserve `trivy.sarif` for consumers that publish to GitHub Code Scanning. Convert failures are swallowed so the SIGSEGV no longer fails the job; consumers fall back to `trivy.json` when the SARIF conversion hits the broken path.
 
 ### Added
 

--- a/gitlab/global/stages/20-security/trivy.yaml
+++ b/gitlab/global/stages/20-security/trivy.yaml
@@ -14,5 +14,6 @@ sast:trivy:
   artifacts:
     when: 'always'
     paths:
+      - "$REPORT_PATH/trivy.json"
       - "$REPORT_PATH/trivy.sarif"
   dependencies: [] # prevent from fetching artifacts

--- a/global/scripts/tools/trivy/run.sh
+++ b/global/scripts/tools/trivy/run.sh
@@ -6,7 +6,7 @@ if [ -z "$SCRIPTS_DIR" ]; then
 fi
 TOOL_NAME="trivy" . "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
 
-fileName="$(pwd)/$REPORT_PATH/trivy.sarif"
+fileName="$(pwd)/$REPORT_PATH/trivy.json"
 
 # Install Trivy if not already available
 if ! command -v trivy > /dev/null 2>&1; then
@@ -24,9 +24,16 @@ if [ ! -f ".trivyignore" ]; then
 fi
 
 echo "Running Trivy IaC misconfiguration scan..."
+# Use `--format json` instead of `sarif`: Trivy's SARIF writer crashes with
+# a nil-URL SIGSEGV when a Terraform `source` references an SSH remote like
+# `git@host:path/repo?ref=x` because `net/url` rejects the colon in the
+# first path segment (see `pkg/report/sarif.go:103` in trivy@v0.70.0). JSON
+# is compatible with the rest of the tool scripts (`trivy-sca.json`,
+# `govulncheck.json`, `semgrep.json`) and does not exercise the broken
+# code path.
 trivy filesystem \
   --scanners misconfig \
-  --format sarif \
+  --format json \
   --output "$fileName" \
   --exit-code 1 \
   "$(pwd)" || EXIT_CODE=$?

--- a/global/scripts/tools/trivy/run.sh
+++ b/global/scripts/tools/trivy/run.sh
@@ -6,7 +6,8 @@ if [ -z "$SCRIPTS_DIR" ]; then
 fi
 TOOL_NAME="trivy" . "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
 
-fileName="$(pwd)/$REPORT_PATH/trivy.json"
+jsonFile="$(pwd)/$REPORT_PATH/trivy.json"
+sarifFile="$(pwd)/$REPORT_PATH/trivy.sarif"
 
 # Install Trivy if not already available
 if ! command -v trivy > /dev/null 2>&1; then
@@ -24,23 +25,31 @@ if [ ! -f ".trivyignore" ]; then
 fi
 
 echo "Running Trivy IaC misconfiguration scan..."
-# Use `--format json` instead of `sarif`: Trivy's SARIF writer crashes with
-# a nil-URL SIGSEGV when a Terraform `source` references an SSH remote like
-# `git@host:path/repo?ref=x` because `net/url` rejects the colon in the
-# first path segment (see `pkg/report/sarif.go:103` in trivy@v0.70.0). JSON
-# is compatible with the rest of the tool scripts (`trivy-sca.json`,
-# `govulncheck.json`, `semgrep.json`) and does not exercise the broken
-# code path.
+# Primary output is JSON — always works and aligns with the other tool
+# scripts (`trivy-sca.json`, `govulncheck.json`, `semgrep.json`, etc.).
 trivy filesystem \
   --scanners misconfig \
   --format json \
-  --output "$fileName" \
+  --output "$jsonFile" \
   --exit-code 1 \
   "$(pwd)" || EXIT_CODE=$?
+
+# SARIF is produced best-effort via `trivy convert` for consumers that
+# publish to GitHub Code Scanning. Trivy's SARIF writer crashes with a
+# nil-URL SIGSEGV in `pkg/report/sarif.go:103` when a Terraform `source`
+# pin references an SSH remote like `git@host:path/repo?ref=x` (Go's
+# `net/url` rejects the colon in the first path segment). Swallowing the
+# convert failure keeps the job green; consumers fall back to `trivy.json`
+# when SARIF is missing.
+echo "Converting Trivy JSON report to SARIF (best-effort)..."
+trivy convert \
+  --format sarif \
+  --output "$sarifFile" \
+  "$jsonFile" || echo "SARIF conversion failed; trivy.json is authoritative."
 
 if [ "$ignoreFileExists" = false ]; then
   rm -f .trivyignore
 fi
 
-echo "Trivy analysis complete. Results written to: $fileName"
+echo "Trivy analysis complete. Results written to: $jsonFile (and $sarifFile when convertible)."
 exit ${EXIT_CODE:-0}


### PR DESCRIPTION
## Summary

- Split `global/scripts/tools/trivy/run.sh` into two outputs:
  - `trivy.json` — **primary**, produced by `trivy filesystem --format json`. Always works.
  - `trivy.sarif` — **best-effort**, produced by `trivy convert --format sarif trivy.json`. Preserved so consumers that publish to GitHub Code Scanning keep getting SARIF when the conversion succeeds.
- The `trivy convert` call is wrapped in `|| echo ...` so a SARIF crash no longer fails the job; consumers fall back to `trivy.json`.
- Added a `CHANGELOG.md` entry under `[Unreleased] > Fixed`.

## Motivation

Trivy `0.70.0` (current `latest`) panics with a nil-URL `SIGSEGV` when writing SARIF for a Terraform project that pins modules via SSH:

```
ERROR  [sarif] Unable to parse URI
URI="git@dev.azure.com-arancia:v3/ZestSecurity/terraform-modules/azm-k8s-cluster?ref=1.6.0/main.tf"
err="... first path segment in URL cannot contain colon"
panic: runtime error: invalid memory address or nil pointer dereference
...
pkg/report/sarif.go:103 +0x305
```

The scan completes successfully (all `13` root modules parsed, misconfig findings collected) — the crash is strictly in SARIF serialization, because Go's `net/url` returns `nil` for URIs with colons in the first path segment (valid for SSH `git@` URIs) and `SarifWriter.addSarifResult` dereferences it without a guard.

Observed on build [`shared-toolbox#32345`](https://dev.azure.com/ZestSecurity/Zest-Terraform/_build/results?buildId=32345) after PR #344 enabled the SSH hook that finally let Trivy reach these modules.

## Why both outputs

- **JSON** is aligned with every other tool script (`trivy-sca.json`, `govulncheck.json`, `semgrep.json`, `gitleaks.json`). It's the always-works primary.
- **SARIF** is load-bearing for GitHub Code Scanning uploads. Consumers without SSH module pins (or with the upstream Trivy fix one day) still get `trivy.sarif` for free via `trivy convert`. When `trivy convert` hits the same panic, the convert failure is swallowed and only JSON is published.

Reporting the panic to Trivy upstream is a separate track; this PR unblocks consumers today.

## Test plan

- [ ] Next `shared-toolbox` build: `sast:trivy` exits `0` (clean) or `1` (findings) instead of `2` (runtime error).
- [ ] `build/reports/trivy/trivy.json` is valid JSON readable by `jq`.
- [ ] On a consumer **without** SSH module pins, `build/reports/trivy/trivy.sarif` is also produced and valid.
- [ ] On `shared-toolbox`, the SARIF convert logs `SARIF conversion failed; trivy.json is authoritative.` and the job still succeeds.

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?