### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,9 +7,13 @@ This repository provides comprehensive SDLC pipeline templates for GitHub Action
 ## Quick Reference
 
 **Essential Commands:**
-- `make test` - Run all validation tests
+- `make test` - Run all validation tests (Go, Lambda, YAML merge, SonarQube, release tag, tftest-gen)
 - `make test-go-script` - Test Go script changes specifically
+- `make test-lambda` - Test Lambda template validation specifically
 - `make test-yaml-merge` - Test YAML merge validation specifically
+- `make test-sonarqube` - Test SonarQube auto-derivation specifically
+- `make test-release-tag-idempotency` - Test release tag idempotency specifically
+- `make test-tftest-gen` - Test tftest-gen generator specifically
 - `bash global/scripts/shared/cleanup.sh` - Clean up build reports
 - `docker --version && make --version && go version` - Check dependencies
 
@@ -154,6 +158,8 @@ The Terra CLI pipeline test stage runs through a single unified `test:all` job o
 | **Terra Test (unified)** | Orchestrates both tiers behind one `test:all` job  | `global/scripts/languages/terraform/test-all/run.sh`    |
 | **terra-test**           | `terraform test` over `modules/*/tests/*.tftest.hcl` | `global/scripts/languages/terraform/terra-test/run.sh`  |
 | **Terratest**            | Go test suite under `tests/terratest/*.go`         | `global/scripts/languages/terraform/terratest/run.sh`   |
+| **Structural**           | Third-tier runner for `tests/structural.sh`        | `global/scripts/languages/terraform/structural/run.sh`  |
+| **tftest-gen**           | Generates `tests/smoke.tftest.hcl` for modules     | `global/scripts/languages/terraform/tftest-gen/run.sh`  |
 | **Terraform CycloneDX**  | SBOM generation for Terraform projects             | `global/scripts/languages/terraform/cyclonedx/run.sh`   |
 
 ### Container Images
@@ -237,9 +243,13 @@ pipelines/
 │   │   │   ├── trivy/         # IaC misconfiguration scanning
 │   │   │   └── dependency-track/ # SCA analysis
 │   │   ├── languages/         # Language-specific scripts
-│   │   │   ├── golang/        # Go scripts (test, cyclonedx, golangci-lint, goreleaser, init)
-│   │   │   ├── java/          # Java scripts (checkstyle)
-│   │   │   └── python/        # Python scripts (cyclonedx)
+│   │   │   ├── golang/        # Go scripts (test, cyclonedx, golangci-lint, goreleaser, govulncheck, cross-compile, init)
+│   │   │   ├── java/          # Java scripts (checkstyle, pmd)
+│   │   │   ├── javascript/    # JavaScript scripts (unused-code detection)
+│   │   │   ├── php/           # PHP scripts (unused-code detection)
+│   │   │   ├── python/        # Python scripts (cyclonedx, unused-code detection)
+│   │   │   ├── ruby/          # Ruby scripts (unused-code detection)
+│   │   │   └── terraform/     # Terraform scripts (terra-test, terratest, test-all, structural, cyclonedx, tftest-gen)
 │   │   └── shared/            # Common utilities
 │   ├── containers/            # Custom Docker images
 │   │   ├── golang.*/          # Go development images
@@ -623,13 +633,16 @@ docker build -t test-image -f global/containers/awscli.latest/Dockerfile global/
 
 ### Test Suite Usage
 ```bash
-# Run all validation tests (Go test script + Lambda templates + YAML merge)
+# Run all validation tests (Go, Lambda, YAML merge, SonarQube, release tag, tftest-gen)
 make test
 
 # Run individual test suites
 make test-go-script
 make test-lambda
 make test-yaml-merge
+make test-sonarqube
+make test-release-tag-idempotency
+make test-tftest-gen
 ```
 
 Test scripts are located in `.github/tests/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to document the full `make test` suite (6 targets), all 7 language directories under `global/scripts/languages/`, the `shellcheck` tool, and the newer Terraform helpers (`cyclonedx`, `tftest-gen`, `structural`)
+
 ### Added
 
 - added `global/scripts/languages/terraform/tftest-gen/` — a generator that emits `tests/smoke.tftest.hcl` for a single terraform-module repo (per-repo-is-module layout, complementing the `modules/<name>/` layout handled by `customer-clusters/tests/generators/gen_smoke_tests.py`). Parses `variables.tf` + `main.tf` / `providers.tf`, emits one `mock_provider "<local>" {}` per required provider plus a `run "smoke_plans_successfully"` block with type-valid stubs for every required variable (name-hint table tuned for Azure / Cloudflare / Kubernetes / Helm / Keycloak / OpenSearch). For every required variable that has a `validation {}` block, also emits a `run "validation_rejects_invalid_<var>"` block with an invalid stub and `expect_failures = [var.<var>]` so guards are exercised instead of just declared. Respects hand-written tests (auto-generated files carry a marker on line 1). Piloted on `azm-resource-group` (no validations) and `azm-storage-account` (validations) — both green under `terraform test`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,13 @@ A CI/CD pipeline templates library providing reusable workflows for **GitHub Act
 ## Commands
 
 ```bash
-make test              # Run all validation tests (Go + Lambda)
+make test              # Run all validation tests (Go, Lambda, YAML merge, SonarQube, release tag, tftest-gen)
 make test-go-script    # Test Go validation script only
 make test-lambda       # Test Lambda template validation only
+make test-yaml-merge   # Test YAML merge validation only
+make test-sonarqube    # Test SonarQube auto-derivation only
+make test-release-tag-idempotency  # Test release tag idempotency only
+make test-tftest-gen   # Test tftest-gen generator only
 make build-and-push NAME=<image> TAG=<tag>  # Build and push a container image
 ```
 
@@ -34,12 +38,14 @@ All platforms follow consistent numbered stages:
 - `.github/workflows/` — GitHub Actions reusable workflows (e.g., `go-docker.yaml`, `pdm-docker.yaml`)
 - `gitlab/<language>/` — GitLab CI templates with `stages/`, `scripts/`, `abstracts/` subdirs
 - `azure-devops/<language>/` — Azure DevOps templates, same structure as GitLab
-- `global/scripts/tools/` — Platform-agnostic security tools (codeql, gitleaks, semgrep, hadolint, trivy, sonarqube, dependency-track)
-- `global/scripts/languages/` — Language-specific scripts (golang, python, terraform). Most `run.sh` scripts follow shared conventions, but the Terraform helpers below are documented exceptions: they write reports directly under `build/reports/` and do not rely on the common `cleanup.sh` / Docker-in-Docker pattern.
+- `global/scripts/tools/` — Platform-agnostic security tools (codeql, gitleaks, semgrep, hadolint, shellcheck, trivy, sonarqube, dependency-track)
+- `global/scripts/languages/` — Language-specific scripts (golang, java, javascript, php, python, ruby, terraform). Most `run.sh` scripts follow shared conventions, but the Terraform helpers below are documented exceptions: they write reports directly under `build/reports/` and do not rely on the common `cleanup.sh` / Docker-in-Docker pattern.
   - `terraform/terra-test/` — `terraform test` runner over `modules/*/tests/*.tftest.hcl` (emits JUnit + Markdown/JSON/Cobertura coverage under `build/reports/`)
   - `terraform/terratest/` — Go Terratest runner over `tests/terratest/*.go` (emits JUnit under `build/reports/`)
   - `terraform/test-all/` — unified orchestrator for the first two tiers; runs both when present, merges JUnits into `build/reports/junit-terra-all.xml`, exits `0` when neither tier has tests (stack-only repos)
   - `terraform/structural/` — third tier runner for `tests/structural.sh` (repo-convention assertions the consumer owns); emits `build/reports/junit-structural.xml` (empty-but-valid on skip). Runs on its own parallel job (`test:structural`) instead of through `test-all` because the shell tier is offline and deps-free and shouldn't block on the heavier tiers
+  - `terraform/cyclonedx/` — CycloneDX BOM generator for Terraform projects (delegates to `trivy filesystem --format cyclonedx`)
+  - `terraform/tftest-gen/` — generator that emits `tests/smoke.tftest.hcl` for single-module repos; parses `variables.tf` + `main.tf` / `providers.tf` and emits `mock_provider` blocks plus validation-rejection runs
 - `global/scripts/shared/` — Shared utilities (cleanup.sh, rebase-check.sh, changelog-check.sh)
 - `global/containers/` — Docker image definitions for CI environments
 - `makefiles/` — Includable `.mk` fragments for downstream projects (`common.mk`, `golang.mk`, `python.mk`, etc.)


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.