### PR TITLE
feat(docker): publish multi-arch manifest list by default

### DIFF
--- a/.github/tests/test-docker-multi-arch.sh
+++ b/.github/tests/test-docker-multi-arch.sh
@@ -103,7 +103,7 @@ assert_yq \
 # so a future bump that drops multi-arch support has to surface here.
 assert_true \
   "'docker/build-push-action' must be at least v6 (multi-arch via buildx is stable from v6 onwards)" \
-  "yq -e '.runs.steps[] | select(.uses | test(\"^docker/build-push-action@v[6-9]\"))' '$ACTION_FILE' >/dev/null"
+  "yq -e '.runs.steps[] | select(.uses | test(\"^docker/build-push-action@v([6-9]|[1-9][0-9]+)$\"))' '$ACTION_FILE' >/dev/null"
 
 echo ""
 echo "=== Results ==="

--- a/.github/tests/test-docker-multi-arch.sh
+++ b/.github/tests/test-docker-multi-arch.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -e
+
+# Pin the multi-arch contract on the shared `40-delivery/docker` composite
+# action.
+#
+# Why a dedicated regression test exists:
+#
+# `code-guru` rolled out to an AKS cluster with `aks-workersarm-*` ARM
+# workers and crashlooped with `exec /usr/local/bin/code-guru: exec format
+# error` because the published image was a single-arch `linux/amd64`
+# manifest. The fix wires `setup-qemu-action` + `setup-buildx-action`
+# ahead of `docker/build-push-action` and exposes a `platforms` input that
+# defaults to `linux/amd64,linux/arm64`. Each of those four pieces has a
+# distinct silent-failure mode if it regresses:
+#
+#   - missing `setup-buildx-action` → default Docker builder silently
+#     ignores `platforms:` and emits a single-arch manifest;
+#   - missing `setup-qemu-action` → multi-arch builds that exec foreign-arch
+#     binaries inside a `RUN` step (e.g., installer scripts) fail with a
+#     misleading `exec format error` on the BUILD side;
+#   - `platforms` input dropped or default narrowed to `linux/amd64` →
+#     consumers silently regress to single-arch images;
+#   - `platforms` not wired through `with:` on the build step → the input
+#     is accepted but ignored, producing a silently single-arch manifest.
+#
+# These assertions catch each one before it ships.
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ACTION_FILE="$SCRIPTS_DIR/github/global/stages/40-delivery/docker/action.yaml"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_true() {
+  local description="$1"
+  local condition="$2"
+  if eval "$condition"; then
+    echo -e "${GREEN}  PASS: $description${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}  FAIL: $description${NC}"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+assert_yq() {
+  local description="$1"
+  local expression="$2"
+  local expected="$3"
+  local actual
+  actual=$(yq "$expression" "$ACTION_FILE")
+  if [ "$actual" = "$expected" ]; then
+    echo -e "${GREEN}  PASS: $description${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}  FAIL: $description (got: '$actual', expected: '$expected')${NC}"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+# given: the shared docker delivery action exists at the canonical path
+echo "=== Multi-arch contract on $ACTION_FILE ==="
+assert_true \
+  "the action file must exist (path is canonical and consumed by every *-docker.yaml workflow)" \
+  "[ -f '$ACTION_FILE' ]"
+
+# when: the file is parsed as YAML
+# then: every piece of the multi-arch contract must be present
+assert_yq \
+  "the 'platforms' input must be declared so consumers can override at the call-site" \
+  '.inputs.platforms.type' \
+  'string'
+
+assert_yq \
+  "the 'platforms' default must publish a multi-arch manifest list (amd64 AND arm64), not a single-arch image" \
+  '.inputs.platforms.default' \
+  'linux/amd64,linux/arm64'
+
+assert_yq \
+  "'platforms' must be optional (consumers do not have to specify it for the multi-arch default to apply)" \
+  '.inputs.platforms.required' \
+  'false'
+
+assert_true \
+  "'docker/setup-qemu-action' step must be present so RUN steps in arm64 builds can exec foreign-arch binaries via binfmt" \
+  "yq -e '.runs.steps[] | select(.uses == \"docker/setup-qemu-action@v3\")' '$ACTION_FILE' >/dev/null"
+
+assert_true \
+  "'docker/setup-buildx-action' step must be present — the default Docker builder silently ignores 'platforms:' and emits a single-arch manifest" \
+  "yq -e '.runs.steps[] | select(.uses == \"docker/setup-buildx-action@v3\")' '$ACTION_FILE' >/dev/null"
+
+assert_yq \
+  "'platforms' must be wired into the 'docker/build-push-action' step's 'with:' so the input actually reaches the build" \
+  '(.runs.steps[] | select(.uses | test("^docker/build-push-action"))).with.platforms' \
+  '${{ inputs.platforms }}'
+
+# Given the dependency on the build-push-action, also pin the action major
+# so a future bump that drops multi-arch support has to surface here.
+assert_true \
+  "'docker/build-push-action' must be at least v6 (multi-arch via buildx is stable from v6 onwards)" \
+  "yq -e '.runs.steps[] | select(.uses | test(\"^docker/build-push-action@v[6-9]\"))' '$ACTION_FILE' >/dev/null"
+
+echo ""
+echo "=== Results ==="
+echo -e "Passed: ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Failed: ${RED}${TESTS_FAILED}${NC}"
+
+if [ "$TESTS_FAILED" -gt 0 ]; then
+  exit 1
+fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
           for f in CONTRIBUTING.md CHANGELOG.md README.md Makefile clone.sh; do
             test -f "$f" && echo "  ✓ $f" || { echo "  ✗ $f is missing"; exit 1; }
           done
-          for f in .github/tests/test-go-validation.sh .github/tests/test-lambda-templates.sh .github/tests/test-sonarqube-auto-derive.sh .github/tests/test-release-tag-idempotency.sh; do
+          for f in .github/tests/test-go-validation.sh .github/tests/test-lambda-templates.sh .github/tests/test-sonarqube-auto-derive.sh .github/tests/test-release-tag-idempotency.sh .github/tests/test-docker-multi-arch.sh; do
             test -f "$f" && echo "  ✓ $f" || { echo "  ✗ $f is missing"; exit 1; }
           done
 

--- a/.github/workflows/go-binary.yaml
+++ b/.github/workflows/go-binary.yaml
@@ -22,6 +22,11 @@ on:
         required: false
         default: false
         description: 'Also build and push a Docker image to ghcr.io/<owner>/<repo>. Mirrors the delivery-docker job from go-docker.yaml, publishing latest on main pushes and workflow_dispatch runs, and versioned images for tags/releases.'
+      docker_platforms:
+        type: 'string'
+        required: false
+        default: 'linux/amd64,linux/arm64'
+        description: 'Comma-separated list of target platforms forwarded to docker/build-push-action (e.g., `linux/amd64`, `linux/amd64,linux/arm64`). Defaults to a multi-arch manifest list so the image runs on either AMD or ARM Kubernetes nodes; override with a single platform when ARM is not needed and the QEMU emulation cost on the build is undesirable.'
       gpg_sign:
         type: 'boolean'
         required: false
@@ -80,6 +85,7 @@ jobs:
       - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker@main'
         with:
           tag_name: "${{ needs.delivery-release.outputs.tag_name }}"
+          platforms: "${{ inputs.docker_platforms }}"
     needs: [ 'go', 'delivery-release' ]
     if: "inputs.deliver_docker && !failure() && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/'))"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `platforms` input to `github/global/stages/40-delivery/docker/action.yaml` (default `linux/amd64,linux/arm64`) so the published manifest is a multi-arch list. The action now runs `docker/setup-qemu-action@v3` + `docker/setup-buildx-action@v3` before `docker/build-push-action@v7` so the build can cross-compile and emit a manifest list. Surfaced as `docker_platforms` on the `go-binary.yaml` reusable workflow for consumer override (defaults to the same multi-arch pair). Motivated by `code-guru` rolling out to an AKS cluster with `aks-workersarm-*` ARM workers and crashlooping with `exec /usr/local/bin/code-guru: exec format error` because the previous single-arch `linux/amd64` manifest could not execute on those nodes; every other Docker-publishing consumer (`go-docker.yaml`, `npm-docker.yaml`, `pdm-docker.yaml`, `bundler-docker.yaml`, `maven-docker.yaml`, `dotnet-docker.yaml`) inherits the new default automatically through the action and can override at the action call-site if a single platform is preferred
+
+### Changed
+
+- changed the `docker/build-push-action` invocation in `40-delivery/docker` to require buildx (`setup-buildx-action`) — the default Docker builder silently ignores `platforms:` and emits a single-arch manifest, which was the exact failure mode that crashlooped `code-guru` pods. With buildx the action correctly produces a manifest list
+
 ## [4.8.0] - 2026-04-29
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TAG := latest
 ROOT := global/containers
 CONTAINER_REGISTRY = ghcr.io/rios0rios0/pipelines
 
-.PHONY: login setup-buildx build-and-push test-go-script test-lambda test-yaml-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test
+.PHONY: login setup-buildx build-and-push test-go-script test-lambda test-yaml-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-docker-multi-arch test
 
 login:
 	docker login $(CONTAINER_REGISTRY)
@@ -42,5 +42,9 @@ test-tftest-gen:
 	@echo "Running tftest-gen generator validation..."
 	@./.github/tests/test-tftest-gen.sh
 
-test: test-go-script test-lambda test-yaml-merge test-sonarqube test-release-tag-idempotency test-tftest-gen
+test-docker-multi-arch:
+	@echo "Running 40-delivery/docker multi-arch contract validation..."
+	@./.github/tests/test-docker-multi-arch.sh
+
+test: test-go-script test-lambda test-yaml-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-docker-multi-arch
 	@echo "All tests completed successfully!"

--- a/github/global/stages/40-delivery/docker/action.yaml
+++ b/github/global/stages/40-delivery/docker/action.yaml
@@ -14,6 +14,20 @@ inputs:
     type: 'string'
     required: false
     default: ''
+  platforms:
+    description: |
+      Target platforms for the build, as a comma-separated list. Defaults
+      to `linux/amd64,linux/arm64` so the published manifest is a
+      multi-arch list and the image runs on both AMD and ARM Kubernetes
+      worker pools — `code-guru` rolling out to an AKS cluster with
+      `aks-workersarm-*` workers crashlooped with `exec format error`
+      because the previous single-arch `linux/amd64` image could not
+      execute on those nodes. Override with a single platform (e.g.
+      `linux/amd64`) when a consumer explicitly does not need ARM and
+      wants to skip the QEMU emulation cost on the build.
+    type: 'string'
+    required: false
+    default: 'linux/amd64,linux/arm64'
 
 runs:
   using: 'composite'
@@ -56,10 +70,30 @@ runs:
         username: '${{ github.actor }}'
         password: '${{ inputs.github_token || github.token }}'
 
+    # `setup-qemu-action` registers `binfmt_misc` handlers so the GitHub
+    # `ubuntu-latest` runner (amd64) can execute ARM binaries during the
+    # `RUN` steps of an `arm64` build. Without it, multi-arch builds
+    # that invoke an architecture-specific binary inside a `RUN` step
+    # (e.g. `apk add`, `apt-get install`, a `curl`-then-bash installer
+    # like `claude.ai/install.sh`) fail at the foreign-arch interpreter
+    # exec rather than producing a working image.
+    - name: 'Set up QEMU'
+      uses: 'docker/setup-qemu-action@v3'
+
+    # `setup-buildx-action` swaps the default Docker builder for the
+    # buildx driver, which is what `docker/build-push-action` requires
+    # to produce a multi-platform manifest list. The default builder
+    # silently ignores `platforms:` and emits a single-arch manifest —
+    # the exact failure mode that bit `code-guru` and motivated this
+    # change.
+    - name: 'Set up Docker Buildx'
+      uses: 'docker/setup-buildx-action@v3'
+
     - name: 'Build and Push'
       uses: 'docker/build-push-action@v7'
       with:
         file: '.ci/stages/40-delivery/app.Dockerfile'
         context: '.'
         push: true
+        platforms: '${{ inputs.platforms }}'
         tags: '${{ inputs.tags || steps.release-tags.outputs.tags || steps.meta.outputs.tags }}'


### PR DESCRIPTION
## Summary

`code-guru` rolled out to an AKS cluster with `aks-workersarm-*` ARM workers and crashlooped with `exec /usr/local/bin/code-guru: exec format error` because the published image at `ghcr.io/rios0rios0/code-guru:latest` was a single-arch `linux/amd64` manifest. The default Docker builder silently ignores `platforms:` and emits a single-arch manifest.

This PR makes the `40-delivery/docker` composite action publish a multi-arch manifest list (`linux/amd64,linux/arm64`) by default.

## Changes

- **`github/global/stages/40-delivery/docker/action.yaml`**
  - New `platforms` input (default `linux/amd64,linux/arm64`).
  - Inserts `docker/setup-qemu-action@v3` and `docker/setup-buildx-action@v3` before `docker/build-push-action@v7`. QEMU enables `binfmt_misc` so RUN steps in arm64 builds can exec foreign-arch binaries (installer scripts like `claude.ai/install.sh` would otherwise fail at the interpreter exec on the build side). Buildx is what actually emits a manifest list — the stock builder cannot.
  - `platforms` is wired into the build step's `with:`.
- **`.github/workflows/go-binary.yaml`** — forwards `docker_platforms` from caller through to the action so consumers can override.
- **`.github/tests/test-docker-multi-arch.sh`** (new) — 8 assertions pinning the multi-arch contract; each row carries a comment describing the specific silent-failure mode it catches.
- **`Makefile`** + **`.github/workflows/ci.yaml`** — new `test-docker-multi-arch` target wired into `make test` and the CI required-files check.
- **`CHANGELOG.md`** — `[Unreleased]` entry under Added + Changed.

## Backward compatibility

Existing call-sites that don't pass `platforms` automatically inherit multi-arch. Consumers who explicitly want amd64-only override at the call-site. The other Docker-publishing reusable workflows inherit the new default through the action with no workflow change required.

## Test plan

- [x] `./.github/tests/test-docker-multi-arch.sh` — 8/8 pass
- [x] `make test-docker-multi-arch`
- [ ] After merge, the next code-guru build emits a manifest list and the cluster's ARM workers can pull and run it (companion `shared-toolbox#12074` removes the `nodeSelector` workaround once we verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)