### PR TITLE
fix(sca): fixed composer-audit failing for zero-package PHP projects

### DIFF
--- a/.github/workflows/composer.yaml
+++ b/.github/workflows/composer.yaml
@@ -115,7 +115,14 @@ jobs:
           php-version: '8.3'
           tools: 'composer'
 
-      - run: composer audit
+      - run: |
+          composer install --no-interaction --prefer-dist
+          PACKAGES=$(composer show --format=json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('installed', [])))" 2>/dev/null || echo '0')
+          if [ "${PACKAGES}" -gt 0 ]; then
+            composer audit
+          else
+            echo 'No packages to audit.'
+          fi
         shell: 'bash'
     needs: [ 'code_check-style_php_lint', 'code_check-quality_phpmd' ]
     continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed `sca:composer-audit` GitHub Actions job in `composer.yaml` always exiting with code `1` for PHP projects that have no `require` packages (only platform constraints like `php: >=7.2`). The step previously ran bare `composer audit` without a prior `composer install`, which fails with `No installed packages found` even after install when the lock file has zero packages. The step now installs first and skips the audit when zero packages are present, printing `No packages to audit.` to make the intent explicit; projects with real package dependencies continue to run the full `composer audit` and will still fail on any advisory
+
 ## [4.12.0] - 2026-06-03
 
 ### Added


### PR DESCRIPTION
## Summary

- The `sca:composer-audit` step in `composer.yaml` runs bare `composer audit` with no prior `composer install`, and fails with exit code 1 for PHP projects that declare zero `require` packages (only platform constraints like `php: >=7.2`)
- The error message is `No installed packages found. Please run "composer install" before running "audit" or pass "--locked" to audit the lock file.` — even after `composer install`, Composer exits 1 when the installed package count is zero
- Fix: the step now runs `composer install` first, then conditionally runs `composer audit` only when at least one package is installed; zero-package projects print `No packages to audit.` and exit 0

## Test plan

- [ ] PHP project with zero `require` packages (e.g., `usocial-network`): `sca:composer-audit` now passes
- [ ] PHP project with real dependencies: `composer audit` still runs and fails on any advisory
- [ ] PHP project with a vulnerable dependency: `composer audit` still reports it and fails the job

🤖 Generated with [Claude Code](https://claude.com/claude-code)