### PR TITLE
fix(proguard): detected build tool to pick correct setup-java cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed `quality:proguard` GitHub Actions cache backend mismatch. The build tool detection in `action.yaml` checked `pom.xml` before `gradlew`, so repos containing both files received the Maven cache even though `run.sh` compiles them with Gradle. Flipped the detection order to mirror `run.sh` (`gradlew` first, then `pom.xml`) so the `actions/setup-java@v5` cache always matches the build tool that actually runs
+
 ## [4.9.1] - 2026-05-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Fixed
 
 - fixed `golangci-lint` install script URL pointing to the deprecated `master` branch instead of `main`. The golangci-lint project announced in v2.12.1 that `master` is no longer used, causing the stale install script to produce SHA256 checksum mismatches when downloading new releases and failing the pipeline with exit code 127. Switched to the official stable URL `https://golangci-lint.run/install.sh` recommended by the project
+- fixed `quality:proguard` GitHub Actions step failing on Maven projects. The `actions/setup-java@v5` step was hardcoded with `cache: 'gradle'`, which errors out when no Gradle build files are present and prevented the proguard analysis from running on Maven repos. The setup now detects `pom.xml` vs `build.gradle*` / `gradlew` and selects the matching cache backend
 
 ## [4.9.0] - 2026-05-03
 

--- a/github/java/stages/10-code-check/proguard/action.yaml
+++ b/github/java/stages/10-code-check/proguard/action.yaml
@@ -4,12 +4,24 @@ runs:
     - name: 'Checkout code'
       uses: 'actions/checkout@v6'
 
+    - name: 'Detect build tool'
+      id: 'build_tool'
+      shell: 'bash'
+      run: |
+        if [ -f 'pom.xml' ]; then
+          echo 'cache=maven' >> "$GITHUB_OUTPUT"
+        elif [ -f 'build.gradle' ] || [ -f 'build.gradle.kts' ] || [ -f 'gradlew' ]; then
+          echo 'cache=gradle' >> "$GITHUB_OUTPUT"
+        else
+          echo 'cache=' >> "$GITHUB_OUTPUT"
+        fi
+
     - name: 'Setup Java'
       uses: 'actions/setup-java@v5'
       with:
         distribution: 'temurin'
         java-version: '21'
-        cache: 'gradle'
+        cache: ${{ steps.build_tool.outputs.cache }}
 
     - uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
 

--- a/github/java/stages/10-code-check/proguard/action.yaml
+++ b/github/java/stages/10-code-check/proguard/action.yaml
@@ -8,10 +8,10 @@ runs:
       id: 'build_tool'
       shell: 'bash'
       run: |
-        if [ -f 'pom.xml' ]; then
-          echo 'cache=maven' >> "$GITHUB_OUTPUT"
-        elif [ -f 'build.gradle' ] || [ -f 'build.gradle.kts' ] || [ -f 'gradlew' ]; then
+        if [ -f 'gradlew' ]; then
           echo 'cache=gradle' >> "$GITHUB_OUTPUT"
+        elif [ -f 'pom.xml' ]; then
+          echo 'cache=maven' >> "$GITHUB_OUTPUT"
         else
           echo 'cache=' >> "$GITHUB_OUTPUT"
         fi


### PR DESCRIPTION
## Summary

- The `quality:proguard` job in the Maven workflow hardcoded `cache: 'gradle'` on `setup-java@v5`, which errors out on Maven projects with: `##[error]No file in <repo> matched to [**/*.gradle*,**/gradle-wrapper.properties,...]`.
- That single error short-circuited the composite action so the proguard analysis never ran, then `actions/upload-artifact@v7` failed with `if-no-files-found: error` because `build/reports/proguard/` had not been created.
- The setup now detects the build tool (`pom.xml` → `maven`, `build.gradle*` / `gradlew` → `gradle`, otherwise empty / no cache) and passes the matching value to `setup-java`.

This unblocks `quality:proguard` on Maven repos (e.g. `rios0rios0/rest-arch`) without changing behaviour for Gradle repos.

## Test plan

- [ ] Re-run the `quality:proguard` job on a Maven repo (`rios0rios0/rest-arch` PR #26) and confirm it now passes.
- [ ] Re-run on an existing Gradle repo and confirm cache continues to be used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)