### PR TITLE
fix(sast): added architecture detection to Hadolint download script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 - refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to add ShellCheck to the stage 20 SAST tools list, add the 8 `*-library.yaml` workflows to the copilot-instructions template list, and include `make test-docker-multi-arch` in the test suite usage section
 
+### Fixed
+
+- fixed `global/scripts/tools/hadolint/run.sh` to detect the host architecture via `uname -m` when downloading the Hadolint binary. The script previously hard-coded `hadolint-Linux-x86_64`, which fails with `Exec format error` on `aarch64` / `arm64` runners. The new `case` switch maps `x86_64` and `aarch64`/`arm64` to the matching upstream binary (`hadolint-Linux-x86_64` / `hadolint-Linux-arm64`) and exits with a clear message on unsupported architectures, mirroring the `case`-based switch already used by `global/scripts/tools/gitleaks/run.sh` and `global/scripts/tools/shellcheck/run.sh`
+
 ## [4.10.2] - 2026-05-22
 
 ### Changed

--- a/global/scripts/tools/hadolint/run.sh
+++ b/global/scripts/tools/hadolint/run.sh
@@ -43,7 +43,18 @@ fi
 if ! command -v hadolint > /dev/null 2>&1; then
   echo "Downloading Hadolint..."
   HADOLINT_VERSION=$(curl -fsSL https://api.github.com/repos/hadolint/hadolint/releases/latest | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
-  curl -fsSL "https://github.com/hadolint/hadolint/releases/download/$HADOLINT_VERSION/hadolint-Linux-x86_64" -o /tmp/hadolint
+
+  ARCH=$(uname -m)
+  case "$ARCH" in
+    x86_64)        HADOLINT_ARCH="x86_64" ;;
+    aarch64|arm64) HADOLINT_ARCH="arm64" ;;
+    *)
+      echo "Unsupported architecture: $ARCH" >&2
+      exit 1
+      ;;
+  esac
+
+  curl -fsSL "https://github.com/hadolint/hadolint/releases/download/$HADOLINT_VERSION/hadolint-Linux-$HADOLINT_ARCH" -o /tmp/hadolint
   chmod +x /tmp/hadolint
   export PATH="/tmp:$PATH"
 fi


### PR DESCRIPTION
## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?

## Summary

The `global/scripts/tools/hadolint/run.sh` install block hard-coded the upstream `hadolint-Linux-x86_64` binary, so the curl download succeeds on any host but the resulting binary fails with `Exec format error` (exit `126`) when executed on `aarch64` / `arm64` runners.

The fix mirrors the `case`-based architecture switch already used by the sibling `gitleaks/run.sh` and `shellcheck/run.sh` scripts:

```bash
ARCH=$(uname -m)
case "$ARCH" in
  x86_64)        HADOLINT_ARCH="x86_64" ;;
  aarch64|arm64) HADOLINT_ARCH="arm64" ;;
  *)
    echo "Unsupported architecture: $ARCH" >&2
    exit 1
    ;;
esac

curl -fsSL "https://github.com/hadolint/hadolint/releases/download/$HADOLINT_VERSION/hadolint-Linux-$HADOLINT_ARCH" -o /tmp/hadolint
```

Hadolint publishes both `hadolint-Linux-x86_64` and `hadolint-Linux-arm64` release assets, so the switch covers every architecture the upstream supports; anything else fails fast with an explicit message instead of producing a non-executable file.

No behaviour change on `x86_64` runners — the resolved download URL is byte-identical to the previous one.