### PR TITLE
fix(cyclonedx): set required metadata.component.type so Dependency-Track accepts the BOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed the `report:dependency-track` job failing with `curl: (22) ... HTTP 400` for every Python integrator: `global/scripts/languages/python/cyclonedx/run.sh` generated the BOM with `cyclonedx-py environment` (which emits no root `metadata.component`) and then hand-built the component via `jq` with only `name` and `version`, omitting the schema-required `component.type`, so Dependency-Track (>= 4.11, BOM validation on by default) rejected every upload — and because the job runs with `continueOnError`/`allow_failure`, builds finished `partiallySucceeded` while no SBOM was ever ingested. The root component is now populated by `cyclonedx-py` itself from the project's `pyproject.toml` (`--pyproject`), and since not every PDM project is an application, the component type is derived from PDM's own library marker under `[tool.pdm]` (`distribution = true`, or the older `package-type = "library"`, yields `library`; anything else defaults to `application`), with a `CYCLONEDX_MC_TYPE` environment variable available to force any valid CycloneDX type per project. Only `version` is still injected via `jq`, since PEP 621 allows it to stay dynamic and be resolved by the build backend
+
 ## [4.13.0] - 2026-06-30
 
 ### Added

--- a/global/scripts/languages/python/cyclonedx/run.sh
+++ b/global/scripts/languages/python/cyclonedx/run.sh
@@ -9,13 +9,26 @@ fi
 
 # TODO: this should not be needed since it's covered by the parent YAML file that calls this shell script
 BOM_PATH="$PREFIX$REPORT_PATH" && mkdir -p "$BOM_PATH"
+
+# CycloneDX requires the root `metadata.component.type`, and Dependency-Track
+# (>= 4.11, BOM validation on by default) rejects uploads without it (HTTP 400).
+# Not every PDM project is an application, so derive the type from the project
+# itself: PDM marks installable libraries with `distribution = true` (PDM >= 2.12)
+# or the older `package-type = "library"` (PDM 2.11) under `[tool.pdm]`.
+# Consumers can force any valid CycloneDX type by exporting CYCLONEDX_MC_TYPE.
+if [ -z "$CYCLONEDX_MC_TYPE" ]; then
+  CYCLONEDX_MC_TYPE="application"
+  if sed -n '/^\[tool\.pdm\]/,/^\[/p' pyproject.toml 2>/dev/null |
+      grep -Eq '^[[:space:]]*(distribution[[:space:]]*=[[:space:]]*true|package-type[[:space:]]*=[[:space:]]*"library")'; then
+    CYCLONEDX_MC_TYPE="library"
+  fi
+fi
+
 # Build the SBOM and let cyclonedx-py populate the root `metadata.component`
 # (name, type, bom-ref) from the project's pyproject.toml (PEP 621) rather than
-# hand-patching it afterwards. CycloneDX requires `component.type`; without a
-# valid root component, Dependency-Track (>= 4.11, BOM validation on by default)
-# rejects the upload with HTTP 400.
+# hand-patching it afterwards.
 pdm run cyclonedx-py environment "$(pdm info --python)" \
-  --pyproject pyproject.toml --mc-type application \
+  --pyproject pyproject.toml --mc-type "$CYCLONEDX_MC_TYPE" \
   --of JSON -o "$BOM_PATH/bom.json"
 # `version` is the one field PEP 621 may leave dynamic (resolved by the build
 # backend, e.g. pdm-backend), so resolve it via pdm and inject only that.

--- a/global/scripts/languages/python/cyclonedx/run.sh
+++ b/global/scripts/languages/python/cyclonedx/run.sh
@@ -9,16 +9,18 @@ fi
 
 # TODO: this should not be needed since it's covered by the parent YAML file that calls this shell script
 BOM_PATH="$PREFIX$REPORT_PATH" && mkdir -p "$BOM_PATH"
-pdm run cyclonedx-py environment "$(pdm info --python)" --of JSON -o "$BOM_PATH/bom.json"
-name=$(pdm show --name 2>/dev/null)
+# Build the SBOM and let cyclonedx-py populate the root `metadata.component`
+# (name, type, bom-ref) from the project's pyproject.toml (PEP 621) rather than
+# hand-patching it afterwards. CycloneDX requires `component.type`; without a
+# valid root component, Dependency-Track (>= 4.11, BOM validation on by default)
+# rejects the upload with HTTP 400.
+pdm run cyclonedx-py environment "$(pdm info --python)" \
+  --pyproject pyproject.toml --mc-type application \
+  --of JSON -o "$BOM_PATH/bom.json"
+# `version` is the one field PEP 621 may leave dynamic (resolved by the build
+# backend, e.g. pdm-backend), so resolve it via pdm and inject only that.
 version=$(pdm show --version 2>/dev/null)
-# `cyclonedx-py environment` emits no root `metadata.component`, so this jq
-# creates it from scratch. CycloneDX requires `component.type`, and
-# Dependency-Track (>= 4.11, BOM validation enabled by default) rejects an
-# upload whose component is missing it with HTTP 400. Set it to "application"
-# alongside the name/version so the generated BOM is schema-valid.
-jq --arg name "$name" \
-   --arg version "$version" \
-   '.metadata.component.type = "application" | .metadata.component.name = $name | .metadata.component.version = $version' \
+jq --arg version "$version" \
+   '.metadata.component.version = $version' \
    "$BOM_PATH/bom.json" > "$BOM_PATH/temp.json"
 mv "$BOM_PATH/temp.json" "$BOM_PATH/bom.json"

--- a/global/scripts/languages/python/cyclonedx/run.sh
+++ b/global/scripts/languages/python/cyclonedx/run.sh
@@ -12,8 +12,13 @@ BOM_PATH="$PREFIX$REPORT_PATH" && mkdir -p "$BOM_PATH"
 pdm run cyclonedx-py environment "$(pdm info --python)" --of JSON -o "$BOM_PATH/bom.json"
 name=$(pdm show --name 2>/dev/null)
 version=$(pdm show --version 2>/dev/null)
+# `cyclonedx-py environment` emits no root `metadata.component`, so this jq
+# creates it from scratch. CycloneDX requires `component.type`, and
+# Dependency-Track (>= 4.11, BOM validation enabled by default) rejects an
+# upload whose component is missing it with HTTP 400. Set it to "application"
+# alongside the name/version so the generated BOM is schema-valid.
 jq --arg name "$name" \
    --arg version "$version" \
-   '.metadata.component.name = $name | .metadata.component.version = $version' \
+   '.metadata.component.type = "application" | .metadata.component.name = $name | .metadata.component.version = $version' \
    "$BOM_PATH/bom.json" > "$BOM_PATH/temp.json"
 mv "$BOM_PATH/temp.json" "$BOM_PATH/bom.json"


### PR DESCRIPTION
## Problem

The `report:dependency-track` job fails on every Python integrator: the BOM upload (`POST /api/v1/bom`) returns `curl: (22) ... HTTP 400`. The job is `continueOnError: true`, so builds still finish `partiallySucceeded`, but the SBOM is never actually ingested by Dependency-Track.

## Root cause

`global/scripts/languages/python/cyclonedx/run.sh` generates the BOM with `cyclonedx-py environment`, which produces a CycloneDX 1.6 document with **no root `metadata.component`**. The existing `jq` then creates `metadata.component` from scratch, setting only `name` and `version`:

```json
"metadata": { "component": { "name": "<proj>", "version": "<ver>" } }
```

`component.type` is **required** by the CycloneDX schema. Dependency-Track validates uploaded BOMs and rejects the schema-invalid document with **HTTP 400**. (The server is recent enough to validate: the `GET /api/v1/project/latest/<name>` call just above only exists from DT 4.11+. `curl --fail` hides the response body, so it surfaces only as exit 22.)

Because the generation path is shared, every Python consumer of the template fails identically.

### Reproduction (any Python repo)

```sh
pdm run cyclonedx-py environment "$(pdm info --python)" --of JSON -o bom.json
jq '.metadata.component' bom.json
# -> null                                   # no root component
```

## Fix

Let `cyclonedx-py` build the root `metadata.component` itself from the project's `pyproject.toml` (`--pyproject`) instead of hand-patching it with `jq` afterwards, and pass the schema-required `--mc-type` explicitly.

Since **not every PDM project is an application**, the component type is derived from the project's own metadata instead of being hardcoded:

| Signal in `pyproject.toml` | Resulting type |
|---|---|
| `[tool.pdm]` `distribution = true` (PDM >= 2.12) or `package-type = "library"` (PDM 2.11) | `library` |
| anything else | `application` (default) |
| `CYCLONEDX_MC_TYPE` env var set on the consuming pipeline | forces any valid CycloneDX type |

Only `version` is still injected via `jq`, because PEP 621 allows it to stay `dynamic` and be resolved by the build backend (e.g. `pdm-backend`).

The resulting root component is schema-valid (`type`, `name`, `bom-ref` from cyclonedx-py; `version` from pdm) and Dependency-Track accepts the upload. Fixes all Python consumers of the template at once.

A `CHANGELOG.md` entry was added under `[Unreleased]`.

## Optional follow-ups (not required for the 400)

- Consider a prod-only dependency scope so the shipped SBOM excludes dev/build tooling (`environment` mode currently bundles every installed package).

## Test plan

- [ ] Run a Python pipeline and confirm `report:dependency-track` succeeds (no HTTP 400) and the project/BOM appears in Dependency-Track.
- [ ] Verify the generated `bom.json` has `metadata.component.type == "application"` for an application repo.
- [ ] Verify a repo with `[tool.pdm] distribution = true` yields `metadata.component.type == "library"`.
- [ ] Verify `CYCLONEDX_MC_TYPE` overrides the detected value.
