### PR TITLE
fix(golang): pin golangci-lint to v2.12.2 to eliminate local/CI version skew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Fixed
 
+- fixed golangci-lint version skew between local and CI by pinning the install script to `v2.12.2` and rejecting any locally installed binary that doesn't match the pinned version
 - fixed `quality:proguard` GitHub Actions cache backend mismatch. The build tool detection in `action.yaml` checked `pom.xml` before `gradlew`, so repos containing both files received the Maven cache even though `run.sh` compiles them with Gradle. Flipped the detection order to mirror `run.sh` (`gradlew` first, then `pom.xml`) so the `actions/setup-java@v5` cache always matches the build tool that actually runs
 
 ## [4.9.1] - 2026-05-08

--- a/global/scripts/languages/golang/golangci-lint/run.sh
+++ b/global/scripts/languages/golang/golangci-lint/run.sh
@@ -80,15 +80,17 @@ else
   cp "$defaultYamlFile" "$mergedYamlFile"
 fi
 
+GOLANGCI_LINT_VERSION="v2.12.2"
+
 GOLANGCI_LINT=""
 if command -v golangci-lint > /dev/null 2>&1; then
-  DETECTED_MAJOR=$(golangci-lint version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 | cut -d. -f1)
-  if [ "$DETECTED_MAJOR" -ge 2 ] 2>/dev/null; then
+  DETECTED_VERSION=$(golangci-lint version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+  if [ "$DETECTED_VERSION" = "${GOLANGCI_LINT_VERSION#v}" ]; then
     GOLANGCI_LINT="golangci-lint"
   fi
 fi
 if [ -z "$GOLANGCI_LINT" ]; then
-  wget -O- -nv https://golangci-lint.run/install.sh | sh
+  wget -O- -nv https://golangci-lint.run/install.sh | sh -s -- -b ./bin "${GOLANGCI_LINT_VERSION}"
   GOLANGCI_LINT="./bin/golangci-lint"
 fi
 "$GOLANGCI_LINT" run \


### PR DESCRIPTION
## Summary

The golangci-lint install script accepted any locally installed v2.x binary while always downloading the latest release on CI. When v2.12.2 shipped with a changed gosec rule set, directives that were valid locally became unused on CI and `nolintlint` failed the pipeline. Pinning the version to `v2.12.2` ensures both paths run the exact same binary.

## Context

The previous version check only tested the major version (`-ge 2`), so a developer on 2.11.x would pass lint locally while the same commit failed in CI on 2.12.x. The fix changes the check to an exact version match — if the local binary doesn't match the pin it falls through to the download path, which now passes `v2.12.2` explicitly to the install script rather than fetching latest.

## Impact

- **Breaking:** No — consumers get a predictable pinned version instead of an unpredictable latest; any project already passing lint on v2.12.2 is unaffected
- **Reversibility:** High — reverting is a one-line change to the version constant; updating is the same

## Testing

- [x] Lint: script logic validated locally — local binary version check and pinned download path both exercised
- [ ] CI pipeline: will be confirmed by the ADO pipeline running this script against sight-detector PR #12464