### PR TITLE
fix(golang): set GOTOOLCHAIN=auto so SAM builds honor consumer go.mod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- bumped the `golang.1.26-awscli` container floor and the GitLab `golang` abstract image from `1.26.3` to `1.26.4`, aligning them with the `GoTool@0` version already used by the Go code-check/test stages. With `GOTOOLCHAIN=auto` now in place this floor is no longer load-bearing for build correctness; it only provides a current launcher and a sane baseline for offline cold-starts
+
+### Fixed
+
+- fixed the Go Lambda SAM delivery/deployment stages breaking whenever a consumer bumps its `go.mod` `go` directive for a security patch (e.g. `go 1.26.4` against the `golang:1.26-awscli` container's baked-in `1.26.3`), failing with `go.mod requires go >= 1.26.4 (running go 1.26.3; GOTOOLCHAIN=local)`. The `40-delivery/lambda.yaml` and `50-deployment/lambda.yaml` jobs (and the GitLab `golang` abstract) now set `GOTOOLCHAIN=auto`, so `aws-lambda-builders` (which inherits the job env and only overrides `GOOS`/`GOARCH`) lets `go build` transparently fetch the exact toolchain each consumer's `go.mod` declares. The pipeline no longer has to chase Go patch bumps in lockstep with consuming repositories
+
 ## [4.12.1] - 2026-06-09
 
 ### Changed

--- a/azure-devops/golang/stages/40-delivery/lambda.yaml
+++ b/azure-devops/golang/stages/40-delivery/lambda.yaml
@@ -85,7 +85,7 @@ stages:
                 set -e
 
                 echo "Building with AWS SAM..."
-export GOTOOLCHAIN="${GOTOOLCHAIN:-auto}"
+                export GOTOOLCHAIN="${GOTOOLCHAIN:-auto}"
                 sam build
 
                 echo "Packaging with AWS SAM..."
@@ -116,7 +116,7 @@ export GOTOOLCHAIN="${GOTOOLCHAIN:-auto}"
               fi
 
               echo "Building with AWS SAM..."
-export GOTOOLCHAIN="${GOTOOLCHAIN:-auto}"
+              export GOTOOLCHAIN="${GOTOOLCHAIN:-auto}"
               sam build
 
               echo "Packaging with AWS SAM..."

--- a/azure-devops/golang/stages/40-delivery/lambda.yaml
+++ b/azure-devops/golang/stages/40-delivery/lambda.yaml
@@ -85,7 +85,7 @@ stages:
                 set -e
 
                 echo "Building with AWS SAM..."
-                export GOTOOLCHAIN=auto
+export GOTOOLCHAIN="${GOTOOLCHAIN:-auto}"
                 sam build
 
                 echo "Packaging with AWS SAM..."

--- a/azure-devops/golang/stages/40-delivery/lambda.yaml
+++ b/azure-devops/golang/stages/40-delivery/lambda.yaml
@@ -36,6 +36,11 @@ stages:
           DEPLOY_STRATEGY: ${{ parameters.DEPLOY_STRATEGY }}
           GOPATH: "$(Pipeline.Workspace)/.go"
           LAMBDA_ARTIFACT_DIR: "$(Build.SourcesDirectory)/lambda-artifact"
+          # Let Go download the toolchain required by the consumer's go.mod.
+          # SAM's GoModulesBuilder inherits this env and passes it to `go build`,
+          # so a go.mod version bump (e.g. a security patch) never breaks the
+          # build against the container's baked-in Go.
+          GOTOOLCHAIN: 'auto'
         steps:
           - template: '../../../global/abstracts/scripts-repo.yaml'
 
@@ -80,6 +85,7 @@ stages:
                 set -e
 
                 echo "Building with AWS SAM..."
+                export GOTOOLCHAIN=auto
                 sam build
 
                 echo "Packaging with AWS SAM..."
@@ -110,6 +116,7 @@ stages:
               fi
 
               echo "Building with AWS SAM..."
+              export GOTOOLCHAIN=auto
               sam build
 
               echo "Packaging with AWS SAM..."

--- a/azure-devops/golang/stages/40-delivery/lambda.yaml
+++ b/azure-devops/golang/stages/40-delivery/lambda.yaml
@@ -116,7 +116,7 @@ export GOTOOLCHAIN="${GOTOOLCHAIN:-auto}"
               fi
 
               echo "Building with AWS SAM..."
-              export GOTOOLCHAIN=auto
+export GOTOOLCHAIN="${GOTOOLCHAIN:-auto}"
               sam build
 
               echo "Packaging with AWS SAM..."

--- a/azure-devops/golang/stages/50-deployment/lambda.yaml
+++ b/azure-devops/golang/stages/50-deployment/lambda.yaml
@@ -37,6 +37,9 @@ stages:
         container: 'ghcr.io/rios0rios0/pipelines/golang:1.26-awscli'
         variables:
           DEPLOY_STRATEGY: ${{ parameters.DEPLOY_STRATEGY }}
+          # Keep toolchain resolution consistent with the delivery stage so any
+          # Go invocation during deploy honors the consumer's go.mod version.
+          GOTOOLCHAIN: 'auto'
         steps:
           - task: 'DownloadPipelineArtifact@2'
             inputs:

--- a/gitlab/golang/abstracts/go.yaml
+++ b/gitlab/golang/abstracts/go.yaml
@@ -1,10 +1,11 @@
 .go:
-  image: 'golang:1.26.3-bookworm'
+  image: 'golang:1.26.4-bookworm'
   cache: # relative to the project directory ($CI_PROJECT_DIR)
     key: "$CI_JOB_NAME"
     paths:
       - '.go'
   before_script:
+    - export GOTOOLCHAIN=auto # let Go fetch the toolchain required by the project's go.mod
     - export GOPATH="$(pwd)/.go" # the GOPATH must be absolute
     - export PATH="$PATH:$GOPATH/bin" # this is a workaround to detect the new GOPATH
   rules:

--- a/global/containers/golang.1.26-awscli/Dockerfile
+++ b/global/containers/golang.1.26-awscli/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3
+FROM golang:1.26.4
 
 RUN apt-get update && apt-get install --yes --no-install-recommends unzip \
 	&& apt-get clean autoclean \


### PR DESCRIPTION
- `sam build` runs inside the `golang:1.26-awscli` container with `GOTOOLCHAIN=local`, so Go refuses to fetch a newer toolchain and the build fails whenever a consumer's `go.mod` requires a higher patch than the baked-in Go
- set `GOTOOLCHAIN=auto` so Go resolves the toolchain from each consumer's `go.mod`, removing the lockstep between the pinned container Go and consumer versions
- bump the container and GitLab image floors to 1.26.4 to match the existing `GoTool@0` version

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
