### PR TITLE
feat(makefiles): derived the golang build version from CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added a `VERSION` variable to `makefiles/golang.mk`, derived from the latest versioned heading in the consuming project's `CHANGELOG.md` (then the most recent Git tag, then `dev`). Go projects that bake `-X main.version=$(VERSION)` now report the current `CHANGELOG.md` version from `make build`/`make install` even when Git tags lag behind a release, fixing stale `version` and `self-update` output. A project's own `VERSION ?=` line (included after this file) is transparently overridden; an explicit `VERSION` from the environment or command line still wins
+
 ## [4.12.3] - 2026-06-22
 
 ### Fixed

--- a/makefiles/golang.mk
+++ b/makefiles/golang.mk
@@ -6,6 +6,7 @@
 #   -include $(SCRIPTS_DIR)/makefiles/golang.mk
 #
 # Targets provided: lint, test, cross-compile, cyclonedx
+# Variables provided: VERSION (CHANGELOG-/Git-tag-derived build version)
 # Also sets CODEQL_LANGUAGE=go, SEMGREP_LANGUAGE=golang for the common.mk sast target.
 # Note: Unused code detection is handled by golangci-lint (unused, unparam, wastedassign linters).
 
@@ -13,6 +14,15 @@ CODEQL_LANGUAGE ?= go
 SEMGREP_LANGUAGE ?= golang
 export PREFIX ?= .
 export REPORT_PATH ?= ./reports
+
+# Default build version for consuming projects' `-X main.version=$(VERSION)` ldflags.
+# Resolved from the latest versioned heading in the project's CHANGELOG.md (the
+# release source of truth), then the most recent Git tag, and finally "dev". Git
+# tags can lag behind the CHANGELOG when a release pipeline is interrupted, so the
+# CHANGELOG is preferred. Because this file is included before a project's own
+# `VERSION ?=` line, that line becomes a no-op and this value wins; an explicit
+# VERSION from the environment or command line still overrides everything.
+VERSION ?= $(shell { grep -m1 -oE '^\#\# \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'; } || { git describe --tags --abbrev=0 2>/dev/null || echo "dev"; } | sed 's/^v//')
 
 .PHONY: lint test cross-compile cyclonedx
 


### PR DESCRIPTION
## Summary

Go projects that consume `makefiles/golang.mk` bake their version with `-X main.version=$(VERSION)`, where each project derives `VERSION` from `git describe --tags`. When a release pipeline is interrupted, Git tags fall behind `CHANGELOG.md`, so `make build`/`make install` produce a binary that reports a **stale version** — and `self-update` echoes it.

This centralizes the version derivation in `golang.mk` so every consuming project is fixed at once.

## Change

`golang.mk` now defines:

```make
VERSION ?= $(shell { grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'; } || { git describe --tags --abbrev=0 2>/dev/null || echo "dev"; } | sed 's/^v//')
```

Resolution order: latest `## [X.Y.Z]` heading in the project's `CHANGELOG.md` → most recent Git tag → `dev`.

## Why it works without touching consumers

`golang.mk` is `-include`d **before** each project's own `VERSION ?=` line, so the central value is set first and the project's `?=` becomes a no-op. Verified:

| scenario | result |
|---|---|
| pipelines checked out (normal) | central `golang.mk` value wins |
| pipelines absent | project's own line is the fallback |
| `VERSION=x make build` | explicit value always wins |

**Real consumer proof:** in `autoupdate` (latest tag `0.16.1`, CHANGELOG `0.16.2`), `make -n build` now resolves `main.version=0.16.2` with no change to that repo.

## Scope / impact

- Affects only local `make` builds; released binaries (built by goreleaser from the tag) are unchanged.
- Lazy: `VERSION` is only expanded by targets that reference it (`build`), so `lint`/`test` are unaffected.
- Libraries that don't bake a version simply gain an unused variable.

Consuming projects' own `VERSION ?=` lines can be removed in follow-ups, but are harmless as a no-pipelines fallback.