### PR TITLE
fix(trivy): added --tf-exclude-downloaded-modules to skip vendored module scans

### DIFF
--- a/global/scripts/tools/trivy/run.sh
+++ b/global/scripts/tools/trivy/run.sh
@@ -27,8 +27,21 @@ fi
 echo "Running Trivy IaC misconfiguration scan..."
 # Primary output is JSON — always works and aligns with the other tool
 # scripts (`trivy-sca.json`, `govulncheck.json`, `semgrep.json`, etc.).
+#
+# `--tf-exclude-downloaded-modules` keeps Trivy from re-flagging vendored
+# Terraform modules that the parser resolves through `module "x" { source = "git@..." }`
+# blocks. Each upstream module owns its security posture (runs its own
+# `make sast`, ships its own `.trivyignore`); without this flag the
+# consumer scan re-flags every unresolvable `var.*` default in the
+# vendored `main.tf` and consumers have to mirror every upstream
+# `.trivyignore` (Trivy reads `.trivyignore` only at the scan root, not
+# from vendored subdirs) — producing duplicate, drift-prone suppression
+# lists. The flag does NOT silence findings against module references
+# inside the consumer's own configuration (resource attributes, variable
+# wiring, etc.), only the bodies of the downloaded modules themselves.
 trivy filesystem \
   --scanners misconfig \
+  --tf-exclude-downloaded-modules \
   --format json \
   --output "$jsonFile" \
   --exit-code 1 \

--- a/global/scripts/tools/trivy/run.sh
+++ b/global/scripts/tools/trivy/run.sh
@@ -39,9 +39,16 @@ echo "Running Trivy IaC misconfiguration scan..."
 # lists. The flag does NOT silence findings against module references
 # inside the consumer's own configuration (resource attributes, variable
 # wiring, etc.), only the bodies of the downloaded modules themselves.
+trivy_tf_exclude_flag=""
+if trivy filesystem --help 2>/dev/null | grep -q -- '--tf-exclude-downloaded-modules'; then
+  trivy_tf_exclude_flag="--tf-exclude-downloaded-modules"
+else
+  echo "Installed Trivy does not support --tf-exclude-downloaded-modules; continuing without it."
+fi
+
 trivy filesystem \
   --scanners misconfig \
-  --tf-exclude-downloaded-modules \
+  ${trivy_tf_exclude_flag:+$trivy_tf_exclude_flag} \
   --format json \
   --output "$jsonFile" \
   --exit-code 1 \


### PR DESCRIPTION
## Summary

- Adds `--tf-exclude-downloaded-modules` to the `trivy filesystem` invocation in `global/scripts/tools/trivy/run.sh`.
- Stops the consumer scan from re-flagging vendored Terraform modules that the parser resolves through `module \"x\" { source = \"git@...\" }` blocks.

## Why

Trivy's terraform parser resolves remote module sources and analyzes their bodies as part of the consumer's scan. For terragrunt projects this means every consumer re-flags every unresolvable `var.*` default in every vendored module's `main.tf` — and consumers have to mirror every upstream `.trivyignore` because Trivy reads `.trivyignore` only at the scan root, not from vendored subdirs.

Concrete example: `customer-clusters` PR 11980 bumped `azm-key-vault@1.0.5 → 1.1.0`. The new module ships its own `.trivyignore` covering `AVD-AZU-0013` (network ACL `default_action` defaults to `Allow` — intentional) and `AVD-AZU-0016` (`var.purge_protection_enabled` defaults to `true` but Trivy can't follow the variable). The customer-clusters CI re-fired both findings sourced from the vendored module, even though the module's own CI was clean. Without this flag, the consumer would have to copy/paste those suppressions into every `.trivyignore` of every consumer of every module — drift-prone and a maintenance burden.

`--tf-exclude-downloaded-modules` excludes misconfigurations sourced from downloaded modules **without** affecting findings against module references inside the consumer's own configuration (resource attributes, variable wiring, root-level resources). Each upstream module's CI run keeps owning its own security posture.

## Note

`--skip-dirs '**/.terragrunt-cache'` does NOT solve this. Trivy resolves the module remotely (without needing the `.terragrunt-cache` files on disk), so filesystem-level skips are ineffective.

## Test plan

Reproduced locally on `customer-clusters`:

| State | HIGH/CRITICAL/MEDIUM findings |
|---|---|
| Before this fix (default flag set) | 2 — `AZU-0013` + `AZU-0016` from `azm-key-vault@1.1.0/main.tf` |
| After this fix | 0 |

The module's own CI run on `azm-key-vault` continues to enforce its `.trivyignore` — its security posture is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)