### PR TITLE
fix(golangci-lint): update install script URL from deprecated `master…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed `golangci-lint` install script URL pointing to the deprecated `master` branch instead of `main`. The golangci-lint project announced in v2.12.1 that `master` is no longer used, causing the stale install script to produce SHA256 checksum mismatches when downloading new releases and failing the pipeline with exit code 127. Switched to the official stable URL `https://golangci-lint.run/install.sh` recommended by the project
+
 ## [4.9.0] - 2026-05-03
 
 ### Added

--- a/global/scripts/languages/golang/golangci-lint/run.sh
+++ b/global/scripts/languages/golang/golangci-lint/run.sh
@@ -88,7 +88,7 @@ if command -v golangci-lint > /dev/null 2>&1; then
   fi
 fi
 if [ -z "$GOLANGCI_LINT" ]; then
-  wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh
+  wget -O- -nv https://golangci-lint.run/install.sh | sh
   GOLANGCI_LINT="./bin/golangci-lint"
 fi
 "$GOLANGCI_LINT" run \


### PR DESCRIPTION
…` branch

The golangci-lint project stopped using the `master` branch in favor of `main` (announced in v2.12.1 release notes). The stale install script on `master` causes SHA256 checksum mismatches when downloading new releases, breaking the pipeline with exit code 127.

Switch to the official stable URL recommended by the project.

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
