### PR TITLE
feat(codeql): add resource tuning and project-level config support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Added
 
 - added `DEPENDS_ON` parameter to Golang Azure DevOps stage templates (`10-code-check`, `20-security`, `30-tests`, `35-management`), allowing consumers to override stage dependencies for parallel execution
+- added `CODEQL_RAM`, `CODEQL_THREADS` environment variable support and project-level `codeql-config.yml` auto-detection to `global/scripts/tools/codeql/run.sh`. Projects can now tune CodeQL resource usage via pipeline variables (`CODEQL_RAM` sets `--ram`, `CODEQL_THREADS` sets `--threads`, default `1`) and exclude irrelevant queries or paths by placing a `codeql-config.yml` in the project root (passed as `--codescanning-config`). Without any of these, behavior is identical to before
 
 ### Changed
 

--- a/global/scripts/tools/codeql/run.sh
+++ b/global/scripts/tools/codeql/run.sh
@@ -9,6 +9,23 @@ TOOL_NAME="codeql" . "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
 CODEQL_LANGUAGE="${1:?Usage: run.sh <language> (e.g., go, python, java, javascript, csharp)}"
 fileName="$(pwd)/$REPORT_PATH/codeql.sarif"
 
+CODEQL_RAM="${CODEQL_RAM:-}"
+CODEQL_THREADS="${CODEQL_THREADS:-1}"
+
+RAM_FLAG=""
+if [ -n "$CODEQL_RAM" ]; then
+  RAM_FLAG="--ram=$CODEQL_RAM"
+  echo "CodeQL RAM limit set to ${CODEQL_RAM} MB"
+fi
+THREADS_FLAG="--threads=$CODEQL_THREADS"
+echo "CodeQL threads set to $CODEQL_THREADS"
+
+CONFIG_FLAG=""
+if [ -f "$(pwd)/codeql-config.yml" ]; then
+  CONFIG_FLAG="--codescanning-config=$(pwd)/codeql-config.yml"
+  echo "Using project CodeQL config: codeql-config.yml"
+fi
+
 # Load project-level configuration if available (e.g. for Go build environment)
 if [ "$CODEQL_LANGUAGE" = "go" ]; then
   INIT_SCRIPT="config.sh"
@@ -56,9 +73,12 @@ if ! command -v codeql > /dev/null 2>&1; then
 fi
 
 echo "Creating CodeQL database for language: $CODEQL_LANGUAGE"
+# shellcheck disable=SC2086
 if ! codeql database create \
   --language="$CODEQL_LANGUAGE" \
   --source-root="$(pwd)" \
+  $THREADS_FLAG \
+  $CONFIG_FLAG \
   "$(pwd)/.codeql-db"; then
   echo "ERROR: 'codeql database create' failed for language '$CODEQL_LANGUAGE'." >&2
   rm -rf "$(pwd)/.codeql-db"
@@ -66,9 +86,12 @@ if ! codeql database create \
 fi
 
 echo "Running CodeQL analysis..."
+# shellcheck disable=SC2086
 if ! codeql database analyze \
   --format=sarifv2.1.0 \
   --output="$fileName" \
+  $RAM_FLAG \
+  $THREADS_FLAG \
   "$(pwd)/.codeql-db" \
   "$CODEQL_LANGUAGE-security-and-quality.qls"; then
   echo "ERROR: 'codeql database analyze' failed for language '$CODEQL_LANGUAGE'." >&2


### PR DESCRIPTION
## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?

## Summary

  - Added `CODEQL_RAM` and `CODEQL_THREADS` environment variable support to `global/scripts/tools/codeql/run.sh`, allowing per-project resource tuning via pipeline variables (`--ram` and
  `--threads` flags)
  - Added auto-detection of `codeql-config.yml` in the project root, passed as `--codescanning-config` to `codeql database create` — enables per-project `paths-ignore` and `query-filters`
  without modifying the shared script

  ## Context

  CodeQL CI was failing or underperforming on two projects:

  1. **Frontend/catalog (React)**: OOM crash (`OutOfMemoryError "Java heap space"`) caused by irrelevant AngularJS queries running on a React project. Fixed with `codeql-config.yml`
  `query-filters` excluding `frameworks/angularjs` queries.
  2. **Backend/catalog (Go)**: ~14 min runtime due to memory thrashing (95%+ usage from `msgraph-sdk-go` type graph extraction on 7 GB VMs). Reduced to ~8 min with `--threads=0` (using
  both cores) and `--ram=4096`.

  **Note on Go limitations**: CodeQL does not support `paths-ignore` for Go — the log explicitly states *"Go does not support path-based filtering"*. For Go projects, only `CODEQL_RAM` and
   `CODEQL_THREADS` provide improvement. `query-filters` works for all languages.

  ## Backwards compatibility

  All changes are opt-in via environment variables. Without any configuration:
  - `CODEQL_THREADS` defaults to `1` (current behavior)
  - `CODEQL_RAM` is unset (no `--ram` flag passed, current behavior)
  - No `codeql-config.yml` → no `--codescanning-config` flag (current behavior)

  ## Test plan

  - [x] Tested on frontend/catalog (PR #12945): OOM crash eliminated, runtime ~2 min, 5 real findings
  - [x] Tested on backend/catalog (PR #12983 draft): runtime reduced from ~14 min to ~8 min, 0 findings, clean scan
  - [x] Verified backwards compatibility: without env vars or config file, behavior is identical to before
  - [ ] Verify no regressions on other projects after merge