### PR TITLE
chore: bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/composer.yaml
+++ b/.github/workflows/composer.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout code'
-        uses: 'actions/checkout@v4'
+        uses: 'actions/checkout@v6'
 
       - name: 'Setup PHP'
         uses: 'shivammathur/setup-php@v2'
@@ -40,7 +40,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout code'
-        uses: 'actions/checkout@v4'
+        uses: 'actions/checkout@v6'
 
       - name: 'Setup PHP'
         uses: 'shivammathur/setup-php@v2'
@@ -107,7 +107,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout code'
-        uses: 'actions/checkout@v4'
+        uses: 'actions/checkout@v6'
 
       - name: 'Setup PHP'
         uses: 'shivammathur/setup-php@v2'
@@ -128,7 +128,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout code'
-        uses: 'actions/checkout@v4'
+        uses: 'actions/checkout@v6'
 
       - name: 'Setup PHP'
         uses: 'shivammathur/setup-php@v2'

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -106,13 +106,13 @@ jobs:
         uses: 'actions/checkout@v6'
 
       - name: 'Set up QEMU'
-        uses: 'docker/setup-qemu-action@v3'
+        uses: 'docker/setup-qemu-action@v4'
 
       - name: 'Set up Docker Buildx'
-        uses: 'docker/setup-buildx-action@v3'
+        uses: 'docker/setup-buildx-action@v4'
 
       - name: 'Login to GitHub Container Registry'
-        uses: 'docker/login-action@v3'
+        uses: 'docker/login-action@v4'
         with:
           registry: 'ghcr.io'
           username: ${{ github.actor }}

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: 'actions/checkout@v6'
 
       - name: 'Setup .NET'
-        uses: 'actions/setup-dotnet@v4'
+        uses: 'actions/setup-dotnet@v5'
         with:
           dotnet-version: '8.0.x'
 
@@ -102,7 +102,7 @@ jobs:
         uses: 'actions/checkout@v6'
 
       - name: 'Setup .NET'
-        uses: 'actions/setup-dotnet@v4'
+        uses: 'actions/setup-dotnet@v5'
         with:
           dotnet-version: '8.0.x'
 

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -140,7 +140,7 @@ jobs:
 
       - name: 'Test Results'
         if: "always() && hashFiles('junit.xml') != ''"
-        uses: 'dorny/test-reporter@v1'
+        uses: 'dorny/test-reporter@v3'
         with:
           name: 'Test Results'
           path: 'junit.xml'
@@ -148,7 +148,7 @@ jobs:
 
       - name: 'Upload Coverage Report'
         if: "always() && hashFiles('coverage.txt') != ''"
-        uses: 'actions/upload-artifact@v4'
+        uses: 'actions/upload-artifact@v7'
         with:
           name: 'coverage-report'
           path: |
@@ -177,7 +177,7 @@ jobs:
           fetch-tags: true
 
       - name: 'Download coverage artifact'
-        uses: 'actions/download-artifact@v4'
+        uses: 'actions/download-artifact@v8'
         with:
           name: 'coverage-report'
           path: '.'

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -171,7 +171,7 @@ jobs:
 
       - name: 'Test Results'
         if: "always() && hashFiles('build/test-results/test/*.xml') != ''"
-        uses: 'dorny/test-reporter@v1'
+        uses: 'dorny/test-reporter@v3'
         with:
           name: 'Test Results'
           path: 'build/test-results/test/*.xml'
@@ -179,7 +179,7 @@ jobs:
 
       - name: 'Upload Coverage Report'
         if: "always() && hashFiles('build/reports/jacoco/test/jacocoTestReport.xml') != ''"
-        uses: 'actions/upload-artifact@v4'
+        uses: 'actions/upload-artifact@v7'
         with:
           name: 'coverage-report'
           path: 'build/reports/jacoco/'
@@ -205,7 +205,7 @@ jobs:
           fetch-tags: true
 
       - name: 'Download coverage artifact'
-        uses: 'actions/download-artifact@v4'
+        uses: 'actions/download-artifact@v8'
         with:
           name: 'coverage-report'
           path: 'build/reports/jacoco/'

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -171,7 +171,7 @@ jobs:
 
       - name: 'Test Results'
         if: "always() && hashFiles('target/surefire-reports/*.xml') != ''"
-        uses: 'dorny/test-reporter@v1'
+        uses: 'dorny/test-reporter@v3'
         with:
           name: 'Test Results'
           path: 'target/surefire-reports/*.xml'
@@ -179,7 +179,7 @@ jobs:
 
       - name: 'Upload Coverage Report'
         if: "always() && hashFiles('target/site/jacoco/jacoco.xml') != ''"
-        uses: 'actions/upload-artifact@v4'
+        uses: 'actions/upload-artifact@v7'
         with:
           name: 'coverage-report'
           path: 'target/site/jacoco/'
@@ -205,7 +205,7 @@ jobs:
           fetch-tags: true
 
       - name: 'Download coverage artifact'
-        uses: 'actions/download-artifact@v4'
+        uses: 'actions/download-artifact@v8'
         with:
           name: 'coverage-report'
           path: 'target/site/jacoco/'

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: 'actions/checkout@v6'
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@v4'
+        uses: 'actions/setup-node@v6'
         with:
           node-version: '20'
           cache: 'npm'
@@ -120,7 +120,7 @@ jobs:
         uses: 'actions/checkout@v6'
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@v4'
+        uses: 'actions/setup-node@v6'
         with:
           node-version: '20'
           cache: 'npm'
@@ -143,7 +143,7 @@ jobs:
         uses: 'actions/checkout@v6'
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@v4'
+        uses: 'actions/setup-node@v6'
         with:
           node-version: '20'
           cache: 'npm'
@@ -163,7 +163,7 @@ jobs:
 
       - name: 'Test Results'
         if: "always() && hashFiles('junit-report.xml') != ''"
-        uses: 'dorny/test-reporter@v1'
+        uses: 'dorny/test-reporter@v3'
         with:
           name: 'Test Results'
           path: 'junit-report.xml'
@@ -171,7 +171,7 @@ jobs:
 
       - name: 'Upload Coverage Report'
         if: "always() && hashFiles('coverage/index.html') != ''"
-        uses: 'actions/upload-artifact@v4'
+        uses: 'actions/upload-artifact@v7'
         with:
           name: 'coverage-report'
           path: 'coverage/'
@@ -187,7 +187,7 @@ jobs:
         uses: 'actions/checkout@v6'
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@v4'
+        uses: 'actions/setup-node@v6'
         with:
           node-version: '20'
           cache: 'npm'
@@ -217,7 +217,7 @@ jobs:
           fetch-tags: true
 
       - name: 'Download coverage artifact'
-        uses: 'actions/download-artifact@v4'
+        uses: 'actions/download-artifact@v8'
         with:
           name: 'coverage-report'
           path: 'coverage/'

--- a/.github/workflows/terra.yaml
+++ b/.github/workflows/terra.yaml
@@ -233,7 +233,7 @@ jobs:
 
       - name: 'Publish test results'
         if: 'always()'
-        uses: 'actions/upload-artifact@v4'
+        uses: 'actions/upload-artifact@v7'
         with:
           name: 'terra-coverage'
           path: "${{ env.REPORT_PATH }}"
@@ -294,7 +294,7 @@ jobs:
 
       - name: 'Publish structural JUnit'
         if: 'always()'
-        uses: 'actions/upload-artifact@v4'
+        uses: 'actions/upload-artifact@v7'
         with:
           name: 'structural-results'
           path: "${{ env.REPORT_PATH }}/junit-structural.xml"

--- a/.github/workflows/update-major-version-tag.yaml
+++ b/.github/workflows/update-major-version-tag.yaml
@@ -30,7 +30,7 @@ jobs:
       !github.event.release.prerelease &&
       contains(github.event.release.tag_name, '.'))
     steps:
-      - uses: 'actions/checkout@v4'
+      - uses: 'actions/checkout@v6'
         with:
           # Need full history + tags so the SemVer tag (e.g., `4.6.0`) is
           # resolvable when anchoring the major-version tag to its commit.

--- a/.github/workflows/yarn.yaml
+++ b/.github/workflows/yarn.yaml
@@ -35,7 +35,7 @@ jobs:
         run: 'corepack enable'
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@v4'
+        uses: 'actions/setup-node@v6'
         with:
           node-version: '20'
           cache: 'yarn'
@@ -126,7 +126,7 @@ jobs:
         run: 'corepack enable'
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@v4'
+        uses: 'actions/setup-node@v6'
         with:
           node-version: '20'
           cache: 'yarn'
@@ -150,7 +150,7 @@ jobs:
         run: 'corepack enable'
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@v4'
+        uses: 'actions/setup-node@v6'
         with:
           node-version: '20'
           cache: 'yarn'
@@ -170,7 +170,7 @@ jobs:
 
       - name: 'Test Results'
         if: "always() && hashFiles('junit-report.xml') != ''"
-        uses: 'dorny/test-reporter@v1'
+        uses: 'dorny/test-reporter@v3'
         with:
           name: 'Test Results'
           path: 'junit-report.xml'
@@ -178,7 +178,7 @@ jobs:
 
       - name: 'Upload Coverage Report'
         if: "always() && hashFiles('coverage/index.html') != ''"
-        uses: 'actions/upload-artifact@v4'
+        uses: 'actions/upload-artifact@v7'
         with:
           name: 'coverage-report'
           path: 'coverage/'
@@ -197,7 +197,7 @@ jobs:
         run: 'corepack enable'
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@v4'
+        uses: 'actions/setup-node@v6'
         with:
           node-version: '20'
           cache: 'yarn'
@@ -227,7 +227,7 @@ jobs:
           fetch-tags: true
 
       - name: 'Download coverage artifact'
-        uses: 'actions/download-artifact@v4'
+        uses: 'actions/download-artifact@v8'
         with:
           name: 'coverage-report'
           path: 'coverage/'

--- a/github/global/stages/20-security/docker-gitleaks/action.yaml
+++ b/github/global/stages/20-security/docker-gitleaks/action.yaml
@@ -12,7 +12,7 @@ runs:
       run: $SCRIPTS_DIR/global/scripts/tools/gitleaks/run.sh
 
     - name: 'Upload Report'
-      uses: 'actions/upload-artifact@v6'
+      uses: 'actions/upload-artifact@v7'
       with:
         name: 'gitleaks'
         path: 'build/reports/gitleaks/'

--- a/github/global/stages/20-security/docker-semgrep/action.yaml
+++ b/github/global/stages/20-security/docker-semgrep/action.yaml
@@ -28,7 +28,7 @@ runs:
       run: $SCRIPTS_DIR/global/scripts/tools/semgrep/run.sh "${{ inputs.semgrep_lang }}"
 
     - name: 'Upload Report'
-      uses: 'actions/upload-artifact@v6'
+      uses: 'actions/upload-artifact@v7'
       with:
         name: 'semgrep'
         path: 'build/reports/semgrep/'

--- a/github/global/stages/20-security/hadolint/action.yaml
+++ b/github/global/stages/20-security/hadolint/action.yaml
@@ -12,7 +12,7 @@ runs:
       run: $SCRIPTS_DIR/global/scripts/tools/hadolint/run.sh
 
     - name: 'Upload Report'
-      uses: 'actions/upload-artifact@v6'
+      uses: 'actions/upload-artifact@v7'
       with:
         name: 'hadolint'
         path: 'build/reports/hadolint/'

--- a/github/global/stages/20-security/shellcheck/action.yaml
+++ b/github/global/stages/20-security/shellcheck/action.yaml
@@ -12,7 +12,7 @@ runs:
       run: $SCRIPTS_DIR/global/scripts/tools/shellcheck/run.sh
 
     - name: 'Upload Report'
-      uses: 'actions/upload-artifact@v6'
+      uses: 'actions/upload-artifact@v7'
       with:
         name: 'shellcheck'
         path: 'build/reports/shellcheck/'

--- a/github/global/stages/20-security/trivy-sca/action.yaml
+++ b/github/global/stages/20-security/trivy-sca/action.yaml
@@ -12,7 +12,7 @@ runs:
       run: $SCRIPTS_DIR/global/scripts/tools/trivy/run-sca.sh
 
     - name: 'Upload Report'
-      uses: 'actions/upload-artifact@v6'
+      uses: 'actions/upload-artifact@v7'
       with:
         name: 'trivy-sca'
         path: 'build/reports/trivy-sca/'

--- a/github/global/stages/20-security/trivy/action.yaml
+++ b/github/global/stages/20-security/trivy/action.yaml
@@ -25,7 +25,7 @@ runs:
       run: $SCRIPTS_DIR/global/scripts/tools/trivy/run.sh
 
     - name: 'Upload Report'
-      uses: 'actions/upload-artifact@v6'
+      uses: 'actions/upload-artifact@v7'
       with:
         name: 'trivy'
         path: 'build/reports/trivy/'

--- a/github/global/stages/40-delivery/docker/action.yaml
+++ b/github/global/stages/40-delivery/docker/action.yaml
@@ -40,7 +40,7 @@ runs:
 
     - name: 'Extract Docker metadata'
       id: 'meta'
-      uses: 'docker/metadata-action@v5'
+      uses: 'docker/metadata-action@v6'
       with:
         images: 'ghcr.io/${{ github.repository }}'
         tags: |
@@ -50,14 +50,14 @@ runs:
       if: "inputs.tags == '' && inputs.tag_name == ''"
 
     - name: 'Login to Registry'
-      uses: 'docker/login-action@v3'
+      uses: 'docker/login-action@v4'
       with:
         registry: 'ghcr.io'
         username: '${{ github.actor }}'
         password: '${{ inputs.github_token || github.token }}'
 
     - name: 'Build and Push'
-      uses: 'docker/build-push-action@v6'
+      uses: 'docker/build-push-action@v7'
       with:
         file: '.ci/stages/40-delivery/app.Dockerfile'
         context: '.'

--- a/github/global/stages/40-delivery/release/action.yaml
+++ b/github/global/stages/40-delivery/release/action.yaml
@@ -43,7 +43,7 @@ runs:
         fi
 
     - name: 'Create Release'
-      uses: 'softprops/action-gh-release@v2'
+      uses: 'softprops/action-gh-release@v3'
       with:
         draft: false
         prerelease: false

--- a/github/golang/stages/20-security/govulncheck/action.yaml
+++ b/github/golang/stages/20-security/govulncheck/action.yaml
@@ -16,7 +16,7 @@ runs:
       shell: 'bash'
 
     - name: 'Upload Report'
-      uses: 'actions/upload-artifact@v6'
+      uses: 'actions/upload-artifact@v7'
       with:
         name: 'govulncheck'
         path: 'build/reports/govulncheck/'

--- a/github/golang/stages/40-delivery/binary/action.yaml
+++ b/github/golang/stages/40-delivery/binary/action.yaml
@@ -77,13 +77,13 @@ runs:
     - name: 'Import GPG key'
       id: 'import_gpg'
       if: "inputs.gpg_sign == 'true'"
-      uses: 'crazy-max/ghaction-import-gpg@v6'
+      uses: 'crazy-max/ghaction-import-gpg@v7'
       with:
         gpg_private_key: "${{ inputs.gpg_private_key }}"
         passphrase: "${{ inputs.gpg_passphrase }}"
 
     - name: 'Run GoReleaser'
-      uses: 'goreleaser/goreleaser-action@v6'
+      uses: 'goreleaser/goreleaser-action@v7'
       with:
         distribution: 'goreleaser'
         version: '~> v2'

--- a/github/java/stages/10-code-check/proguard/action.yaml
+++ b/github/java/stages/10-code-check/proguard/action.yaml
@@ -17,7 +17,7 @@ runs:
       shell: 'bash'
 
     - name: 'Upload Report'
-      uses: 'actions/upload-artifact@v6'
+      uses: 'actions/upload-artifact@v7'
       with:
         name: 'proguard'
         path: 'build/reports/proguard/'

--- a/github/javascript/stages/10-code-check/knip/action.yaml
+++ b/github/javascript/stages/10-code-check/knip/action.yaml
@@ -16,7 +16,7 @@ runs:
       shell: 'bash'
 
     - name: 'Setup Node.js'
-      uses: 'actions/setup-node@v4'
+      uses: 'actions/setup-node@v6'
       with:
         node-version: '20'
         cache: '${{ inputs.package_manager }}'
@@ -37,7 +37,7 @@ runs:
       shell: 'bash'
 
     - name: 'Upload Report'
-      uses: 'actions/upload-artifact@v6'
+      uses: 'actions/upload-artifact@v7'
       with:
         name: 'knip'
         path: 'build/reports/knip/'

--- a/github/python/stages/10-code-check/vulture/action.yaml
+++ b/github/python/stages/10-code-check/vulture/action.yaml
@@ -27,7 +27,7 @@ runs:
       shell: 'bash'
 
     - name: 'Upload Report'
-      uses: 'actions/upload-artifact@v6'
+      uses: 'actions/upload-artifact@v7'
       with:
         name: 'vulture'
         path: 'build/reports/vulture/'

--- a/github/python/stages/30-tests/all/action.yaml
+++ b/github/python/stages/30-tests/all/action.yaml
@@ -26,7 +26,7 @@ runs:
       shell: 'bash'
 
     - name: 'Upload test results'
-      uses: 'actions/upload-artifact@v6'
+      uses: 'actions/upload-artifact@v7'
       with:
         name: 'test-results'
         path: 'build/reports/'


### PR DESCRIPTION
## Summary

Bumps GitHub Actions to their latest versions. Addresses the upcoming [deprecation of Node.js 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) (forced Node 24 default on June 2, 2026; Node 20 removed September 16, 2026) and brings third-party actions to current majors.

### Updates applied

| Action | Old | New |
|---|---|---|
| `actions/checkout` | v2 / v4 / v5 / pinned | **v6** / pinned to v6.0.2 |
| `actions/cache` | v1 / pinned | **v5** / pinned to v5.0.5 |
| `actions/setup-go` | v5 / pinned | **v6** / pinned to v6.4.0 |
| `actions/setup-node` | v4 / pinned | **v6** / pinned to v6.4.0 |
| `actions/setup-dotnet` | v4 | **v5** |
| `actions/upload-artifact` | v4 / v6 / pinned | **v7** / pinned to v7.0.1 |
| `actions/download-artifact` | v4 | **v8** |
| `actions/upload-pages-artifact` | v3 | **v5** |
| `actions/deploy-pages` | v4 | **v5** |
| `actions/configure-pages` | v5 | **v6** |
| `actions/dependency-review-action` | pinned v4.8.3 | pinned to v4.9.0 |
| `actions/github-script` | pinned v8.0.0 | pinned to v9.0.0 |
| `actions/stale` | v3 / pinned v9 | **v10** / pinned to v10.2.0 |
| `crazy-max/ghaction-import-gpg` | v6 / pinned | **v7** / pinned to v7.0.0 |
| `dorny/test-reporter` | v1 | **v3** |
| `pnpm/action-setup` | v4 | **v5** |
| `softprops/action-gh-release` | v1 / v2 / pinned | **v3** / pinned to v3.0.0 |
| `goreleaser/goreleaser-action` | v6 / pinned | **v7** / pinned to v7.2.1 |
| `jdx/mise-action` | pinned v3 | pinned to v4.0.1 |
| `docker/build-push-action` | v5 / v6 | **v7** |
| `docker/login-action` | v1 / v3 | **v4** |
| `docker/metadata-action` | v5 | **v6** |
| `docker/setup-buildx-action` | v3 | **v4** |
| `docker/setup-qemu-action` | v3 | **v4** |
| `step-security/harden-runner` | pinned v2.15.0 | pinned to v2.19.0 |
| `azohra/shell-linter` | `@latest` (unpinned!) | **v0.8.0** |

### Heads-up — major-version bumps to verify

These had breaking changes between majors and may need workflow tweaks. Review before merging:

- **`actions/upload-artifact` v4 → v7** and **`download-artifact` v4 → v8** — v4 changed artifact immutability and naming; v5+ requires unique artifact names per upload.
- **`softprops/action-gh-release` v1/v2 → v3** — input schema changes in v3.
- **`dorny/test-reporter` v1 → v3** — config inputs may have changed.
- **`pnpm/action-setup` v4 → v5** — verify Node setup ordering still works.
- **`goreleaser-action` v6 → v7** — requires GoReleaser v2.
- **`actions/stale` v3 → v10** — large gap; verify input names.

## Test plan

- [ ] Verify each affected workflow runs successfully on this branch
- [ ] Confirm artifact upload/download still succeeds where applicable
- [ ] Confirm release workflows publish correctly (where touched)
- [ ] Spot-check Docker build & push if Docker stages were updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
