### PR TITLE
fix(gitleaks): preserved project-local .gitleaks.toml on the GitLab pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed `global/scripts/tools/gitleaks/run.sh` silently overwriting and deleting any project-local `.gitleaks.toml` during the second (GitLab-rule) pass, so consumers had no way to keep their own rules + allowlist across both passes. The wrapper now mounts the bundled GitLab config read-only into the container and selects it via `--config` for the second pass, leaving the project's working tree untouched. Both passes still auto-discover the project's `.gitleaksignore` (fingerprint allowlist) at the source root, so suppressed findings stay suppressed in both passes.
+
 ## [4.6.1] - 2026-04-19
 
 ### Fixed

--- a/global/scripts/tools/gitleaks/run.sh
+++ b/global/scripts/tools/gitleaks/run.sh
@@ -10,35 +10,53 @@ chmod -R 777 "$REPORT_PATH" # DinD approach needs this line
 export CONTAINER_PATH="/opt/src"
 fileName="$REPORT_PATH/gitleaks.json"
 
+# Path to the GitLab-customized rule set we ship in this repo. It is mounted
+# read-only into the container alongside the project source so the second
+# pass can point at it via `--config` without ever touching the project's
+# working tree (the previous behaviour was to `cp` it over the project's
+# `.gitleaks.toml`, then `rm` afterwards — which silently deleted any
+# project-local config the consumer relied on).
+GITLAB_CONFIG_HOST_PATH="$SCRIPTS_DIR/global/scripts/tools/gitleaks/.gitleaks.toml"
+GITLAB_CONFIG_CONTAINER_PATH="/opt/pipelines-gitleaks-config.toml"
+
 export ENTRYPOINT_FILE="gitleaks.entrypoint.sh"
 cat >"$ENTRYPOINT_FILE" <<EOL
 #!/bin/bash
 
 fileName="$CONTAINER_PATH/$REPORT_PATH/gitleaks-\$REPORT_NUMBER.json"
 git config --global --add safe.directory $CONTAINER_PATH
-gitleaks detect --source "$CONTAINER_PATH" --report-path \$fileName
+configArg=""
+if [ -n "\$GITLEAKS_CONFIG" ]; then
+  configArg="--config \$GITLEAKS_CONFIG"
+fi
+# shellcheck disable=SC2086
+gitleaks detect --source "$CONTAINER_PATH" --report-path \$fileName \$configArg
 EOL
 chmod +x "$ENTRYPOINT_FILE"
 
-# default configuration file
+# Pass 1: gitleaks defaults + the project's `.gitleaks.toml` / `.gitleaksignore`
+# if present (gitleaks auto-discovers them at the source root).
 docker run \
   -v "$(pwd):$CONTAINER_PATH" \
   --env REPORT_NUMBER="01" \
   --entrypoint "$CONTAINER_PATH/$ENTRYPOINT_FILE" \
   zricethezav/gitleaks:latest || EXIT_CODE=$?
 
-# TODO: create a way to have customized .gitleaks.toml
+# Pass 2: GitLab-customized rule set, mounted read-only and explicitly
+# selected with `--config`. The project's `.gitleaksignore` (fingerprint
+# allowlist) is still auto-discovered from the source root and applies to
+# this pass too. Skipped when pass 1 already failed.
 if [ -z "$EXIT_CODE" ]; then
-  # GitLab customized configuration file
-  cp "$SCRIPTS_DIR/global/scripts/tools/gitleaks/.gitleaks.toml" .
   docker run \
     -v "$(pwd):$CONTAINER_PATH" \
+    -v "$GITLAB_CONFIG_HOST_PATH:$GITLAB_CONFIG_CONTAINER_PATH:ro" \
     --env REPORT_NUMBER="02" \
+    --env GITLEAKS_CONFIG="$GITLAB_CONFIG_CONTAINER_PATH" \
     --entrypoint "$CONTAINER_PATH/$ENTRYPOINT_FILE" \
     zricethezav/gitleaks:latest || EXIT_CODE=$?
-
-  rm $ENTRYPOINT_FILE .gitleaks.toml
 fi
+
+rm -f "$ENTRYPOINT_FILE"
 
 if ls "$REPORT_PATH"/*.json 1> /dev/null 2>&1; then
   jq -s "add" "$REPORT_PATH"/*.json > "$fileName"


### PR DESCRIPTION
## Summary

- preserve the project's `.gitleaks.toml` across both gitleaks passes by mounting the bundled GitLab config read-only and selecting it with `--config`, instead of `cp`/`rm`-ing it over the project file
- both passes still auto-discover the project's `.gitleaksignore` (fingerprint allowlist) at the source root, so suppressed findings stay suppressed across both rule sets

## Why

While making `customer-clusters` SAST green I noticed the wrapper was silently overwriting and then deleting any project-local `.gitleaks.toml` during the second pass. That meant a project could:

1. craft a `.gitleaks.toml` with `[allowlist]` rules covering known false positives,
2. see pass 1 succeed,
3. watch pass 2 nuke the file, run with the GitLab config, and fail the build on the same false positives,
4. end up with an empty working tree (the file was removed).

The TODO that the previous wrapper carried — *"create a way to have customized .gitleaks.toml"* — is what this PR resolves.

## Behaviour after the fix

| Pass | Rules | Allowlist |
|---|---|---|
| 1 | gitleaks defaults | project's `.gitleaks.toml` (auto-discovered) + project's `.gitleaksignore` |
| 2 | GitLab-customized rule set (`--config /opt/pipelines-gitleaks-config.toml`, mounted ro) | project's `.gitleaksignore` (auto-discovered) |

The project's `.gitleaks.toml` is never touched, copied, or removed.

## Test plan

- [x] Re-ran `make gitleaks` against `customer-clusters` (which had a real `.gitleaks.toml`); the file is intact after the run
- [ ] Re-run on a consumer that did NOT have a `.gitleaks.toml`; pass 2 still uses GitLab rules