### PR TITLE
feat(terraform): add file-ordering check/auto-fixer to the code-check stage

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,13 +7,14 @@ This repository provides comprehensive SDLC pipeline templates for GitHub Action
 ## Quick Reference
 
 **Essential Commands:**
-- `make test` - Run all validation tests (Go, Lambda, YAML merge, SonarQube, release tag, tftest-gen, docker-multi-arch)
+- `make test` - Run all validation tests (Go, Lambda, YAML merge, SonarQube, release tag, tftest-gen, order-check, docker-multi-arch)
 - `make test-go-script` - Test Go script changes specifically
 - `make test-lambda` - Test Lambda template validation specifically
 - `make test-yaml-merge` - Test YAML merge validation specifically
 - `make test-sonarqube` - Test SonarQube auto-derivation specifically
 - `make test-release-tag-idempotency` - Test release tag idempotency specifically
 - `make test-tftest-gen` - Test tftest-gen generator specifically
+- `make test-order-check` - Test the Terragrunt file-ordering checker/fixer specifically
 - `make test-docker-multi-arch` - Test 40-delivery/docker multi-arch contract specifically
 - `bash global/scripts/shared/cleanup.sh` - Clean up build reports
 - `docker --version && make --version && go version` - Check dependencies
@@ -162,6 +163,7 @@ The Terra CLI pipeline test stage runs through a single unified `test:all` job o
 | **Terratest**            | Go test suite under `tests/terratest/*.go`         | `global/scripts/languages/terraform/terratest/run.sh`   |
 | **Structural**           | Third-tier runner for `tests/structural.sh`        | `global/scripts/languages/terraform/structural/run.sh`  |
 | **tftest-gen**           | Generates `tests/smoke.tftest.hcl` for modules     | `global/scripts/languages/terraform/tftest-gen/run.sh`  |
+| **order-check**          | Checks/auto-fixes file ordering (deps, variables, providers, outputs); runs in `10-code-check` | `global/scripts/languages/terraform/order-check/run.sh` |
 | **Terraform CycloneDX**  | SBOM generation for Terraform projects             | `global/scripts/languages/terraform/cyclonedx/run.sh`   |
 
 ### Container Images
@@ -251,7 +253,7 @@ pipelines/
 │   │   │   ├── php/           # PHP scripts (unused-code detection)
 │   │   │   ├── python/        # Python scripts (cyclonedx, unused-code detection)
 │   │   │   ├── ruby/          # Ruby scripts (unused-code detection)
-│   │   │   └── terraform/     # Terraform scripts (terra-test, terratest, test-all, structural, cyclonedx, tftest-gen)
+│   │   │   └── terraform/     # Terraform scripts (terra-test, terratest, test-all, structural, cyclonedx, tftest-gen, order-check)
 │   │   └── shared/            # Common utilities
 │   ├── containers/            # Custom Docker images
 │   │   ├── golang.*/          # Go development images
@@ -635,7 +637,7 @@ docker build -t test-image -f global/containers/awscli.latest/Dockerfile global/
 
 ### Test Suite Usage
 ```bash
-# Run all validation tests (Go, Lambda, YAML merge, SonarQube, release tag, tftest-gen, docker-multi-arch)
+# Run all validation tests (Go, Lambda, YAML merge, SonarQube, release tag, tftest-gen, order-check, docker-multi-arch)
 make test
 
 # Run individual test suites
@@ -645,6 +647,7 @@ make test-yaml-merge
 make test-sonarqube
 make test-release-tag-idempotency
 make test-tftest-gen
+make test-order-check
 make test-docker-multi-arch
 ```
 

--- a/.github/tests/test-order-check.sh
+++ b/.github/tests/test-order-check.sh
@@ -573,6 +573,127 @@ set +e; oc --repo-dir "$R13" >/dev/null 2>&1; RC13=$?; set -e
 assert_true "exit 0 on repo with nothing to check" "[ $RC13 -eq 0 ]"
 
 # =============================================================================
+# Test 14: --fix never corrupts heredocs or block comments containing braces.
+#   (regression guard: a bare `}` inside a heredoc body or a `/* { } */` block
+#    comment must not be counted as a structural brace, or find_matching_brace
+#    would end a block early and the reorder would scramble the file)
+# =============================================================================
+echo "TEST 14: --fix preserves heredoc + block-comment braces while reordering"
+# given
+R14="$TEST_DIR/heredoc"
+make_clean_repo "$R14"
+cat > "$R14/stacks/04_app/variables.tf" << 'HCL'
+// SET ON .HCL
+
+variable "kube" {
+  /* config note: this resource uses { and } tokens */
+  type = string
+}
+
+variable "registry" {
+  type    = string
+  default = <<-EOT
+    a dangling close brace } sits in this prose
+  EOT
+}
+
+// SET ON .ENV
+
+variable "environment" {
+  type = string
+}
+HCL
+# when (fix)
+oc --repo-dir "$R14" --fix >/dev/null 2>&1
+set +e; oc --repo-dir "$R14" >/dev/null 2>&1; RC14=$?; set -e
+# then
+assert_true "re-check passes after --fix (no corruption)" "[ $RC14 -eq 0 ]"
+assert_true "registry(01) reordered before kube(03)" \
+  "awk '/variable \"registry\"/{r=NR} /variable \"kube\"/{k=NR} END{exit !(r<k)}' '$R14/stacks/04_app/variables.tf'"
+assert_true "heredoc body line preserved intact" \
+  "grep -qF 'a dangling close brace } sits in this prose' '$R14/stacks/04_app/variables.tf'"
+assert_true "heredoc terminator preserved" \
+  "grep -qE '^  EOT$' '$R14/stacks/04_app/variables.tf'"
+assert_true "block comment with braces preserved" \
+  "grep -qF '/* config note: this resource uses { and } tokens */' '$R14/stacks/04_app/variables.tf'"
+
+# =============================================================================
+# Test 15: stacks are discovered independently of root.hcl, so an orphan stack
+#   (not referenced by any root.hcl) is still checked for markers + outputs.
+# =============================================================================
+echo "TEST 15: orphan stack (no root.hcl) is still checked"
+# given -- a repo with no environments/, just a stack
+R15="$TEST_DIR/orphan"
+mkdir -p "$R15/stacks/orphan"
+cat > "$R15/stacks/orphan/variables.tf" << 'HCL'
+variable "anything" {
+  type = string
+}
+HCL
+cat > "$R15/stacks/orphan/main.tf" << 'HCL'
+module "alpha" {
+  source = "./a"
+}
+
+module "beta" {
+  source = "./b"
+}
+HCL
+cat > "$R15/stacks/orphan/outputs.tf" << 'HCL'
+output "b" {
+  value = module.beta.id
+}
+
+output "a" {
+  value = module.alpha.id
+}
+HCL
+# when
+set +e; OUT15="$(oc --repo-dir "$R15" 2>&1)"; RC15=$?; set -e
+# then
+assert_true "orphan stack variables.tf marker warning emitted" \
+  "echo \"\$OUT15\" | grep -q 'stacks/orphan/variables.tf'"
+assert_true "orphan stack outputs.tf ordering flagged (no root.hcl needed)" \
+  "echo \"\$OUT15\" | grep -q 'stacks/orphan/outputs.tf'"
+assert_true "outputs ordering is the failing error" "[ $RC15 -eq 1 ]"
+
+# =============================================================================
+# Test 16: check mode catches a dependency reference on a later line of a
+#   multi-line input value (not just the assignment's first line).
+# =============================================================================
+echo "TEST 16: multi-line input value dependency reference is detected"
+# given
+R16="$TEST_DIR/multiline"
+make_clean_repo "$R16"
+cat > "$R16/environments/04_app/root.hcl" << 'HCL'
+dependency "shared_common" {
+  config_path = "${get_path_to_repo_root()}//environments/01_shared/02_common"
+}
+
+dependency "kubernetes" {
+  config_path = "${get_path_to_repo_root()}//environments/03_kubernetes/x"
+}
+
+terraform {
+  source = "${get_path_to_repo_root()}//stacks/04_app"
+}
+
+inputs = {
+  kube_cfg = {
+    host = dependency.kubernetes.outputs.host
+  }
+
+  registry = dependency.shared_common.outputs.registry
+}
+HCL
+# when -- kubernetes(03) ref is on line 2 of kube_cfg's value, then
+#         shared_common(01) follows: out of order, must be detected
+set +e; OUT16="$(oc --repo-dir "$R16" 2>&1)"; set -e
+# then
+assert_true "multi-line input dependency ref is parsed and flagged" \
+  "echo \"\$OUT16\" | grep -q 'root-hcl-inputs'"
+
+# =============================================================================
 # Summary
 # =============================================================================
 echo ""

--- a/.github/tests/test-order-check.sh
+++ b/.github/tests/test-order-check.sh
@@ -1,0 +1,582 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034  # captured *_OUT/*_RC vars are consumed inside assert_true's eval'd condition
+set -e
+
+# Test script for the Terragrunt file-ordering checker/fixer.
+# Exercises check_order.py against synthetic Terragrunt layouts and asserts
+# both the detection (check mode) and the safe reordering (--fix mode) of:
+#   * root.hcl dependency blocks + inputs grouping
+#   * stacks/*/variables.tf .HCL/.ENV sections
+#   * **/providers.tf provider weight ordering (stacks + modules)
+#   * stacks/*/outputs.tf main.tf declaration ordering
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OC="$SCRIPTS_DIR/global/scripts/languages/terraform/order-check/check_order.py"
+RUN_SH="$SCRIPTS_DIR/global/scripts/languages/terraform/order-check/run.sh"
+TEST_DIR="$(mktemp -d)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_true() {
+  local description="$1"
+  local condition="$2"
+  if eval "$condition"; then
+    echo -e "${GREEN}  PASS: $description${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}  FAIL: $description${NC}"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+cleanup() { rm -rf "$TEST_DIR"; }
+trap cleanup EXIT
+
+oc() { REPORT_PATH="$(mktemp -d)/reports" python3 "$OC" "$@"; }
+
+# Build a correct, in-standard repo at $1.
+make_clean_repo() {
+  local repo="$1"
+  mkdir -p "$repo/environments/04_app" "$repo/stacks/04_app" "$repo/modules/foo"
+
+  cat > "$repo/environments/04_app/root.hcl" << 'HCL'
+dependency "shared_common" {
+  config_path = "${get_path_to_repo_root()}//environments/01_shared/02_common"
+}
+
+dependency "kubernetes" {
+  config_path = "${get_path_to_repo_root()}//environments/03_kubernetes/x"
+}
+
+terraform {
+  source = "${get_path_to_repo_root()}//stacks/04_app"
+}
+
+inputs = {
+  tags = local.tags
+
+  registry = dependency.shared_common.outputs.registry
+
+  kube = dependency.kubernetes.outputs.kube
+
+  image = "app:1.0.0"
+}
+HCL
+
+  cat > "$repo/stacks/04_app/variables.tf" << 'HCL'
+// SET ON .HCL
+
+variable "tags" {
+  type = map(string)
+}
+
+variable "registry" {
+  type = string
+}
+
+variable "kube" {
+  type = string
+}
+
+variable "image" {
+  type = string
+}
+
+// SET ON .ENV
+
+variable "environment" {
+  type = string
+}
+HCL
+
+  cat > "$repo/stacks/04_app/providers.tf" << 'HCL'
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    helm = {
+      source = "hashicorp/helm"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "helm" {}
+
+provider "random" {}
+HCL
+
+  cat > "$repo/stacks/04_app/main.tf" << 'HCL'
+module "alpha" {
+  source = "../../modules/foo"
+}
+
+module "beta" {
+  source = "../../modules/foo"
+}
+HCL
+
+  cat > "$repo/stacks/04_app/outputs.tf" << 'HCL'
+output "a" {
+  value = module.alpha.id
+}
+
+output "b" {
+  value = module.beta.id
+}
+HCL
+
+  cat > "$repo/modules/foo/providers.tf" << 'HCL'
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+  }
+}
+HCL
+}
+
+# =============================================================================
+# Test 1: A correct repo passes cleanly and writes a JUnit report.
+# =============================================================================
+echo "TEST 1: in-standard repo passes with no errors"
+# given
+R1="$TEST_DIR/clean"
+make_clean_repo "$R1"
+# when
+OUT1="$(REPORT_PATH="$R1/build/reports" python3 "$OC" --repo-dir "$R1" 2>&1)"; RC1=$?
+# then
+assert_true "exit code 0 on clean repo" "[ $RC1 -eq 0 ]"
+assert_true "prints 'no ordering errors'" "echo \"\$OUT1\" | grep -q 'no ordering errors'"
+assert_true "JUnit report written" "[ -f '$R1/build/reports/junit-order-check.xml' ]"
+assert_true "JUnit reports zero failures" \
+  "grep -q 'testsuites name=\"order-check\" tests=\"[0-9]*\" failures=\"0\"' '$R1/build/reports/junit-order-check.xml'"
+
+# =============================================================================
+# Test 2: root.hcl dependency blocks out of order -> detected, then fixed.
+# =============================================================================
+echo "TEST 2: root.hcl dependency blocks out of order"
+# given
+R2="$TEST_DIR/deps"
+make_clean_repo "$R2"
+cat > "$R2/environments/04_app/root.hcl" << 'HCL'
+dependency "kubernetes" {
+  config_path = "${get_path_to_repo_root()}//environments/03_kubernetes/x"
+}
+
+dependency "shared_common" {
+  config_path = "${get_path_to_repo_root()}//environments/01_shared/02_common"
+}
+
+terraform {
+  source = "${get_path_to_repo_root()}//stacks/04_app"
+}
+
+inputs = {
+  registry = dependency.shared_common.outputs.registry
+  kube     = dependency.kubernetes.outputs.kube
+}
+HCL
+# when (check)
+set +e; OUT2="$(oc --repo-dir "$R2" 2>&1)"; RC2=$?; set -e
+# then
+assert_true "check fails (exit 1)" "[ $RC2 -eq 1 ]"
+assert_true "flags root-hcl-deps" "echo \"\$OUT2\" | grep -q 'root-hcl-deps'"
+# when (fix)
+oc --repo-dir "$R2" --fix >/dev/null 2>&1
+set +e; oc --repo-dir "$R2" >/dev/null 2>&1; RC2B=$?; set -e
+# then
+assert_true "re-check passes after --fix" "[ $RC2B -eq 0 ]"
+assert_true "shared_common now precedes kubernetes" \
+  "awk '/dependency \"shared_common\"/{s=NR} /dependency \"kubernetes\"/{k=NR} END{exit !(s<k)}' '$R2/environments/04_app/root.hcl'"
+
+# =============================================================================
+# Test 3: root.hcl inputs not grouped by dependency number -> detected + fixed.
+# =============================================================================
+echo "TEST 3: root.hcl inputs out of dependency-number order"
+# given
+R3="$TEST_DIR/inputs"
+make_clean_repo "$R3"
+cat > "$R3/environments/04_app/root.hcl" << 'HCL'
+dependency "shared_common" {
+  config_path = "${get_path_to_repo_root()}//environments/01_shared/02_common"
+}
+
+dependency "kubernetes" {
+  config_path = "${get_path_to_repo_root()}//environments/03_kubernetes/x"
+}
+
+terraform {
+  source = "${get_path_to_repo_root()}//stacks/04_app"
+}
+
+inputs = {
+  tags = local.tags
+
+  kube = dependency.kubernetes.outputs.kube
+
+  registry = dependency.shared_common.outputs.registry
+
+  image = "app:1.0.0"
+}
+HCL
+# when (check)
+set +e; OUT3="$(oc --repo-dir "$R3" 2>&1)"; RC3=$?; set -e
+# then
+assert_true "flags root-hcl-inputs" "echo \"\$OUT3\" | grep -q 'root-hcl-inputs'"
+# when (fix)
+oc --repo-dir "$R3" --fix >/dev/null 2>&1
+# then
+assert_true "registry(01) now precedes kube(03) in inputs" \
+  "awk '/registry = dependency/{r=NR} /kube = dependency/{k=NR} END{exit !(r<k)}' '$R3/environments/04_app/root.hcl'"
+assert_true "tags (local) stays first in inputs" \
+  "awk '/tags = local/{t=NR} /registry = dependency/{r=NR} END{exit !(t<r)}' '$R3/environments/04_app/root.hcl'"
+assert_true "image literal stays last in inputs" \
+  "awk '/kube = dependency/{k=NR} /image  *= /{i=NR} END{exit !(k<i)}' '$R3/environments/04_app/root.hcl'"
+
+# =============================================================================
+# Test 4: variables.tf .HCL out of dependency order; tags/literals unconstrained.
+# =============================================================================
+echo "TEST 4: variables.tf .HCL ordering (deps only; tags/literals free)"
+# given
+R4="$TEST_DIR/vars"
+make_clean_repo "$R4"
+cat > "$R4/stacks/04_app/variables.tf" << 'HCL'
+// SET ON .HCL
+
+variable "tags" {
+  type = map(string)
+}
+
+variable "kube" {
+  type = string
+}
+
+variable "registry" {
+  type = string
+}
+
+variable "image" {
+  type = string
+}
+
+// SET ON .ENV
+
+variable "environment" {
+  type = string
+}
+HCL
+# when (check)
+set +e; OUT4="$(oc --repo-dir "$R4" 2>&1)"; RC4=$?; set -e
+# then
+assert_true "flags variables-order" "echo \"\$OUT4\" | grep -q 'variables-order'"
+assert_true "does NOT blame 'tags' (local, unconstrained)" \
+  "! echo \"\$OUT4\" | grep -q \"'tags'\""
+# when (fix)
+oc --repo-dir "$R4" --fix >/dev/null 2>&1
+set +e; oc --repo-dir "$R4" >/dev/null 2>&1; RC4B=$?; set -e
+# then
+assert_true "re-check passes after --fix" "[ $RC4B -eq 0 ]"
+assert_true "registry(01) now precedes kube(03)" \
+  "awk '/variable \"registry\"/{r=NR} /variable \"kube\"/{k=NR} END{exit !(r<k)}' '$R4/stacks/04_app/variables.tf'"
+assert_true ".ENV section still after .HCL section" \
+  "awk '/SET ON .HCL/{h=NR} /SET ON .ENV/{e=NR} END{exit !(h<e)}' '$R4/stacks/04_app/variables.tf'"
+assert_true "environment var stays in .ENV section" \
+  "awk '/SET ON .ENV/{e=NR} /variable \"environment\"/{v=NR} END{exit !(e<v)}' '$R4/stacks/04_app/variables.tf'"
+
+# =============================================================================
+# Test 5: .ENV section before .HCL -> error.
+# =============================================================================
+echo "TEST 5: variables.tf with .ENV before .HCL"
+# given
+R5="$TEST_DIR/sections"
+make_clean_repo "$R5"
+cat > "$R5/stacks/04_app/variables.tf" << 'HCL'
+// SET ON .ENV
+
+variable "environment" {
+  type = string
+}
+
+// SET ON .HCL
+
+variable "registry" {
+  type = string
+}
+HCL
+# when
+set +e; OUT5="$(oc --repo-dir "$R5" 2>&1)"; RC5=$?; set -e
+# then
+assert_true "flags variables-sections" "echo \"\$OUT5\" | grep -q 'variables-sections'"
+assert_true "exit 1" "[ $RC5 -eq 1 ]"
+
+# =============================================================================
+# Test 6: missing section markers -> warning only (not a hard failure).
+# =============================================================================
+echo "TEST 6: variables.tf without section markers -> warning"
+# given
+R6="$TEST_DIR/nomarkers"
+make_clean_repo "$R6"
+cat > "$R6/stacks/04_app/variables.tf" << 'HCL'
+variable "registry" {
+  type = string
+}
+
+variable "kube" {
+  type = string
+}
+HCL
+# when
+set +e; OUT6="$(oc --repo-dir "$R6" 2>&1)"; RC6=$?; set -e
+# then
+assert_true "emits variables-markers warning" "echo \"\$OUT6\" | grep -q 'variables-markers'"
+assert_true "missing markers is WARNING not ERROR" "echo \"\$OUT6\" | grep -q 'WARNING'"
+assert_true "exit 0 (warning does not fail CI)" "[ $RC6 -eq 0 ]"
+
+# =============================================================================
+# Test 7: providers.tf out of weight order (stack + module) -> detected + fixed.
+# =============================================================================
+echo "TEST 7: providers.tf heaviest->lightest ordering (stacks + modules)"
+# given
+R7="$TEST_DIR/providers"
+make_clean_repo "$R7"
+cat > "$R7/stacks/04_app/providers.tf" << 'HCL'
+terraform {
+  required_providers {
+    random = {
+      source = "hashicorp/random"
+    }
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    helm = {
+      source = "hashicorp/helm"
+    }
+  }
+}
+
+provider "random" {}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "helm" {}
+HCL
+# module providers.tf out of order too
+cat > "$R7/modules/foo/providers.tf" << 'HCL'
+terraform {
+  required_providers {
+    null = {
+      source = "hashicorp/null"
+    }
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+  }
+}
+HCL
+# when (check)
+set +e; OUT7="$(oc --repo-dir "$R7" 2>&1)"; RC7=$?; set -e
+# then
+assert_true "flags providers in stack" "echo \"\$OUT7\" | grep -q 'stacks/04_app/providers.tf'"
+assert_true "flags providers in module too" "echo \"\$OUT7\" | grep -q 'modules/foo/providers.tf'"
+# when (fix)
+oc --repo-dir "$R7" --fix >/dev/null 2>&1
+set +e; oc --repo-dir "$R7" >/dev/null 2>&1; RC7B=$?; set -e
+# then
+assert_true "re-check passes after --fix" "[ $RC7B -eq 0 ]"
+assert_true "azurerm now precedes random in required_providers" \
+  "awk '/azurerm = {/{a=NR} /random = {/{r=NR} END{exit !(a<r)}' '$R7/stacks/04_app/providers.tf'"
+assert_true "azurerm provider block precedes random provider block" \
+  "awk '/provider \"azurerm\"/{a=NR} /provider \"random\"/{r=NR} END{exit !(a<r)}' '$R7/stacks/04_app/providers.tf'"
+
+# =============================================================================
+# Test 8: unknown provider -> warning; --fix pins it and sorts the rest safely.
+# =============================================================================
+echo "TEST 8: unknown provider warns and is pinned by --fix"
+# given
+R8="$TEST_DIR/unknown"
+make_clean_repo "$R8"
+cat > "$R8/stacks/04_app/providers.tf" << 'HCL'
+terraform {
+  required_providers {
+    random = {
+      source = "hashicorp/random"
+    }
+    mysteryprovider = {
+      source = "acme/mysteryprovider"
+    }
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+  }
+}
+HCL
+BEFORE_COUNT=$(grep -c ' = {' "$R8/stacks/04_app/providers.tf")
+# when
+set +e; OUT8="$(oc --repo-dir "$R8" 2>&1)"; set -e
+oc --repo-dir "$R8" --fix >/dev/null 2>&1
+AFTER_COUNT=$(grep -c ' = {' "$R8/stacks/04_app/providers.tf")
+# then
+assert_true "warns about unknown provider" \
+  "echo \"\$OUT8\" | grep -q 'not in the ranking'"
+assert_true "names mysteryprovider in the warning" \
+  "echo \"\$OUT8\" | grep -q 'mysteryprovider'"
+assert_true "no provider entry lost during --fix (content preserved)" \
+  "[ '$BEFORE_COUNT' = '$AFTER_COUNT' ]"
+assert_true "azurerm sorted before random among known providers" \
+  "awk '/azurerm = {/{a=NR} /random = {/{r=NR} END{exit !(a<r)}' '$R8/stacks/04_app/providers.tf'"
+
+# =============================================================================
+# Test 9: outputs.tf out of main*.tf declaration order -> detected + fixed.
+# =============================================================================
+echo "TEST 9: outputs.tf follows main.tf module declaration order"
+# given
+R9="$TEST_DIR/outputs"
+make_clean_repo "$R9"
+cat > "$R9/stacks/04_app/outputs.tf" << 'HCL'
+output "b" {
+  value = module.beta.id
+}
+
+output "passthrough" {
+  value = var.registry
+}
+
+output "a" {
+  value = module.alpha.id
+}
+HCL
+# when (check)
+set +e; OUT9="$(oc --repo-dir "$R9" 2>&1)"; set -e
+# then
+assert_true "flags outputs ordering" "echo \"\$OUT9\" | grep -q 'outputs'"
+# when (fix)
+oc --repo-dir "$R9" --fix >/dev/null 2>&1
+set +e; oc --repo-dir "$R9" >/dev/null 2>&1; RC9B=$?; set -e
+# then
+assert_true "re-check passes after --fix" "[ $RC9B -eq 0 ]"
+assert_true "output a (module.alpha) precedes output b (module.beta)" \
+  "awk '/output \"a\"/{a=NR} /output \"b\"/{b=NR} END{exit !(a<b)}' '$R9/stacks/04_app/outputs.tf'"
+assert_true "passthrough output preserved (not dropped)" \
+  "grep -q 'output \"passthrough\"' '$R9/stacks/04_app/outputs.tf'"
+
+# =============================================================================
+# Test 10: --fix is idempotent and preserves all blocks.
+# =============================================================================
+echo "TEST 10: --fix idempotency and block preservation"
+# given
+R10="$TEST_DIR/idem"
+make_clean_repo "$R10"
+# scramble a few files
+cat > "$R10/stacks/04_app/providers.tf" << 'HCL'
+terraform {
+  required_providers {
+    random = {
+      source = "hashicorp/random"
+    }
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    helm = {
+      source = "hashicorp/helm"
+    }
+  }
+}
+HCL
+PROV_BEFORE=$(grep -c ' = {' "$R10/stacks/04_app/providers.tf")
+# when (first fix)
+oc --repo-dir "$R10" --fix >/dev/null 2>&1
+FIRST="$(cat "$R10/stacks/04_app/providers.tf")"
+# when (second fix)
+OUT10="$(oc --repo-dir "$R10" --fix 2>&1)"
+SECOND="$(cat "$R10/stacks/04_app/providers.tf")"
+PROV_AFTER=$(grep -c ' = {' "$R10/stacks/04_app/providers.tf")
+# then
+assert_true "second --fix rewrites 0 files (idempotent)" \
+  "echo \"\$OUT10\" | grep -q 'rewrote 0 file'"
+assert_true "file content identical across two fixes" "[ \"\$FIRST\" = \"\$SECOND\" ]"
+assert_true "provider entry count preserved" "[ '$PROV_BEFORE' = '$PROV_AFTER' ]"
+
+# =============================================================================
+# Test 11: .terraform-order.json overrides ranking and ignores paths.
+# =============================================================================
+echo "TEST 11: .terraform-order.json override + ignore"
+# given -- declare a ranking where 'random' outranks 'azurerm'
+R11="$TEST_DIR/config"
+make_clean_repo "$R11"
+cat > "$R11/stacks/04_app/providers.tf" << 'HCL'
+terraform {
+  required_providers {
+    random = {
+      source = "hashicorp/random"
+    }
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+  }
+}
+HCL
+cat > "$R11/.terraform-order.json" << 'JSON'
+{
+  "provider_order": ["random", "azurerm"],
+  "ignore": ["modules/**"]
+}
+JSON
+# when -- random-before-azurerm is now in-order, so providers check passes;
+#         the (out-of-order by default) module file is ignored.
+set +e; OUT11="$(oc --repo-dir "$R11" 2>&1)"; set -e
+# then
+assert_true "custom ranking makes random-before-azurerm valid" \
+  "! echo \"\$OUT11\" | grep -q 'stacks/04_app/providers.tf'"
+assert_true "ignore glob skips modules/**" \
+  "! echo \"\$OUT11\" | grep -q 'modules/foo/providers.tf'"
+
+# =============================================================================
+# Test 12: run.sh is POSIX sh and executable.
+# =============================================================================
+echo "TEST 12: run.sh is POSIX sh, not bash"
+assert_true "run.sh uses #!/usr/bin/env sh" \
+  "head -n1 '$RUN_SH' | grep -qx '#!/usr/bin/env sh'"
+assert_true "run.sh avoids bash-only BASH_SOURCE" "! grep -q 'BASH_SOURCE' '$RUN_SH'"
+assert_true "run.sh avoids bash-only pipefail" "! grep -q 'pipefail' '$RUN_SH'"
+assert_true "run.sh is executable" "[ -x '$RUN_SH' ]"
+assert_true "check_order.py is executable" "[ -x '$OC' ]"
+
+# =============================================================================
+# Test 13: a non-Terragrunt repo (no environments/stacks) passes cleanly.
+# =============================================================================
+echo "TEST 13: empty/non-terragrunt repo exits 0"
+# given
+R13="$TEST_DIR/empty"
+mkdir -p "$R13"
+# when
+set +e; oc --repo-dir "$R13" >/dev/null 2>&1; RC13=$?; set -e
+# then
+assert_true "exit 0 on repo with nothing to check" "[ $RC13 -eq 0 ]"
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "=============================="
+echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"
+echo "=============================="
+[ "$TESTS_FAILED" -eq 0 ]

--- a/.github/workflows/terra.yaml
+++ b/.github/workflows/terra.yaml
@@ -72,6 +72,60 @@ jobs:
     continue-on-error: true
     if: "!startsWith(github.ref, 'refs/tags/')"
 
+  # Enforces the team's file-ordering standard: dependency/inputs ordering in
+  # root.hcl, the // SET ON .HCL / .ENV grouping in variables.tf, the
+  # heaviest->lightest provider order in providers.tf, and main.tf-ordered
+  # outputs.tf. Deps-free (only needs python3, preinstalled on the runner),
+  # so it does not install the terra CLI. Run `order-check/run.sh --fix`
+  # locally to auto-sort before pushing.
+  code_check-style_order_check:
+    name: 'code-check > style:order-check'
+    runs-on: 'ubuntu-latest'
+    env:
+      REPORT_PATH: 'build/reports'
+    steps:
+      - name: 'Checkout code'
+        uses: 'actions/checkout@v6'
+
+      # Pass `inputs.pipelines_ref` via `env:` (not `${{ }}` in `run:`) to
+      # avoid script injection, then resolve the ref this reusable workflow
+      # was invoked with so the shared scripts stay version-locked. Mirrors
+      # the tests jobs below.
+      - name: 'Resolve pipelines ref'
+        id: 'pipelines-ref'
+        shell: 'bash'
+        env:
+          PIPELINES_REF: ${{ inputs.pipelines_ref }}
+        run: |
+          if [ -n "${PIPELINES_REF}" ]; then
+            ref="${PIPELINES_REF}"
+          else
+            ref="${GITHUB_WORKFLOW_REF##*@}"
+          fi
+          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+
+      - name: 'Checkout pipelines repo for shared scripts'
+        uses: 'actions/checkout@v6'
+        with:
+          repository: 'rios0rios0/pipelines'
+          ref: ${{ steps.pipelines-ref.outputs.ref }}
+          path: '.pipelines'
+
+      - name: 'Check file ordering (deps/variables/providers/outputs)'
+        run: |
+          export SCRIPTS_DIR="$GITHUB_WORKSPACE/.pipelines"
+          "$SCRIPTS_DIR/global/scripts/languages/terraform/order-check/run.sh"
+        shell: 'bash'
+
+      - name: 'Publish order-check results'
+        if: 'always()'
+        uses: 'actions/upload-artifact@v7'
+        with:
+          name: 'order-check'
+          path: "${{ env.REPORT_PATH }}/junit-order-check.xml"
+          if-no-files-found: 'ignore'
+    if: "!startsWith(github.ref, 'refs/tags/')"
+
 
   # second stage
   security-sast_codeql:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Python bytecode caches produced by the stdlib helper scripts
+# (global/scripts/languages/terraform/{order-check,tftest-gen}/*.py)
+__pycache__/
+*.py[cod]
+
+# Local report output emitted by the scripts when run at a repo root
+build/reports/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added a Terragrunt file-ordering check/auto-fixer (`global/scripts/languages/terraform/order-check/`) wired into the `10-code-check` stage of the `terra` and `terraform` pipelines on all three platforms (GitHub Actions, GitLab CI, Azure DevOps). It enforces the team's ordering standard for dense infrastructure repos: `dependency` blocks and the `inputs` block in `environments/**/root.hcl` ordered ascending by dependency number; the `// SET ON .HCL` / `// SET ON .ENV` grouping (with dependency-number ordering inside `.HCL`) in `stacks/*/variables.tf`; the heaviest-to-lightest provider order in every `providers.tf` (stacks and modules); and `stacks/*/outputs.tf` ordered to follow `main*.tf` module/resource declaration order. It runs in check mode as a CI gate (emitting `build/reports/junit-order-check.xml`) and offers `order-check/run.sh --fix` to auto-sort locally. The built-in provider ranking is overridable per-repo via an optional `.terraform-order.json` (`provider_order`, `ignore`). It is stdlib-only (`python3`); the `--fix` rewriter is round-trip-safe — it verifies the parsed file reproduces the original byte-for-byte and then only permutes existing block text, so it can never drop or corrupt content
+- added `make test-order-check` and `.github/tests/test-order-check.sh` validating the order-check detection, safe auto-fix, idempotency, `.terraform-order.json` override, and JUnit output; included in the aggregate `make test`
+
 ## [4.11.0] - 2026-05-29
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,13 +9,14 @@ A CI/CD pipeline templates library providing reusable workflows for **GitHub Act
 ## Commands
 
 ```bash
-make test              # Run all validation tests (Go, Lambda, YAML merge, SonarQube, release tag, tftest-gen, docker-multi-arch)
+make test              # Run all validation tests (Go, Lambda, YAML merge, SonarQube, release tag, tftest-gen, order-check, docker-multi-arch)
 make test-go-script    # Test Go validation script only
 make test-lambda       # Test Lambda template validation only
 make test-yaml-merge   # Test YAML merge validation only
 make test-sonarqube    # Test SonarQube auto-derivation only
 make test-release-tag-idempotency  # Test release tag idempotency only
 make test-tftest-gen   # Test tftest-gen generator only
+make test-order-check  # Test the Terragrunt file-ordering checker/fixer only
 make test-docker-multi-arch  # Test 40-delivery/docker multi-arch contract only
 make build-and-push NAME=<image> TAG=<tag>  # Build and push a container image
 ```
@@ -27,7 +28,7 @@ Test scripts live in `.github/tests/`. The CI workflow (`.github/workflows/ci.ya
 ### 5-Stage Pipeline Model
 
 All platforms follow consistent numbered stages:
-1. **10 - Code Check** — Linting, formatting, basic checks (rebase verification, changelog validation)
+1. **10 - Code Check** — Linting, formatting, basic checks (rebase verification, changelog validation). The `terra`/`terraform` templates add an **order-check** job here that enforces the file-ordering standard (dependency/inputs ordering in `root.hcl`, `// SET ON .HCL` / `// SET ON .ENV` grouping in `variables.tf`, heaviest→lightest `providers.tf`, `main*.tf`-ordered `outputs.tf`); see Terraform Ordering Standard below
 2. **20 - Security** — SAST (CodeQL, Semgrep, Gitleaks, Hadolint, ShellCheck, Trivy) and SCA
 3. **30 - Tests** — Unit/integration tests, coverage. For the Azure DevOps `terraform` template, this stage runs three opt-in test tiers as parallel jobs: a plan-time smoke job (`tests/*.tftest.hcl` via `terraform test` with `mock_provider`) and an apply-time e2e job that provisions a disposable [kind](https://kind.sigs.k8s.io/) cluster and runs both `tests/e2e/*.tftest.hcl` (via `terraform test`) and `tests/terratest/*.go` (via the shared `terratest/run.sh`). All tiers are blocking so a red apply-time regression prevents `35-management` and `40-delivery` from running. The earlier `45-e2e` design was merged into `30-test` so smoke and apply-time feedback land in the same stage.
 4. **35 - Management** — SBOM generation, dependency tracking
@@ -47,6 +48,7 @@ All platforms follow consistent numbered stages:
   - `terraform/structural/` — third tier runner for `tests/structural.sh` (repo-convention assertions the consumer owns); emits `build/reports/junit-structural.xml` (empty-but-valid on skip). Runs on its own parallel job (`test:structural`) instead of through `test-all` because the shell tier is offline and deps-free and shouldn't block on the heavier tiers
   - `terraform/cyclonedx/` — CycloneDX BOM generator for Terraform projects (delegates to `trivy filesystem --format cyclonedx`)
   - `terraform/tftest-gen/` — generator that emits `tests/smoke.tftest.hcl` for single-module repos; parses `variables.tf` + `main.tf` / `providers.tf` and emits `mock_provider` blocks plus validation-rejection runs
+  - `terraform/order-check/` — checks (and with `--fix` rewrites) the file-ordering standard across `environments/**/root.hcl`, `stacks/*/{variables,providers,outputs}.tf`, and `**/providers.tf`; emits `build/reports/junit-order-check.xml`. Runs as the `order-check` / `style:order-check` job in the `10-code-check` stage. Stdlib-only `python3`; the `--fix` rewriter is round-trip-safe (parses to exact substrings, then only permutes). See Terraform Ordering Standard below
 - `global/scripts/shared/` — Shared utilities (cleanup.sh, rebase-check.sh, changelog-check.sh)
 - `global/containers/` — Docker image definitions for CI environments
 - `makefiles/` — Includable `.mk` fragments for downstream projects (`common.mk`, `golang.mk`, `python.mk`, etc.)
@@ -117,6 +119,19 @@ The Terra CLI pipeline test stage exposes two parallel jobs on every platform (A
    | `structural`  | `tests/structural.sh` (consumer-owned) | executes the script directly | `junit-structural.xml`          |
 
 The merged JUnit (`junit-terra-all.xml`) is the portable contract for `test:all` — GitLab CI's `artifacts:reports:junit` and GitHub Actions' `upload-artifact` both only take one file. `test:structural` publishes its own `junit-structural.xml` on a separate pipeline surface because it runs on its own job. When a tier has no tests (e.g., a stack-only repo without `modules/`, `tests/terratest/`, or `tests/structural.sh`), the corresponding runner emits an empty-but-valid JUnit and exits `0` so the job passes without a bespoke opt-out. `test:structural` runs on a parallel job rather than through `test-all` because the shell tier is offline and deps-free — queuing it behind the heavier Go / Terraform tiers would waste feedback time.
+
+### Terraform Ordering Standard
+
+The `order-check` job (`global/scripts/languages/terraform/order-check/`, in the `10-code-check` stage of the `terra` and `terraform` templates on all three platforms) enforces the team's file-ordering convention for dense Terragrunt monorepos (numbered dependency layers under `environments/`, root modules under `stacks/`, leaf modules under `modules/`). The rules:
+
+| File | Rule |
+|------|------|
+| `environments/**/root.hcl` | `dependency` blocks ordered ascending by the `environments/NN_` number in `config_path`; the `inputs` block groups `dependency.<name>.outputs.*` assignments by ascending dependency number (locals/`tags` first, static literals last) |
+| `stacks/*/variables.tf` | a `// SET ON .HCL` section before a `// SET ON .ENV` section; inside `.HCL`, **dependency-derived** variables ordered by the dependency number they are fed from (looked up from the paired `root.hcl` inputs). `tags`/literals/feature-flags are unconstrained |
+| `**/providers.tf` (stacks + modules) | `required_providers` entries and top-level `provider` blocks ordered heaviest→lightest by a built-in ranking (cloud → data → orchestration → network/PKI → app/utility → trivial like `null`/`random`/`local`) |
+| `stacks/*/outputs.tf` | outputs ordered to follow the declaration position of the first `module`/`resource` their value references in `main*.tf` |
+
+Check mode is a CI gate (emits `build/reports/junit-order-check.xml`); `run.sh --fix` rewrites files into order. Missing `SET ON` markers and providers absent from the ranking are **warnings** (non-fatal). The provider ranking and path ignores are overridable per-repo via an optional `.terraform-order.json` (`{"provider_order": [...], "ignore": ["glob", ...]}`). The `--fix` rewriter parses each region into exact substrings, verifies a byte-for-byte round-trip, then only permutes those substrings — so it can never drop or corrupt content (it leaves any file it cannot parse cleanly untouched and reports it). Reordering `root.hcl` inputs changes `=` alignment, so run `terra format` / `terragrunt hcl format` after `--fix`; the `.tf` reordering is already `fmt`-clean.
 
 ### Makefile Include Pattern
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TAG := latest
 ROOT := global/containers
 CONTAINER_REGISTRY = ghcr.io/rios0rios0/pipelines
 
-.PHONY: login setup-buildx build-and-push test-go-script test-lambda test-yaml-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-docker-multi-arch test
+.PHONY: login setup-buildx build-and-push test-go-script test-lambda test-yaml-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-docker-multi-arch test
 
 login:
 	docker login $(CONTAINER_REGISTRY)
@@ -42,9 +42,13 @@ test-tftest-gen:
 	@echo "Running tftest-gen generator validation..."
 	@./.github/tests/test-tftest-gen.sh
 
+test-order-check:
+	@echo "Running terraform order-check validation..."
+	@./.github/tests/test-order-check.sh
+
 test-docker-multi-arch:
 	@echo "Running 40-delivery/docker multi-arch contract validation..."
 	@./.github/tests/test-docker-multi-arch.sh
 
-test: test-go-script test-lambda test-yaml-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-docker-multi-arch
+test: test-go-script test-lambda test-yaml-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-docker-multi-arch
 	@echo "All tests completed successfully!"

--- a/README.md
+++ b/README.md
@@ -651,6 +651,44 @@ Every pipeline includes **basic checks** that run in parallel with linting durin
 | **Go Test Runner** | Comprehensive testing | `global/scripts/languages/golang/test/`          |
 | **CycloneDX**      | SBOM generation       | `global/scripts/languages/golang/cyclonedx/`     |
 
+#### Terraform / Terra Tools
+
+| Tool             | Purpose                                              | Script Location                                       |
+|------------------|------------------------------------------------------|-------------------------------------------------------|
+| **order-check**  | File-ordering checker/auto-fixer (see below)         | `global/scripts/languages/terraform/order-check/`     |
+| **tftest-gen**   | Smoke-test generator for single-module repos         | `global/scripts/languages/terraform/tftest-gen/`      |
+| **terra-test**   | `terraform test` runner over module test suites      | `global/scripts/languages/terraform/terra-test/`      |
+| **CycloneDX**    | SBOM generation for Terraform projects               | `global/scripts/languages/terraform/cyclonedx/`       |
+
+##### File-Ordering Standard (`order-check`)
+
+Dense Terragrunt monorepos keep their `*.hcl` / `*.tf` files in a consistent order. The `order-check` job runs in the **Code Check** stage of the `terra` and `terraform` pipelines (all three platforms) and enforces:
+
+- **`environments/**/root.hcl`** — `dependency` blocks and the `inputs` block ordered ascending by dependency number (the `environments/NN_` prefix).
+- **`stacks/*/variables.tf`** — a `// SET ON .HCL` section before a `// SET ON .ENV` section; dependency-derived variables ordered by dependency number inside `.HCL`.
+- **`**/providers.tf`** (stacks + modules) — `required_providers` and `provider` blocks ordered heaviest → lightest (cloud → data → orchestration → network → utility → trivial like `random`/`null`/`local`).
+- **`stacks/*/outputs.tf`** — outputs ordered to follow the declaration order of the modules/resources they reference in `main*.tf`.
+
+```bash
+# check (CI gate; writes build/reports/junit-order-check.xml)
+"$SCRIPTS_DIR/global/scripts/languages/terraform/order-check/run.sh"
+
+# auto-sort, then re-align with your formatter
+"$SCRIPTS_DIR/global/scripts/languages/terraform/order-check/run.sh" --fix
+terra format   # or: terraform fmt -recursive && terragrunt hcl format
+```
+
+The provider ranking and path exclusions can be overridden per-repo with an optional `.terraform-order.json` in the repo root:
+
+```json
+{
+  "provider_order": ["azurerm", "helm", "kubernetes", "random"],
+  "ignore": ["modules/legacy/**"]
+}
+```
+
+Only `python3` is required (no Terraform binary). The `--fix` rewriter is round-trip-safe: it only reorders existing blocks and leaves any file it cannot parse cleanly untouched.
+
 ### Usage Examples
 
 #### Run Security Scanning Locally (via Makefile)

--- a/azure-devops/terra/stages/10-code-check/terra.yaml
+++ b/azure-devops/terra/stages/10-code-check/terra.yaml
@@ -2,6 +2,8 @@ stages:
   - stage: 'code_check'
     displayName: 'code check (style/quality)'
     condition: not(startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
+    variables:
+      REPORT_PATH: 'build/reports'
     jobs:
       - template: '../../../global/stages/10-code-check/basic-checks.yaml'
 
@@ -25,3 +27,27 @@ stages:
 
           - script: tflint --chdir . --recursive
             displayName: 'Run TFLint'
+
+      # Enforces the team's file-ordering standard (dependency/inputs in
+      # root.hcl, .HCL/.ENV grouping in variables.tf, heaviest->lightest
+      # providers.tf, main.tf-ordered outputs.tf). Deps-free: only needs
+      # python3 from the agent, so it reuses scripts-repo without the terra
+      # CLI. Run `order-check/run.sh --fix` locally to auto-sort.
+      - job: 'style_order_check'
+        displayName: 'style:order-check'
+        steps:
+          - template: '../../../global/abstracts/scripts-repo.yaml'
+
+          - script: $(Scripts.Directory)/global/scripts/languages/terraform/order-check/run.sh
+            displayName: 'Check file ordering (deps/variables/providers/outputs)'
+            env:
+              REPORT_PATH: $(REPORT_PATH)
+
+          - task: 'PublishTestResults@2'
+            displayName: 'Publish order-check results'
+            condition: always()
+            inputs:
+              testResultsFormat: 'JUnit'
+              testResultsFiles: '$(REPORT_PATH)/junit-order-check.xml'
+              testRunTitle: 'order-check'
+              failTaskOnFailedTests: true

--- a/azure-devops/terraform/stages/10-code-check/terra.yaml
+++ b/azure-devops/terraform/stages/10-code-check/terra.yaml
@@ -2,6 +2,8 @@ stages:
   - stage: 'code_check'
     displayName: 'code check (style/quality)'
     condition: not(startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
+    variables:
+      REPORT_PATH: 'build/reports'
     jobs:
       - template: '../../../global/stages/10-code-check/basic-checks.yaml'
 
@@ -21,3 +23,27 @@ stages:
 
           - script: tflint --chdir . --recursive
             displayName: 'Run TFLint'
+
+      # Enforces the team's file-ordering standard (dependency/inputs in
+      # root.hcl, .HCL/.ENV grouping in variables.tf, heaviest->lightest
+      # providers.tf, main.tf-ordered outputs.tf). Deps-free: only needs
+      # python3 from the agent. Run `order-check/run.sh --fix` locally to
+      # auto-sort.
+      - job: 'style_order_check'
+        displayName: 'style:order-check'
+        steps:
+          - template: '../../../global/abstracts/scripts-repo.yaml'
+
+          - script: $(Scripts.Directory)/global/scripts/languages/terraform/order-check/run.sh
+            displayName: 'Check file ordering (deps/variables/providers/outputs)'
+            env:
+              REPORT_PATH: $(REPORT_PATH)
+
+          - task: 'PublishTestResults@2'
+            displayName: 'Publish order-check results'
+            condition: always()
+            inputs:
+              testResultsFormat: 'JUnit'
+              testResultsFiles: '$(REPORT_PATH)/junit-order-check.xml'
+              testRunTitle: 'order-check'
+              failTaskOnFailedTests: true

--- a/gitlab/terra/stages/10-code-check/terra.yaml
+++ b/gitlab/terra/stages/10-code-check/terra.yaml
@@ -1,5 +1,6 @@
 include:
   - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/terra/abstracts/terra.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/abstracts/scripts-repo.yaml'
 
 style:terra-format:
   extends: '.terra'
@@ -14,3 +15,26 @@ style:tflint:
   script:
     - wget -qO- https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | sh
     - tflint --chdir . --recursive
+
+# Enforces the team's file-ordering standard (dependency/inputs in root.hcl,
+# .HCL/.ENV grouping in variables.tf, heaviest->lightest providers.tf,
+# main.tf-ordered outputs.tf). Deps-free: a small python image + git is all
+# it needs (no terra CLI / Terraform), so it extends '.scripts-repo' rather
+# than '.terra'. Run 'order-check/run.sh --fix' locally to auto-sort.
+order:check:
+  extends: '.scripts-repo'
+  image: 'python:3-alpine'
+  stage: 'code check (style/quality)'
+  variables:
+    REPORT_PATH: 'build/reports'
+  before_script:
+    - apk add --no-cache git
+    - !reference [.scripts-repo, before_script]
+  script:
+    - "$SCRIPTS_DIR/global/scripts/languages/terraform/order-check/run.sh"
+  artifacts:
+    when: 'always'
+    paths:
+      - "${REPORT_PATH}/"
+    reports:
+      junit: "${REPORT_PATH}/junit-order-check.xml"

--- a/gitlab/terraform/stages/10-code-check/terra.yaml
+++ b/gitlab/terraform/stages/10-code-check/terra.yaml
@@ -1,5 +1,6 @@
 include:
   - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/terraform/abstracts/terra.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/abstracts/scripts-repo.yaml'
 
 style:terraform-fmt:
   extends: '.terra'
@@ -13,3 +14,26 @@ style:tflint:
   script:
     - wget -qO- https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | sh
     - tflint --chdir . --recursive
+
+# Enforces the team's file-ordering standard (dependency/inputs in root.hcl,
+# .HCL/.ENV grouping in variables.tf, heaviest->lightest providers.tf,
+# main.tf-ordered outputs.tf). Deps-free: a small python image + git is all
+# it needs (no Terraform), so it extends '.scripts-repo' rather than '.terra'.
+# Run 'order-check/run.sh --fix' locally to auto-sort.
+order:check:
+  extends: '.scripts-repo'
+  image: 'python:3-alpine'
+  stage: 'code check (style/quality)'
+  variables:
+    REPORT_PATH: 'build/reports'
+  before_script:
+    - apk add --no-cache git
+    - !reference [.scripts-repo, before_script]
+  script:
+    - "$SCRIPTS_DIR/global/scripts/languages/terraform/order-check/run.sh"
+  artifacts:
+    when: 'always'
+    paths:
+      - "${REPORT_PATH}/"
+    reports:
+      junit: "${REPORT_PATH}/junit-order-check.xml"

--- a/global/scripts/languages/terraform/order-check/check_order.py
+++ b/global/scripts/languages/terraform/order-check/check_order.py
@@ -1,0 +1,886 @@
+#!/usr/bin/env python3
+"""Check (and optionally auto-fix) the Terragrunt file-ordering standard.
+
+The team orders the dense `variables.tf` / `providers.tf` / `outputs.tf` /
+`*.hcl` files of its Terragrunt monorepos (numbered dependency layers under
+`environments/`, root modules under `stacks/`, leaf modules under `modules/`)
+by a consistent convention. This tool encodes that convention as a CI gate
+plus an idempotent formatter:
+
+    A. environments/**/root.hcl  -- `dependency` blocks ascending by the
+       `environments/NN_` number in each `config_path`.
+    B. environments/**/root.hcl  -- the `inputs = {}` block groups
+       `dependency.<name>.outputs.*` assignments by dependency, groups
+       ascending by dependency number (locals/tags first, literals last).
+    C. stacks/*/variables.tf     -- a `// SET ON .HCL` section before a
+       `// SET ON .ENV` section; within `.HCL`, variables ordered by the
+       dependency number they are fed from (derived from root.hcl inputs).
+    D. **/providers.tf           -- `required_providers` entries and the
+       top-level `provider` blocks ordered heaviest -> lightest by a
+       built-in weight ranking (overridable via `.terraform-order.json`).
+    E. stacks/*/outputs.tf       -- outputs ordered to follow the
+       declaration position of the first module/resource their value
+       references in `main*.tf`.
+
+Usage:
+    check_order.py [--fix] [--repo-dir DIR] [--config FILE] [--report DIR]
+
+Exit status is 0 when no ordering errors remain (after `--fix` rewrites, if
+requested) and 1 otherwise. The tool is stdlib-only so it runs on a bare CI
+runner with nothing but `python3` -- matching the sibling `tftest-gen`.
+
+Safety of `--fix`: every rewrite first parses the target region into a list
+of *exact* substrings and verifies the concatenation reproduces the original
+byte-for-byte (a round-trip). Only then are those substrings *permuted*. A
+region that does not round-trip is left untouched and reported, so the
+formatter can never drop, duplicate, or corrupt content.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from xml.sax.saxutils import escape as xml_escape
+
+# --------------------------------------------------------------------------- #
+# Provider weight ranking (heaviest/first -> lightest/last)
+# --------------------------------------------------------------------------- #
+# Derived from the observed convention across the reference repos and extended
+# with the common HashiCorp/community providers. Teams override per-repo via
+# `.terraform-order.json` -> {"provider_order": [...]}. Providers absent from
+# the ranking are "unknown": the checker never flags an unknown provider as
+# out of order (it has no defined weight) and the fixer refuses to reorder a
+# block containing one -- both report it so the team can rank it explicitly.
+DEFAULT_PROVIDER_ORDER: list[str] = [
+    # cloud platforms (broadest blast radius)
+    "azuread", "azurerm", "azapi", "aws", "google", "google-beta", "alicloud",
+    "oci", "ibm",
+    # data planes
+    "opensearch", "elasticsearch", "elasticstack", "postgresql", "mysql",
+    "mongodbatlas", "snowflake",
+    # cluster orchestration
+    "helm", "kubernetes", "kubectl", "docker",
+    # network / DNS / PKI
+    "tls", "cloudflare", "dns", "acme",
+    # application / utility services
+    "http-request", "vault", "onepassword", "keycloak", "external", "github",
+    "gitlab", "datadog", "pagerduty", "grafana",
+    # trivial / local-only helpers (lightest)
+    "time", "tfe", "null", "http", "random", "local", "archive", "template",
+]
+
+SET_ON_HCL = "SET ON .HCL"
+SET_ON_ENV = "SET ON .ENV"
+NO_NUMBER = 9_999  # sentinel: sorts unmapped entries to the end of their group
+
+
+# --------------------------------------------------------------------------- #
+# Findings & reporting
+# --------------------------------------------------------------------------- #
+@dataclass
+class Finding:
+    rule: str          # short rule id, e.g. "providers"
+    path: str          # repo-relative file path
+    message: str       # human-readable description
+    severity: str = "error"  # "error" fails CI; "warning" is informational
+
+
+@dataclass
+class FileResult:
+    path: str
+    findings: list[Finding] = field(default_factory=list)
+    fixed: bool = False
+
+
+def rel(repo: Path, p: Path) -> str:
+    try:
+        return str(p.relative_to(repo))
+    except ValueError:
+        return str(p)
+
+
+# All file I/O funnels through these two helpers. This is a file-formatting CLI
+# (like `terraform fmt` / `black` / `isort`): it deliberately reads and, with
+# `--fix`, rewrites the `.tf` / `.hcl` files under the directory the user points
+# it at via `--repo-dir`. SonarCloud's S2083 ("path injection") fires on every
+# read/write because the path derives from a CLI argument -- but for a tool whose
+# whole purpose is to operate on a user-chosen directory there is no
+# trusted-vs-untrusted path boundary to enforce, so the finding is a false
+# positive (the sibling `tftest-gen` shares the same pattern). The `# NOSONAR`
+# markers suppress it at these two sink lines with that rationale.
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")  # NOSONAR
+
+
+def write_text(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")  # NOSONAR
+
+
+# --------------------------------------------------------------------------- #
+# Brace/quote-aware scanning helpers (same approach as tftest-gen)
+# --------------------------------------------------------------------------- #
+def find_matching_brace(text: str, open_index: int) -> int:
+    """Return the index of the `}` matching the `{` at ``open_index``.
+
+    Respects double/single-quoted strings and ``#`` / ``//`` line comments so
+    braces inside them are ignored. Raises ``ValueError`` when unbalanced.
+    """
+    depth = 0
+    i, n = open_index, len(text)
+    in_str, quote = False, ""
+    in_line_comment = False
+    while i < n:
+        ch = text[i]
+        if in_line_comment:
+            if ch == "\n":
+                in_line_comment = False
+            i += 1
+            continue
+        if in_str:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == quote:
+                in_str = False
+            i += 1
+            continue
+        if ch in ('"', "'"):
+            in_str, quote = True, ch
+        elif ch == "#":
+            in_line_comment = True
+        elif ch == "/" and i + 1 < n and text[i + 1] == "/":
+            in_line_comment = True
+            i += 2
+            continue
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    raise ValueError("unbalanced braces")
+
+
+@dataclass
+class Block:
+    """A top-level HCL block captured as an exact substring of the file."""
+    name: str           # primary label (e.g. variable/output/provider name)
+    start: int          # offset of the keyword (column 0)
+    end: int            # offset just past the closing brace's newline
+
+
+def find_top_level_blocks(text: str, keyword: str) -> list[Block]:
+    """Find column-0 ``keyword "<name>" { ... }`` blocks (fmt-canonical files).
+
+    Used for `variable`, `output`, `provider`, and `dependency` blocks, all of
+    which `terraform fmt` / `terragrunt hcl format` anchor at column 0.
+    """
+    blocks: list[Block] = []
+    pattern = re.compile(r'(?m)^' + re.escape(keyword) + r'\s+"([^"]+)"[^\n{]*\{')
+    for m in pattern.finditer(text):
+        open_brace = text.index("{", m.start())
+        close = find_matching_brace(text, open_brace)
+        end = close + 1
+        if end < len(text) and text[end] == "\n":
+            end += 1
+        blocks.append(Block(name=m.group(1), start=m.start(), end=end))
+    return blocks
+
+
+@dataclass
+class Item:
+    """A reorderable unit: leading trivia (comments/blanks) + its block text."""
+    key: tuple          # sort key
+    text: str           # exact substring (trivia + block), preserved verbatim
+    name: str
+
+
+def build_items(text: str, region_start: int, region_end: int,
+                blocks: list[Block], key_of) -> tuple[list[Item], str] | None:
+    """Slice ``text[region_start:region_end]`` into items + a trailing suffix.
+
+    Each item owns the trivia between the previous block and itself, so blank
+    lines and attached comments travel with their block when reordered. Returns
+    ``None`` when the region does not round-trip exactly (then the caller must
+    not rewrite the file).
+    """
+    in_region = [b for b in blocks if region_start <= b.start < region_end]
+    if not in_region:
+        return None
+    items: list[Item] = []
+    cursor = region_start
+    for b in in_region:
+        chunk = text[cursor:b.end]
+        items.append(Item(key=key_of(b), text=chunk, name=b.name))
+        cursor = b.end
+    suffix = text[cursor:region_end]
+    # round-trip guarantee
+    if "".join(it.text for it in items) + suffix != text[region_start:region_end]:
+        return None
+    return items, suffix
+
+
+def reorder_region(text: str, region_start: int, region_end: int,
+                   items: list[Item], suffix: str) -> str:
+    ordered = sorted(items, key=lambda it: it.key)  # stable
+    new_region = "".join(it.text for it in ordered) + suffix
+    return text[:region_start] + new_region + text[region_end:]
+
+
+def reorder_pinned_region(text: str, region_start: int, region_end: int,
+                          blocks: list[Block], movable, key_of) -> str | None:
+    """Sort only the *movable* blocks into the slots they occupy; pin the rest.
+
+    Non-movable blocks (e.g. `tags`/literal variables, un-ranked providers)
+    keep their absolute position, while movable blocks are stable-sorted into
+    the positions movable blocks already held. Returns ``None`` when the region
+    does not round-trip exactly, so the caller leaves the file untouched.
+    """
+    in_region = [b for b in blocks if region_start <= b.start < region_end]
+    if not in_region:
+        return None
+    items: list[Item] = []
+    cursor = region_start
+    for b in in_region:
+        items.append(Item(key=key_of(b), text=text[cursor:b.end], name=b.name))
+        cursor = b.end
+    suffix = text[cursor:region_end]
+    if "".join(it.text for it in items) + suffix != text[region_start:region_end]:
+        return None
+    movable_idx = [i for i, b in enumerate(in_region) if movable(b)]
+    movable_sorted = sorted((items[i] for i in movable_idx), key=lambda it: it.key)
+    new_items = list(items)
+    for slot, it in zip(movable_idx, movable_sorted):
+        new_items[slot] = it
+    new_region = "".join(it.text for it in new_items) + suffix
+    return text[:region_start] + new_region + text[region_end:]
+
+
+def is_sorted(keys: list) -> bool:
+    return all(keys[i] <= keys[i + 1] for i in range(len(keys) - 1))
+
+
+# --------------------------------------------------------------------------- #
+# Config
+# --------------------------------------------------------------------------- #
+@dataclass
+class Config:
+    provider_weight: dict[str, int]
+    ignore: list[str]
+
+    @staticmethod
+    def load(repo: Path, explicit: Path | None) -> "Config":
+        order = DEFAULT_PROVIDER_ORDER
+        ignore: list[str] = []
+        cfg_path = explicit or (repo / ".terraform-order.json")
+        if cfg_path.is_file():
+            data = json.loads(read_text(cfg_path))
+            order = data.get("provider_order", order)
+            ignore = data.get("ignore", [])
+        return Config(provider_weight={p: i for i, p in enumerate(order)},
+                      ignore=ignore)
+
+    def is_ignored(self, repo_rel: str) -> bool:
+        from fnmatch import fnmatch
+        return any(fnmatch(repo_rel, pat) for pat in self.ignore)
+
+
+# --------------------------------------------------------------------------- #
+# root.hcl parsing (rules A & B)
+# --------------------------------------------------------------------------- #
+RE_ENV_NUM = re.compile(r"environments/(\d+)_")
+RE_SOURCE_STACK = re.compile(r'source\s*=\s*"[^"]*stacks/([^"/]+)"')
+RE_DEP_REF = re.compile(r"dependency\.([A-Za-z0-9_]+)\.outputs")
+
+
+@dataclass
+class RootHcl:
+    path: Path
+    text: str
+    dep_to_num: dict[str, int]            # dependency name -> env number
+    dep_block_order: list[tuple[str, int]]  # (name, num) in file order
+    stack_name: str | None
+    var_to_num: dict[str, int]            # input variable -> source dep number
+    inputs_ref_order: list[tuple[str, int]]  # (dep, num) of dependency refs
+
+
+def parse_root_hcl(path: Path) -> RootHcl:
+    text = read_text(path)
+    blocks = find_top_level_blocks(text, "dependency")
+    dep_to_num: dict[str, int] = {}
+    dep_block_order: list[tuple[str, int]] = []
+    for b in blocks:
+        body = text[b.start:b.end]
+        m = RE_ENV_NUM.search(body)
+        num = int(m.group(1)) if m else NO_NUMBER
+        dep_to_num[b.name] = num
+        dep_block_order.append((b.name, num))
+
+    stack_m = RE_SOURCE_STACK.search(text)
+    stack_name = stack_m.group(1) if stack_m else None
+
+    var_to_num: dict[str, int] = {}
+    inputs_ref_order: list[tuple[str, int]] = []
+    inputs_m = re.search(r"(?m)^inputs\s*=\s*\{", text)
+    if inputs_m:
+        open_brace = text.index("{", inputs_m.start())
+        body = text[open_brace + 1:find_matching_brace(text, open_brace)]
+        for line in body.splitlines():
+            am = re.match(r"\s*([A-Za-z0-9_]+)\s*=\s*(.+)", line)
+            if not am:
+                continue
+            ref = RE_DEP_REF.search(am.group(2))
+            if ref:
+                num = dep_to_num.get(ref.group(1), NO_NUMBER)
+                var_to_num[am.group(1)] = num
+                inputs_ref_order.append((ref.group(1), num))
+    return RootHcl(path, text, dep_to_num, dep_block_order, stack_name,
+                   var_to_num, inputs_ref_order)
+
+
+def check_root_hcl(rh: RootHcl, repo: Path, fix: bool) -> FileResult:
+    res = FileResult(path=rel(repo, rh.path))
+    text = rh.text
+    changed = False
+
+    # Rule A: dependency block order
+    nums = [n for _, n in rh.dep_block_order]
+    if not is_sorted(nums):
+        if fix:
+            blocks = find_top_level_blocks(text, "dependency")
+            region_start, region_end = blocks[0].start, blocks[-1].end
+            built = build_items(text, region_start, region_end, blocks,
+                                key_of=lambda b: (rh.dep_to_num.get(b.name, NO_NUMBER),))
+            if built:
+                items, suffix = built
+                text = reorder_region(text, region_start, region_end, items, suffix)
+                changed = True
+            else:
+                res.findings.append(Finding("root-hcl-deps", res.path,
+                    "dependency blocks out of order and could not be safely auto-fixed"))
+        else:
+            order_str = ", ".join(f"{d}({n:02d})" for d, n in rh.dep_block_order)
+            res.findings.append(Finding("root-hcl-deps", res.path,
+                f"dependency blocks not ascending by environments/NN number: {order_str}"))
+
+    # Rule B: inputs grouped by dependency number
+    input_nums = [n for _, n in rh.inputs_ref_order]
+    if not is_sorted(input_nums):
+        if fix:
+            text, fixed_inputs, ok = fix_inputs_block(text, rh.dep_to_num)
+            if fixed_inputs:
+                changed = True
+            elif not ok:
+                res.findings.append(Finding("root-hcl-inputs", res.path,
+                    "inputs block out of order and could not be safely auto-fixed"))
+        else:
+            seq = ", ".join(f"{d}({n:02d})" for d, n in rh.inputs_ref_order)
+            res.findings.append(Finding("root-hcl-inputs", res.path,
+                f"inputs not grouped by ascending dependency number: {seq}"))
+
+    if fix and changed:
+        write_text(rh.path, text)
+        res.fixed = True
+    return res
+
+
+def fix_inputs_block(text: str, dep_to_num: dict[str, int]) -> tuple[str, bool, bool]:
+    """Reorder dependency-referencing assignments inside the `inputs = {}` block.
+
+    Only the assignments whose value references a dependency are reordered;
+    they are stable-sorted by dependency number and placed back into the very
+    positions they occupied, so leading locals/tags and trailing literals stay
+    pinned. Returns (new_text, changed, parsed_ok).
+    """
+    inputs_m = re.search(r"(?m)^inputs\s*=\s*\{", text)
+    if not inputs_m:
+        return text, False, True
+    open_brace = text.index("{", inputs_m.start())
+    close = find_matching_brace(text, open_brace)
+    body = text[open_brace + 1:close]
+
+    # Split body into entries: each entry owns the trivia before it + a
+    # `key = <balanced value>`. Round-trip verified before any reordering.
+    entries: list[dict] = []
+    i, n = 0, len(body)
+    cursor = 0
+    line_start = True
+    while i < n:
+        m = re.compile(r"(?m)^([ \t]*)([A-Za-z0-9_]+)\s*=\s*").match(body, i) if line_start else None
+        if m:
+            value_start = m.end()
+            j = find_value_end(body, value_start)
+            entry_text = body[cursor:j]
+            ref = RE_DEP_REF.search(body[value_start:j])
+            num = dep_to_num.get(ref.group(1), NO_NUMBER) if ref else None
+            entries.append({"text": entry_text, "num": num})
+            cursor = j
+            i = j
+            line_start = j > 0 and body[j - 1] == "\n"
+            continue
+        line_start = body[i] == "\n"
+        i += 1
+    suffix = body[cursor:]
+    if "".join(e["text"] for e in entries) + suffix != body:
+        return text, False, False  # could not parse safely
+
+    dep_positions = [idx for idx, e in enumerate(entries) if e["num"] is not None]
+    dep_entries = [entries[idx] for idx in dep_positions]
+    ordered_dep = sorted(enumerate(dep_entries), key=lambda t: (t[1]["num"], t[0]))
+    new_entries = list(entries)
+    for slot, (_, entry) in zip(dep_positions, ordered_dep):
+        new_entries[slot] = entry
+    new_body = "".join(e["text"] for e in new_entries) + suffix
+    if new_body == body:
+        return text, False, True
+    new_text = text[:open_brace + 1] + new_body + text[close:]
+    return new_text, True, True
+
+
+def find_value_end(body: str, start: int) -> int:
+    """Return the offset just past a HCL value beginning at ``start``.
+
+    Handles single-line scalars and multi-line bracketed values
+    (objects/lists). Consumes the trailing newline so each entry is a clean
+    line-aligned slice.
+    """
+    depth = 0
+    i, n = start, len(body)
+    in_str, quote = False, ""
+    while i < n:
+        ch = body[i]
+        if in_str:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == quote:
+                in_str = False
+            i += 1
+            continue
+        if ch in ('"', "'"):
+            in_str, quote = True, ch
+        elif ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+        elif ch == "\n" and depth == 0:
+            return i + 1
+        i += 1
+    return n
+
+
+# --------------------------------------------------------------------------- #
+# variables.tf parsing (rule C)
+# --------------------------------------------------------------------------- #
+def check_variables_tf(path: Path, repo: Path, var_to_num: dict[str, int],
+                       fix: bool) -> FileResult:
+    res = FileResult(path=rel(repo, path))
+    text = read_text(path)
+
+    hcl_m = re.search(r"(?im)^[ \t]*(?://|#)[ \t]*" + re.escape(SET_ON_HCL), text)
+    env_m = re.search(r"(?im)^[ \t]*(?://|#)[ \t]*" + re.escape(SET_ON_ENV), text)
+
+    if not hcl_m and not env_m:
+        res.findings.append(Finding("variables-markers", res.path,
+            "missing `// SET ON .HCL` / `// SET ON .ENV` section markers",
+            severity="warning"))
+        return res
+    if hcl_m and env_m and env_m.start() < hcl_m.start():
+        res.findings.append(Finding("variables-sections", res.path,
+            "`// SET ON .ENV` section appears before `// SET ON .HCL`"))
+        return res  # ordering inside flipped sections is not meaningful
+
+    # The .HCL section spans from the .HCL marker to the .ENV marker (or EOF).
+    hcl_start = hcl_m.end() if hcl_m else 0
+    hcl_end = env_m.start() if env_m else len(text)
+    blocks = find_top_level_blocks(text, "variable")
+    hcl_blocks = [b for b in blocks if hcl_start <= b.start < hcl_end]
+
+    # Only dependency-derived variables are constrained. `tags` (a `local`-
+    # sourced input), static literals (e.g. image tags), and defaulted feature
+    # flags are not fed by a numbered dependency, so they may sit anywhere in
+    # the .HCL section -- matching the user's rule "variables from dependency 03
+    # before variables from dependency 04".
+    mapped_seq = [(b.name, var_to_num[b.name]) for b in hcl_blocks if b.name in var_to_num]
+    if is_sorted([n for _, n in mapped_seq]):
+        return res
+
+    if fix:
+        new_text = reorder_pinned_region(
+            text, hcl_blocks[0].start, hcl_blocks[-1].end, blocks,
+            movable=lambda b: b.name in var_to_num,
+            key_of=lambda b: (var_to_num.get(b.name, NO_NUMBER),))
+        if new_text is not None:
+            write_text(path, new_text)
+            res.fixed = True
+        else:
+            res.findings.append(Finding("variables-order", res.path,
+                ".HCL variables out of dependency-number order; could not be safely auto-fixed"))
+    else:
+        res.findings.append(Finding("variables-order", res.path,
+            f"`.HCL` variables not ordered by dependency number ({first_regression(mapped_seq)})"))
+    return res
+
+
+def first_regression(seq: list[tuple[str, int]], unit: str = "dep") -> str:
+    prev_label, prev_num = None, -1
+    for label, num in seq:
+        if num < prev_num:
+            return f"'{label}'({unit} {num:02d}) after {unit} {prev_num:02d} ('{prev_label}')"
+        prev_label, prev_num = label, num
+    return "out of order"
+
+
+# --------------------------------------------------------------------------- #
+# providers.tf parsing (rule D)
+# --------------------------------------------------------------------------- #
+def check_providers_tf(path: Path, repo: Path, cfg: Config, fix: bool) -> FileResult:
+    res = FileResult(path=rel(repo, path))
+    text = read_text(path)
+    weight = cfg.provider_weight
+    changed = False
+
+    # ---- required_providers entries (nested block) ----
+    rp_m = re.search(r"required_providers\s*\{", text)
+    if rp_m:
+        rp_open = text.index("{", rp_m.start())
+        rp_close = find_matching_brace(text, rp_open)
+        inner = text[rp_open + 1:rp_close]
+        entries = find_provider_entries(inner)
+        names = [e.name for e in entries]
+        unknown = [nm for nm in names if nm not in weight]
+        keys = [weight.get(nm, NO_NUMBER) for nm in names]
+        if unknown:
+            res.findings.append(Finding("providers", res.path,
+                f"providers not in the ranking (add to .terraform-order.json): {', '.join(sorted(set(unknown)))}",
+                severity="warning"))
+        if not is_sorted([weight[nm] for nm in names if nm in weight]):
+            if fix:
+                new_inner = reorder_provider_entries(inner, entries, weight)
+                if new_inner is not None and new_inner != inner:
+                    text = text[:rp_open + 1] + new_inner + text[rp_close:]
+                    changed = True
+                elif new_inner is None:
+                    res.findings.append(Finding("providers", res.path,
+                        "required_providers out of order; could not be safely auto-fixed"))
+            else:
+                res.findings.append(Finding("providers", res.path,
+                    f"required_providers not ordered heaviest->lightest: {names}"))
+
+    # ---- top-level provider blocks ----
+    pblocks = find_top_level_blocks(text, "provider")
+    if pblocks:
+        pnames = [b.name for b in pblocks]
+        if not is_sorted([weight[nm] for nm in pnames if nm in weight]):
+            if fix:
+                new_text = reorder_pinned_region(
+                    text, pblocks[0].start, pblocks[-1].end, pblocks,
+                    movable=lambda b: b.name in weight,
+                    key_of=lambda b: (weight.get(b.name, NO_NUMBER),))
+                if new_text is not None and new_text != text:
+                    text = new_text
+                    changed = True
+                elif new_text is None:
+                    res.findings.append(Finding("providers", res.path,
+                        "provider blocks out of order; could not be safely auto-fixed"))
+            else:
+                res.findings.append(Finding("providers", res.path,
+                    f"provider blocks not ordered heaviest->lightest: {pnames}"))
+
+    if fix and changed:
+        write_text(path, text)
+        res.fixed = True
+    return res
+
+
+@dataclass
+class ProviderEntry:
+    name: str
+    start: int
+    end: int
+
+
+def find_provider_entries(inner: str) -> list[ProviderEntry]:
+    """Find ``name = { ... }`` entries inside a required_providers body."""
+    out: list[ProviderEntry] = []
+    for m in re.finditer(r"(?m)^[ \t]*([A-Za-z0-9_-]+)\s*=\s*\{", inner):
+        open_brace = inner.index("{", m.start())
+        close = find_matching_brace(inner, open_brace)
+        end = close + 1
+        if end < len(inner) and inner[end] == "\n":
+            end += 1
+        out.append(ProviderEntry(name=m.group(1), start=m.start(), end=end))
+    return out
+
+
+def reorder_provider_entries(inner: str, entries: list[ProviderEntry],
+                             weight: dict[str, int]) -> str | None:
+    """Reorder required_providers entries by weight, pinning un-ranked ones.
+
+    Returns ``None`` when the body does not round-trip (then the caller leaves
+    it untouched).
+    """
+    items: list[Item] = []
+    cursor = entries[0].start
+    prefix = inner[:cursor]
+    for e in entries:
+        items.append(Item(key=(weight.get(e.name, NO_NUMBER),),
+                          text=inner[cursor:e.end], name=e.name))
+        cursor = e.end
+    suffix = inner[cursor:]
+    if prefix + "".join(it.text for it in items) + suffix != inner:
+        return None
+    movable_idx = [i for i, e in enumerate(entries) if e.name in weight]
+    movable_sorted = sorted((items[i] for i in movable_idx), key=lambda it: it.key)
+    new_items = list(items)
+    for slot, it in zip(movable_idx, movable_sorted):
+        new_items[slot] = it
+    return prefix + "".join(it.text for it in new_items) + suffix
+
+
+# --------------------------------------------------------------------------- #
+# outputs.tf parsing (rule E)
+# --------------------------------------------------------------------------- #
+RE_MODULE_DECL = re.compile(r'(?m)^module\s+"([^"]+)"\s*\{')
+RE_RESOURCE_DECL = re.compile(r'(?m)^resource\s+"([^"]+)"\s+"([^"]+)"\s*\{')
+RE_MODULE_REF = re.compile(r"\bmodule\.([A-Za-z0-9_]+)")
+RE_RESOURCE_REF = re.compile(r"\b([a-z][a-z0-9_]+)\.([A-Za-z0-9_]+)")
+_REF_KEYWORDS = {"var", "local", "module", "data", "each", "count", "self", "path", "terraform"}
+
+
+def build_main_positions(stack_dir: Path) -> dict[str, int]:
+    """Map ``module.<name>`` and ``<type>.<name>`` to a global declaration rank.
+
+    Files are ordered with `main.tf` first, then other `main*.tf`
+    alphabetically; within a file, by line. This mirrors the team convention
+    of reading outputs in the order their backing modules appear in `main*.tf`.
+    """
+    main_files = sorted(stack_dir.glob("main*.tf"),
+                        key=lambda p: (p.name != "main.tf", p.name))
+    positions: dict[str, int] = {}
+    rank = 0
+    for f in main_files:
+        body = read_text(f)
+        decls: list[tuple[int, str]] = []
+        for m in RE_MODULE_DECL.finditer(body):
+            decls.append((m.start(), f"module.{m.group(1)}"))
+        for m in RE_RESOURCE_DECL.finditer(body):
+            decls.append((m.start(), f"{m.group(1)}.{m.group(2)}"))
+        for _, token in sorted(decls):
+            if token not in positions:
+                positions[token] = rank
+                rank += 1
+    return positions
+
+
+def output_anchor(value_body: str, positions: dict[str, int]) -> int | None:
+    """Rank of the first module/resource the output value references, if any."""
+    best: int | None = None
+    best_off = None
+    mm = RE_MODULE_REF.search(value_body)
+    if mm and f"module.{mm.group(1)}" in positions:
+        best, best_off = positions[f"module.{mm.group(1)}"], mm.start()
+    for rm in RE_RESOURCE_REF.finditer(value_body):
+        rtype = rm.group(1)
+        if rtype in _REF_KEYWORDS:
+            continue
+        token = f"{rtype}.{rm.group(2)}"
+        if token in positions and (best_off is None or rm.start() < best_off):
+            best, best_off = positions[token], rm.start()
+    return best
+
+
+def check_outputs_tf(path: Path, repo: Path, stack_dir: Path, fix: bool) -> FileResult:
+    res = FileResult(path=rel(repo, path))
+    text = read_text(path)
+    blocks = find_top_level_blocks(text, "output")
+    if len(blocks) < 2:
+        return res
+    positions = build_main_positions(stack_dir)
+    if not positions:
+        return res
+
+    # Effective anchor: an output with no module/resource ref inherits the
+    # anchor of the preceding output, so passthrough (var/local) outputs ride
+    # along with the group they currently follow instead of jumping around.
+    anchors: list[int | None] = []
+    running = -1
+    raw_anchor: list[int | None] = []
+    for b in blocks:
+        a = output_anchor(text[b.start:b.end], positions)
+        raw_anchor.append(a)
+        if a is not None:
+            running = a
+        anchors.append(running)
+
+    # Check only constrains anchored-vs-anchored outputs (conservative).
+    anchored_seq = [(b.name, a) for b, a in zip(blocks, raw_anchor) if a is not None]
+    if is_sorted([a for _, a in anchored_seq]):
+        return res
+
+    if fix:
+        idx_key = {id(b): (anchors[i], i) for i, b in enumerate(blocks)}
+        built = build_items(text, blocks[0].start, blocks[-1].end, blocks,
+                            key_of=lambda b: idx_key[id(b)])
+        if built:
+            items, suffix = built
+            new_text = reorder_region(text, blocks[0].start, blocks[-1].end, items, suffix)
+            write_text(path, new_text)
+            res.fixed = True
+        else:
+            res.findings.append(Finding("outputs", res.path,
+                "outputs out of main.tf order; could not be safely auto-fixed"))
+    else:
+        res.findings.append(Finding("outputs", res.path,
+            f"outputs not ordered by main*.tf module/resource declaration order ({first_regression(anchored_seq, unit='pos')})"))
+    return res
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+# Never descend into these: provider plugin caches, the repo's own VCS dir,
+# and the `.pipelines` checkout the GitHub workflow clones the shared scripts
+# into (a sibling under the consumer workspace -- scanning it would lint the
+# pipelines repo instead of the consumer).
+EXCLUDED_DIRS = {".terraform", ".git", ".pipelines"}
+
+
+def _excluded(p: Path) -> bool:
+    return bool(EXCLUDED_DIRS.intersection(p.parts))
+
+
+def discover_root_hcls(repo: Path) -> list[Path]:
+    env_dir = repo / "environments"
+    base = env_dir if env_dir.is_dir() else repo
+    return sorted(p for p in base.rglob("root.hcl") if not _excluded(p))
+
+
+def discover_providers(repo: Path) -> list[Path]:
+    return sorted(p for p in repo.rglob("providers.tf") if not _excluded(p))
+
+
+def run(repo: Path, cfg: Config, fix: bool) -> list[FileResult]:
+    results: list[FileResult] = []
+    var_to_num_by_stack: dict[str, dict[str, int]] = {}
+
+    # Rules A & B: root.hcl files (also builds var->dep-number maps for rule C).
+    for rh_path in discover_root_hcls(repo):
+        if cfg.is_ignored(rel(repo, rh_path)):
+            continue
+        rh = parse_root_hcl(rh_path)
+        if rh.stack_name:
+            var_to_num_by_stack[rh.stack_name] = rh.var_to_num
+        results.append(check_root_hcl(rh, repo, fix))
+
+        # Rule C: the paired stack's variables.tf.
+        if rh.stack_name:
+            vf = repo / "stacks" / rh.stack_name / "variables.tf"
+            if vf.is_file() and not cfg.is_ignored(rel(repo, vf)):
+                results.append(check_variables_tf(vf, repo, rh.var_to_num, fix))
+            # Rule E: the paired stack's outputs.tf.
+            of = repo / "stacks" / rh.stack_name / "outputs.tf"
+            if of.is_file() and not cfg.is_ignored(rel(repo, of)):
+                results.append(check_outputs_tf(of, repo, of.parent, fix))
+
+    # Rule D: every providers.tf in the repo (stacks + modules + single-module).
+    for pf in discover_providers(repo):
+        if cfg.is_ignored(rel(repo, pf)):
+            continue
+        results.append(check_providers_tf(pf, repo, cfg, fix))
+
+    return [r for r in results if r.findings or r.fixed]
+
+
+# --------------------------------------------------------------------------- #
+# JUnit + human output
+# --------------------------------------------------------------------------- #
+def write_junit(results: list[FileResult], report_dir: Path) -> None:
+    report_dir.mkdir(parents=True, exist_ok=True)
+    cases = []
+    total = failures = 0
+    for r in results:
+        errors = [f for f in r.findings if f.severity == "error"]
+        warns = [f for f in r.findings if f.severity == "warning"]
+        total += 1
+        name = xml_escape(r.path)
+        if errors:
+            failures += 1
+            msg = xml_escape("; ".join(f"[{f.rule}] {f.message}" for f in errors))
+            cases.append(f'    <testcase classname="order-check" name="{name}">'
+                         f'<failure message="{msg}"/></testcase>')
+        else:
+            extra = ""
+            if warns:
+                wmsg = xml_escape("; ".join(f"[{f.rule}] {f.message}" for f in warns))
+                extra = f'<system-out>{wmsg}</system-out>'
+            cases.append(f'    <testcase classname="order-check" name="{name}">{extra}</testcase>')
+    body = "\n".join(cases)
+    xml = ('<?xml version="1.0" encoding="UTF-8"?>\n'
+           f'<testsuites name="order-check" tests="{total}" failures="{failures}">\n'
+           f'  <testsuite name="order-check" tests="{total}" failures="{failures}">\n'
+           f'{body}\n'
+           '  </testsuite>\n</testsuites>\n')
+    write_text(report_dir / "junit-order-check.xml", xml)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Check/auto-fix Terragrunt file ordering.")
+    parser.add_argument("--fix", action="store_true",
+                        help="rewrite files into the canonical order instead of only reporting")
+    parser.add_argument("--repo-dir", default=".", help="repository root to scan (default: cwd)")
+    parser.add_argument("--config", default=None, help="path to .terraform-order.json")
+    parser.add_argument("--report", default=os.environ.get("REPORT_PATH", "build/reports"),
+                        help="directory for the JUnit report")
+    args = parser.parse_args(argv)
+
+    repo = Path(args.repo_dir).resolve()
+    if not repo.is_dir():
+        print(f"ERROR: repo dir not found: {repo}", file=sys.stderr)
+        return 1
+    cfg = Config.load(repo, Path(args.config) if args.config else None)
+
+    results = run(repo, cfg, fix=args.fix)
+    report_dir = (repo / args.report) if not os.path.isabs(args.report) else Path(args.report)
+    write_junit(results, report_dir)
+
+    errors = warnings = fixed = 0
+    for r in results:
+        for f in r.findings:
+            line = f"  {f.severity.upper()}: [{f.rule}] {f.path}: {f.message}"
+            print(line, file=sys.stderr if f.severity == "error" else sys.stdout)
+            if f.severity == "error":
+                errors += 1
+            else:
+                warnings += 1
+        if r.fixed:
+            fixed += 1
+            print(f"  FIXED: {r.path}")
+
+    if args.fix:
+        print(f"\norder-check: rewrote {fixed} file(s); {errors} unfixable error(s), {warnings} warning(s).")
+        if fixed:
+            # Reordering `root.hcl` inputs changes per-group `=` alignment;
+            # the `.tf` reordering is already fmt-clean. Defer alignment to the
+            # repo's formatter (the same one the code-check stage enforces).
+            print("  Tip: run your formatter to normalize alignment "
+                  "(`terra format`, or `terraform fmt -recursive` + `terragrunt hcl format`).")
+        # After a fix run, only genuinely unfixable errors should remain.
+        return 1 if errors else 0
+    if errors:
+        print(f"\norder-check: {errors} ordering error(s) across "
+              f"{len({r.path for r in results if any(f.severity == 'error' for f in r.findings)})} file(s). "
+              f"Run with --fix to auto-sort. ({warnings} warning(s).)", file=sys.stderr)
+        return 1
+    print(f"order-check: no ordering errors. ({warnings} warning(s).)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/global/scripts/languages/terraform/order-check/check_order.py
+++ b/global/scripts/languages/terraform/order-check/check_order.py
@@ -124,40 +124,65 @@ def write_text(path: Path, content: str) -> None:
 # --------------------------------------------------------------------------- #
 # Brace/quote-aware scanning helpers (same approach as tftest-gen)
 # --------------------------------------------------------------------------- #
+def skip_noncode(text: str, i: int) -> int:
+    """If a string, comment, or heredoc starts at ``i``, return the index just
+    past it; otherwise return ``i`` unchanged.
+
+    Lets the brace/value scanners ignore `{`, `}`, and newlines that live inside
+    HCL string literals, `#`/`//` line comments, `/* ... */` block comments, and
+    `<<TAG` / `<<-TAG` heredoc bodies -- so a brace inside any of those is never
+    mistaken for a structural one (which would otherwise let `find_top_level_blocks`
+    cut a block short and corrupt a `--fix` reorder).
+    """
+    n = len(text)
+    ch = text[i]
+    if ch in ('"', "'"):
+        quote, j = ch, i + 1
+        while j < n:
+            if text[j] == "\\":
+                j += 2
+                continue
+            if text[j] == quote:
+                return j + 1
+            j += 1
+        return n
+    if ch == "#" or (ch == "/" and i + 1 < n and text[i + 1] == "/"):
+        nl = text.find("\n", i)
+        return n if nl == -1 else nl  # stop at the newline; caller handles it
+    if ch == "/" and i + 1 < n and text[i + 1] == "*":
+        end = text.find("*/", i + 2)
+        return n if end == -1 else end + 2
+    if ch == "<" and i + 1 < n and text[i + 1] == "<":
+        m = re.match(r'<<-?(["A-Za-z0-9_]+)', text[i:])
+        if m:
+            tag = m.group(1).strip('"')
+            nl = text.find("\n", i)
+            if nl == -1:
+                return n
+            term = re.compile(r"(?m)^[ \t]*" + re.escape(tag) + r"[ \t]*$")
+            tm = term.search(text, nl + 1)
+            if not tm:
+                return n
+            end_nl = text.find("\n", tm.end())
+            return n if end_nl == -1 else end_nl
+    return i
+
+
 def find_matching_brace(text: str, open_index: int) -> int:
     """Return the index of the `}` matching the `{` at ``open_index``.
 
-    Respects double/single-quoted strings and ``#`` / ``//`` line comments so
-    braces inside them are ignored. Raises ``ValueError`` when unbalanced.
+    Braces inside strings, line/block comments, and heredocs are ignored via
+    ``skip_noncode``. Raises ``ValueError`` when unbalanced.
     """
     depth = 0
     i, n = open_index, len(text)
-    in_str, quote = False, ""
-    in_line_comment = False
     while i < n:
+        j = skip_noncode(text, i)
+        if j != i:
+            i = j
+            continue
         ch = text[i]
-        if in_line_comment:
-            if ch == "\n":
-                in_line_comment = False
-            i += 1
-            continue
-        if in_str:
-            if ch == "\\":
-                i += 2
-                continue
-            if ch == quote:
-                in_str = False
-            i += 1
-            continue
-        if ch in ('"', "'"):
-            in_str, quote = True, ch
-        elif ch == "#":
-            in_line_comment = True
-        elif ch == "/" and i + 1 < n and text[i + 1] == "/":
-            in_line_comment = True
-            i += 2
-            continue
-        elif ch == "{":
+        if ch == "{":
             depth += 1
         elif ch == "}":
             depth -= 1
@@ -331,14 +356,14 @@ def parse_root_hcl(path: Path) -> RootHcl:
     if inputs_m:
         open_brace = text.index("{", inputs_m.start())
         body = text[open_brace + 1:find_matching_brace(text, open_brace)]
-        for line in body.splitlines():
-            am = re.match(r"\s*([A-Za-z0-9_]+)\s*=\s*(.+)", line)
-            if not am:
-                continue
-            ref = RE_DEP_REF.search(am.group(2))
+        # Same balanced parser the fixer uses, so a dependency reference on a
+        # later line of a multi-line value is captured by the check too.
+        entries, _ = split_inputs_entries(body)
+        for entry in entries:
+            ref = RE_DEP_REF.search(entry["value"])
             if ref:
                 num = dep_to_num.get(ref.group(1), NO_NUMBER)
-                var_to_num[am.group(1)] = num
+                var_to_num[entry["key"]] = num
                 inputs_ref_order.append((ref.group(1), num))
     return RootHcl(path, text, dep_to_num, dep_block_order, stack_name,
                    var_to_num, inputs_ref_order)
@@ -405,30 +430,13 @@ def fix_inputs_block(text: str, dep_to_num: dict[str, int]) -> tuple[str, bool, 
     close = find_matching_brace(text, open_brace)
     body = text[open_brace + 1:close]
 
-    # Split body into entries: each entry owns the trivia before it + a
-    # `key = <balanced value>`. Round-trip verified before any reordering.
-    entries: list[dict] = []
-    i, n = 0, len(body)
-    cursor = 0
-    line_start = True
-    while i < n:
-        m = re.compile(r"(?m)^([ \t]*)([A-Za-z0-9_]+)\s*=\s*").match(body, i) if line_start else None
-        if m:
-            value_start = m.end()
-            j = find_value_end(body, value_start)
-            entry_text = body[cursor:j]
-            ref = RE_DEP_REF.search(body[value_start:j])
-            num = dep_to_num.get(ref.group(1), NO_NUMBER) if ref else None
-            entries.append({"text": entry_text, "num": num})
-            cursor = j
-            i = j
-            line_start = j > 0 and body[j - 1] == "\n"
-            continue
-        line_start = body[i] == "\n"
-        i += 1
-    suffix = body[cursor:]
+    # Same balanced parser the check uses; round-trip verified before reordering.
+    entries, suffix = split_inputs_entries(body)
     if "".join(e["text"] for e in entries) + suffix != body:
         return text, False, False  # could not parse safely
+    for e in entries:
+        ref = RE_DEP_REF.search(e["value"])
+        e["num"] = dep_to_num.get(ref.group(1), NO_NUMBER) if ref else None
 
     dep_positions = [idx for idx, e in enumerate(entries) if e["num"] is not None]
     dep_entries = [entries[idx] for idx in dep_positions]
@@ -446,26 +454,20 @@ def fix_inputs_block(text: str, dep_to_num: dict[str, int]) -> tuple[str, bool, 
 def find_value_end(body: str, start: int) -> int:
     """Return the offset just past a HCL value beginning at ``start``.
 
-    Handles single-line scalars and multi-line bracketed values
-    (objects/lists). Consumes the trailing newline so each entry is a clean
-    line-aligned slice.
+    Handles single-line scalars, multi-line bracketed values (objects/lists),
+    and heredocs; strings/comments are skipped via ``skip_noncode`` so a `)`,
+    `]`, `}`, or newline inside them does not end the value early. Consumes the
+    trailing newline so each entry is a clean line-aligned slice.
     """
     depth = 0
     i, n = start, len(body)
-    in_str, quote = False, ""
     while i < n:
-        ch = body[i]
-        if in_str:
-            if ch == "\\":
-                i += 2
-                continue
-            if ch == quote:
-                in_str = False
-            i += 1
+        j = skip_noncode(body, i)
+        if j != i:
+            i = j
             continue
-        if ch in ('"', "'"):
-            in_str, quote = True, ch
-        elif ch in "([{":
+        ch = body[i]
+        if ch in "([{":
             depth += 1
         elif ch in ")]}":
             depth -= 1
@@ -473,6 +475,35 @@ def find_value_end(body: str, start: int) -> int:
             return i + 1
         i += 1
     return n
+
+
+def split_inputs_entries(body: str) -> tuple[list[dict], str]:
+    """Split a ``{ ... }`` map body (e.g. terragrunt `inputs`) into entries.
+
+    Each entry is ``{'text': <exact slice incl. leading trivia>, 'key': str,
+    'value': str}``, parsed with balanced (multi-line aware) value scanning so a
+    `dependency.<name>.outputs` reference anywhere in a multi-line object/list
+    value is captured -- not just on the assignment's first line. Returns
+    ``(entries, trailing_suffix)``; concatenating every ``entry['text']`` plus
+    the suffix reproduces ``body`` exactly (used as a round-trip guard).
+    """
+    entries: list[dict] = []
+    i, n, cursor = 0, len(body), 0
+    line_start = True
+    key_re = re.compile(r"(?m)^[ \t]*([A-Za-z0-9_]+)\s*=\s*")
+    while i < n:
+        m = key_re.match(body, i) if line_start else None
+        if m:
+            ve = find_value_end(body, m.end())
+            entries.append({"text": body[cursor:ve], "key": m.group(1),
+                            "value": body[m.end():ve]})
+            cursor = ve
+            i = ve
+            line_start = ve > 0 and body[ve - 1] == "\n"
+            continue
+        line_start = body[i] == "\n"
+        i += 1
+    return entries, body[cursor:]
 
 
 # --------------------------------------------------------------------------- #
@@ -766,11 +797,18 @@ def discover_providers(repo: Path) -> list[Path]:
     return sorted(p for p in repo.rglob("providers.tf") if not _excluded(p))
 
 
+def discover_stack_dirs(repo: Path) -> list[Path]:
+    stacks = repo / "stacks"
+    if not stacks.is_dir():
+        return []
+    return sorted(d for d in stacks.iterdir() if d.is_dir() and not _excluded(d))
+
+
 def run(repo: Path, cfg: Config, fix: bool) -> list[FileResult]:
     results: list[FileResult] = []
     var_to_num_by_stack: dict[str, dict[str, int]] = {}
 
-    # Rules A & B: root.hcl files (also builds var->dep-number maps for rule C).
+    # Rules A & B: root.hcl files (also build var->dep-number maps for rule C).
     for rh_path in discover_root_hcls(repo):
         if cfg.is_ignored(rel(repo, rh_path)):
             continue
@@ -779,15 +817,20 @@ def run(repo: Path, cfg: Config, fix: bool) -> list[FileResult]:
             var_to_num_by_stack[rh.stack_name] = rh.var_to_num
         results.append(check_root_hcl(rh, repo, fix))
 
-        # Rule C: the paired stack's variables.tf.
-        if rh.stack_name:
-            vf = repo / "stacks" / rh.stack_name / "variables.tf"
-            if vf.is_file() and not cfg.is_ignored(rel(repo, vf)):
-                results.append(check_variables_tf(vf, repo, rh.var_to_num, fix))
-            # Rule E: the paired stack's outputs.tf.
-            of = repo / "stacks" / rh.stack_name / "outputs.tf"
-            if of.is_file() and not cfg.is_ignored(rel(repo, of)):
-                results.append(check_outputs_tf(of, repo, of.parent, fix))
+    # Rules C & E: discover stack dirs directly so a stack that is newly added,
+    # currently unreferenced, or wired via a `source` syntax the regex misses is
+    # still checked. The `.HCL`/`.ENV` marker check and the outputs ordering
+    # apply to every stack; the dependency-number variable ordering only kicks
+    # in when a root.hcl mapping was found for that stack (empty map -> no
+    # ordering constraint, just the marker check).
+    for stack_dir in discover_stack_dirs(repo):
+        var_to_num = var_to_num_by_stack.get(stack_dir.name, {})
+        vf = stack_dir / "variables.tf"
+        if vf.is_file() and not cfg.is_ignored(rel(repo, vf)):
+            results.append(check_variables_tf(vf, repo, var_to_num, fix))
+        of = stack_dir / "outputs.tf"
+        if of.is_file() and not cfg.is_ignored(rel(repo, of)):
+            results.append(check_outputs_tf(of, repo, stack_dir, fix))
 
     # Rule D: every providers.tf in the repo (stacks + modules + single-module).
     for pf in discover_providers(repo):

--- a/global/scripts/languages/terraform/order-check/run.sh
+++ b/global/scripts/languages/terraform/order-check/run.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+# Check (or auto-fix) the Terragrunt file-ordering standard for a repo.
+#
+# Usage:
+#   run.sh                       # check the current repo; fail CI on drift
+#   run.sh --fix                 # rewrite files into the canonical order
+#   run.sh --repo-dir /path      # target a specific repo root
+#   run.sh --config FILE         # use a specific .terraform-order.json
+#
+# Enforces (see check_order.py for the full contract):
+#   * environments/**/root.hcl  -- dependency blocks + inputs grouped by
+#                                  ascending dependency number
+#   * stacks/*/variables.tf      -- `// SET ON .HCL` before `// SET ON .ENV`,
+#                                  .HCL vars ordered by dependency number
+#   * **/providers.tf            -- providers ordered heaviest -> lightest
+#   * stacks/*/outputs.tf        -- outputs ordered by main*.tf declaration order
+#
+# Emits build/reports/junit-order-check.xml (override the directory via
+# REPORT_PATH) so CI providers render results in their Tests tab. Stdlib-only:
+# the only runtime dependency is python3, matching the sibling tftest-gen.
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+PY="${SCRIPT_DIR}/check_order.py"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "ERROR: python3 is required on PATH" >&2
+  exit 1
+fi
+
+exec python3 "$PY" "$@"


### PR DESCRIPTION
## Summary

Adds a **Terragrunt file-ordering check/auto-fixer** that enforces the team's ordering standard for dense infrastructure repos. It runs as a new `order-check` job in the **`10-code-check`** stage of the `terra` and `terraform` pipelines on **all three platforms** (GitHub Actions, GitLab CI, Azure DevOps), and ships a `--fix` mode that auto-sorts files.

Motivated by repos where `variables.tf` / `providers.tf` / `outputs.tf` / `*.hcl` drift out of order as people add entries. There was previously **no ordering enforcement anywhere**.

## The standard it enforces

| File | Rule |
|------|------|
| `environments/**/root.hcl` | `dependency` blocks + the `inputs` block ordered **ascending by dependency number** (the `environments/NN_` prefix); locals/`tags` first, literals last |
| `stacks/*/variables.tf` | `// SET ON .HCL` section before `// SET ON .ENV`; **dependency-derived** variables ordered by dependency number inside `.HCL` (`tags`/literals/flags unconstrained) |
| `**/providers.tf` (stacks + modules) | `required_providers` + `provider` blocks ordered **heaviest → lightest** (cloud → data → orchestration → network → utility → trivial like `random`/`null`/`local`) |
| `stacks/*/outputs.tf` | outputs ordered to follow the **`main*.tf` module/resource declaration order** |

## Design highlights

- **Stdlib-only `python3`** (no Terraform binary), matching the sibling `tftest-gen`.
- **Round-trip-safe `--fix`**: each region is parsed into *exact substrings*, verified to reproduce the original byte-for-byte, then only **permuted** — so the rewriter can never drop, duplicate, or corrupt content. Any file it can't parse cleanly is left untouched and reported.
- **Configurable**: the built-in provider ranking and path ignores are overridable per-repo via an optional `.terraform-order.json` (`provider_order`, `ignore`).
- **Non-fatal warnings** for missing `SET ON` markers and un-ranked providers (don't fail CI).
- Emits `build/reports/junit-order-check.xml`.

## Validation

- New `make test-order-check` (`.github/tests/test-order-check.sh`, **47 assertions**, in the `make test` aggregate): detection per rule, safe auto-fix, **idempotency**, content preservation, `.terraform-order.json` override, JUnit output, POSIX-`sh` `run.sh`.
- Exercised end-to-end against a copy of a real Terragrunt monorepo: `--fix` reordered every flagged file, the re-check came back **clean**, block-name signatures were identical before/after (0 loss), and `terraform fmt` reported **0 syntax errors / 0 reformat needed** on the `.tf` output.
- ShellCheck clean; all modified pipeline YAMLs validate with the CI loader.

## Rollout note

This is a **blocking** code-check gate (consistent with `style:terra-format`). Existing consumer repos with drift will fail the stage until baselined — run once per repo:

```bash
"$SCRIPTS_DIR/global/scripts/languages/terraform/order-check/run.sh" --fix
terra format   # re-align root.hcl inputs (`=` alignment); the .tf output is already fmt-clean
```

If you'd prefer a soft launch, the GitHub job can be made `continue-on-error: true` (like `style:tflint`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
