### PR TITLE
fix(hadolint): hardened install against transient GitHub API failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed `global/scripts/tools/hadolint/run.sh` failing the `sast:hadolint` job with a cryptic `hadolint: not found` (exit `127`) whenever GitHub's `releases/latest` API was rate-limited or returned a transient `5xx` (e.g. `504`). The script resolves the version to download by parsing `tag_name` from that API, but the `curl | grep | sed` pipeline reports only `sed`'s exit status, so a failed `curl` silently produced an empty `HADOLINT_VERSION`; the empty value then flowed into a malformed download URL (`.../download//hadolint-Linux-x86_64`) that `404`s, the binary was never written, and the failure only surfaced at the subsequent lint call. The install path is now hardened, mirroring the Trivy install-retry idiom in `global/scripts/tools/trivy/run.sh`: the latest-version lookup and the binary download are each wrapped in a bounded linear backoff (3 attempts, `attempt × 5s`); the resolved version is validated non-empty and falls back to a pinned `HADOLINT_PINNED_VERSION` (default `v2.14.0`, env-overridable) otherwise; the downloaded binary is verified to actually run (`hadolint --version`) before linting, with the pinned version tried as a last resort if the resolved one will not execute; and an unrecoverable install now fails fast with an actionable error instead of falling through to exit `127`. The script stays POSIX-`sh` compatible and ShellCheck-clean
+
 ## [4.12.2] - 2026-06-18
 
 ### Changed

--- a/global/scripts/tools/hadolint/run.sh
+++ b/global/scripts/tools/hadolint/run.sh
@@ -39,24 +39,120 @@ EOF
   exit 0
 fi
 
-# Install Hadolint if not already available
+# Install Hadolint if not already available.
+#
+# Hadolint ships a self-contained binary on every GitHub release, so it is
+# downloaded directly rather than pulled as a Docker image -- Docker Hub's
+# anonymous pull rate limit would otherwise risk a `toomanyrequests` failure on
+# a cache-cold runner. The version is resolved from GitHub's `releases/latest`
+# API for convenience, but that endpoint is rate-limited (60 req/hour per IP
+# unauthenticated) and intermittently returns HTTP 5xx/403. Under POSIX `sh`
+# (no `set -e`) an empty version used to flow straight into a malformed URL
+# (".../download//hadolint-Linux-x86_64"), which 404s; the binary was never
+# written and the failure surfaced only as a cryptic `hadolint: not found`
+# (exit 127) at the lint call below. The install is now hardened: the lookup
+# and the download are retried with backoff, the resolved version is validated
+# non-empty (falling back to a pinned version otherwise), and the binary is
+# verified to actually run before linting. Mirrors the Trivy install-retry
+# idiom in `global/scripts/tools/trivy/run.sh`.
 if ! command -v hadolint > /dev/null 2>&1; then
   echo "Downloading Hadolint..."
-  HADOLINT_VERSION=$(curl -fsSL https://api.github.com/repos/hadolint/hadolint/releases/latest | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+
+  # Known-good fallback used whenever the latest-version lookup cannot be
+  # resolved. Overridable so an operator can pin a specific release without
+  # editing this script when the API is unavailable.
+  HADOLINT_PINNED_VERSION="${HADOLINT_PINNED_VERSION:-v2.14.0}"
 
   ARCH=$(uname -m)
   case "$ARCH" in
     x86_64)        HADOLINT_ARCH="x86_64" ;;
     aarch64|arm64) HADOLINT_ARCH="arm64" ;;
     *)
-      echo "Unsupported architecture: $ARCH" >&2
+      echo "ERROR: unsupported architecture for Hadolint: $ARCH" >&2
       exit 1
       ;;
   esac
 
-  curl -fsSL "https://github.com/hadolint/hadolint/releases/download/$HADOLINT_VERSION/hadolint-Linux-$HADOLINT_ARCH" -o /tmp/hadolint
-  chmod +x /tmp/hadolint
+  # Run a command up to 3 times with linear backoff (5s, then 10s) so a
+  # transient 5xx/network blip is ridden out rather than being fatal. Progress
+  # goes to stderr to keep stdout clean for command substitution.
+  hadolint_retry() {
+    _attempt=1
+    _max=3
+    while :; do
+      if "$@"; then
+        return 0
+      fi
+      if [ "$_attempt" -ge "$_max" ]; then
+        return 1
+      fi
+      _wait=$((_attempt * 5))
+      echo "  attempt $_attempt/$_max failed; retrying in ${_wait}s..." >&2
+      sleep "$_wait"
+      _attempt=$((_attempt + 1))
+    done
+  }
+
+  # Resolve the latest published version. curl's exit status is checked
+  # explicitly: a `curl | grep | sed` pipeline reports only sed's status, so a
+  # failed curl (e.g. HTTP 504) would otherwise masquerade as success with
+  # empty output. Returns non-zero -- engaging the retry, then the pinned
+  # fallback -- when curl fails or no tag can be parsed.
+  hadolint_latest_version() {
+    _body=$(curl -fsSL https://api.github.com/repos/hadolint/hadolint/releases/latest) || return 1
+    _tag=$(printf '%s\n' "$_body" | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+    [ -n "$_tag" ] || return 1
+    printf '%s\n' "$_tag"
+  }
+
+  if HADOLINT_VERSION=$(hadolint_retry hadolint_latest_version) && [ -n "$HADOLINT_VERSION" ]; then
+    echo "Resolved latest Hadolint version: $HADOLINT_VERSION"
+  else
+    HADOLINT_VERSION="$HADOLINT_PINNED_VERSION"
+    echo "WARN: could not resolve the latest Hadolint version (GitHub rate limit, outage, or network failure); falling back to pinned $HADOLINT_VERSION." >&2
+  fi
+
+  # Ordered candidate list: the resolved version first, then the pinned
+  # fallback as a last resort (skipped when identical). `set --` keeps the
+  # iteration ShellCheck-clean without unquoted word-splitting.
+  set -- "$HADOLINT_VERSION"
+  if [ "$HADOLINT_VERSION" != "$HADOLINT_PINNED_VERSION" ]; then
+    set -- "$@" "$HADOLINT_PINNED_VERSION"
+  fi
+
+  hadolint_installed=false
+  for hadolint_candidate in "$@"; do
+    echo "Installing Hadolint $hadolint_candidate (linux/$HADOLINT_ARCH)..."
+    # Download with retries, make executable, then prove the binary actually
+    # runs. Only a binary that answers `--version` is accepted; a 0-byte file
+    # left by a 404 or a corrupt download fails here and the next candidate is
+    # tried.
+    if hadolint_retry curl -fsSL "https://github.com/hadolint/hadolint/releases/download/$hadolint_candidate/hadolint-Linux-$HADOLINT_ARCH" -o /tmp/hadolint \
+      && chmod +x /tmp/hadolint \
+      && /tmp/hadolint --version > /dev/null 2>&1; then
+      hadolint_installed=true
+      break
+    fi
+    echo "WARN: Hadolint $hadolint_candidate did not produce a runnable binary; trying the next source..." >&2
+    rm -f /tmp/hadolint
+  done
+
+  if [ "$hadolint_installed" != true ]; then
+    echo "ERROR: Hadolint could not be installed after trying the latest and pinned ($HADOLINT_PINNED_VERSION) versions." >&2
+    echo "Likely a GitHub API rate limit on the 'latest' lookup, a transient network failure, or upstream GitHub downtime. Re-run the pipeline, or set HADOLINT_PINNED_VERSION to a known-good release." >&2
+    exit 1
+  fi
+
   export PATH="/tmp:$PATH"
+fi
+
+# Defense in depth: refuse to proceed unless `hadolint` is genuinely runnable
+# -- whether freshly downloaded above or assumed preinstalled -- instead of
+# falling through to an opaque `hadolint: not found` (exit 127) at the lint
+# call below.
+if ! hadolint --version > /dev/null 2>&1; then
+  echo "ERROR: 'hadolint' is not runnable on PATH; aborting before lint." >&2
+  exit 1
 fi
 
 # Use default config if the project doesn't provide one

--- a/global/scripts/tools/hadolint/run.sh
+++ b/global/scripts/tools/hadolint/run.sh
@@ -76,20 +76,22 @@ if ! command -v hadolint > /dev/null 2>&1; then
   # Run a command up to 3 times with linear backoff (5s, then 10s) so a
   # transient 5xx/network blip is ridden out rather than being fatal. Progress
   # goes to stderr to keep stdout clean for command substitution.
+  # POSIX `sh` has no `local`, so these temporaries are function-name-prefixed
+  # to keep them from leaking into / colliding with the script scope.
   hadolint_retry() {
-    _attempt=1
-    _max=3
+    _hadolint_retry_attempt=1
+    _hadolint_retry_max=3
     while :; do
       if "$@"; then
         return 0
       fi
-      if [ "$_attempt" -ge "$_max" ]; then
+      if [ "$_hadolint_retry_attempt" -ge "$_hadolint_retry_max" ]; then
         return 1
       fi
-      _wait=$((_attempt * 5))
-      echo "  attempt $_attempt/$_max failed; retrying in ${_wait}s..." >&2
-      sleep "$_wait"
-      _attempt=$((_attempt + 1))
+      _hadolint_retry_wait=$((_hadolint_retry_attempt * 5))
+      echo "  attempt $_hadolint_retry_attempt/$_hadolint_retry_max failed; retrying in ${_hadolint_retry_wait}s..." >&2
+      sleep "$_hadolint_retry_wait"
+      _hadolint_retry_attempt=$((_hadolint_retry_attempt + 1))
     done
   }
 
@@ -99,10 +101,10 @@ if ! command -v hadolint > /dev/null 2>&1; then
   # empty output. Returns non-zero -- engaging the retry, then the pinned
   # fallback -- when curl fails or no tag can be parsed.
   hadolint_latest_version() {
-    _body=$(curl -fsSL https://api.github.com/repos/hadolint/hadolint/releases/latest) || return 1
-    _tag=$(printf '%s\n' "$_body" | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
-    [ -n "$_tag" ] || return 1
-    printf '%s\n' "$_tag"
+    _hadolint_latest_version_body=$(curl -fsSL https://api.github.com/repos/hadolint/hadolint/releases/latest) || return 1
+    _hadolint_latest_version_tag=$(printf '%s\n' "$_hadolint_latest_version_body" | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+    [ -n "$_hadolint_latest_version_tag" ] || return 1
+    printf '%s\n' "$_hadolint_latest_version_tag"
   }
 
   if HADOLINT_VERSION=$(hadolint_retry hadolint_latest_version) && [ -n "$HADOLINT_VERSION" ]; then


### PR DESCRIPTION
## Summary

`global/scripts/tools/hadolint/run.sh` installs `hadolint` at runtime on cache-cold CI agents. The install was fragile: it resolved the version to download by parsing `tag_name` from GitHub's `releases/latest` API with no validation, retry, or pinned fallback. A single transient GitHub API hiccup or rate-limit took the whole `sast:hadolint` lint down.

## Problem

The version was resolved with `curl … | grep '"tag_name"' | sed …`. A shell pipeline reports only the **last** command's exit status, so when `curl` failed (HTTP `504`, rate-limit, network blip) `sed` still succeeded on empty input and `HADOLINT_VERSION` came back **empty**. The script then built a download URL with an empty version segment (`…/download//hadolint-Linux-x86_64`), which `404`s; the binary was never written; and the subsequent lint died with `hadolint: not found` — **exit `127`** — with no pointer back to the real cause.

## Changes (`global/scripts/tools/hadolint/run.sh`)

Hardened the install path, mirroring the Trivy install-retry idiom already in `global/scripts/tools/trivy/run.sh`:

- **Pinned fallback** — added `HADOLINT_PINNED_VERSION` (default `v2.14.0`, env-overridable) used whenever the `latest` lookup can't be resolved.
- **Non-empty validation** — the resolved `latest` version is checked explicitly (curl's real exit status is captured, not masked by the pipeline); on failure it falls back to the pinned version with a `WARN`.
- **Retries with backoff** — both the version lookup and the binary download run through a bounded linear backoff (`3` attempts, `attempt × 5s`), so transient `5xx`/network failures are ridden out rather than fatal.
- **Binary verification** — after download the binary is proved runnable via `hadolint --version` before linting; the pinned version is tried as a last resort if the resolved one won't execute.
- **Fail fast** — an unrecoverable install now exits non-zero with a clear, actionable message instead of falling through to `hadolint: not found` (exit `127`).
- **POSIX-sh** — kept `#!/usr/bin/env sh` compatible and ShellCheck-clean.

All three platforms (GitHub Actions, GitLab CI, Azure DevOps) consume this single script, so the fix applies everywhere at once.

## Testing

- `shellcheck --severity=warning` (the CI gate) — **clean**; `sh -n` — valid.
- Functional test with stubbed `curl`/`sleep` (no network, instant retries), covering all paths:
  - **total failure** (API + download both fail): retries each call 3×, falls back to pinned, then exits **`1`** with the actionable error — **not `127`**.
  - **fallback-to-pinned** (API fails, download ok): warns, installs the pinned version, verifies it, lints — exit `0`.
  - **happy path** (API + download ok): resolves `latest`, lints — exit `0`.
- Repo suite: `test-basic-checks` (changelog) and `test-lambda`/`test-yaml-merge`/`test-release-tag-idempotency`/`test-tftest-gen`/`test-order-check`/`test-docker-multi-arch` all pass locally. (`test-go-script` fails on a pre-existing hardcoded `/home/runner/...` CI path, unrelated to this change.)

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?

🤖 Generated with [Claude Code](https://claude.com/claude-code)