### PR TITLE
feat(azure-devops): added TEST_ENV to map secret vars into go test step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Added
 
 - added a `VERSION` variable to `makefiles/golang.mk`, derived from the latest versioned heading in the consuming project's `CHANGELOG.md` (then the most recent Git tag, then `dev`). Go projects that bake `-X main.version=$(VERSION)` now report the current `CHANGELOG.md` version from `make build`/`make install` even when Git tags lag behind a release, fixing stale `version` and `self-update` output. A project's own `VERSION ?=` line (included after this file) is transparently overridden; an explicit `VERSION` from the environment or command line still wins
+- added a `TEST_ENV` object parameter to the Azure DevOps Go test stage (`azure-devops/golang/stages/30-tests/go.yaml`, `go-with-registry.yaml`) and its abstract (`azure-devops/golang/abstracts/test.yaml`). It maps the supplied key/value pairs onto the `Run Tests` step's `env:`, so secret-backed settings (which Azure Pipelines withholds from script-step environments) reach the test process. Defaults to empty, leaving existing consumers unchanged
 
 ## [4.12.3] - 2026-06-22
 

--- a/azure-devops/golang/abstracts/test.yaml
+++ b/azure-devops/golang/abstracts/test.yaml
@@ -1,8 +1,21 @@
+parameters:
+  # Extra environment variables to expose to the test run. Azure Pipelines
+  # gates secret variables from the process environment of script steps, so
+  # secret-backed settings (tokens, passwords) must be mapped explicitly here
+  # or the tests receive empty values. Defaults to none for existing consumers.
+  - name: 'TEST_ENV'
+    type: object
+    default: {}
+
 steps:
   - template: 'go.yaml'
 
   - script: $(Scripts.Directory)/global/scripts/languages/golang/test/run.sh
     displayName: 'Run Tests'
+    ${{ if gt(length(parameters.TEST_ENV), 0) }}:
+      env:
+        ${{ each pair in parameters.TEST_ENV }}:
+          ${{ pair.key }}: ${{ pair.value }}
 
   - task: 'PublishTestResults@2'
     inputs:

--- a/azure-devops/golang/stages/30-tests/go-with-registry.yaml
+++ b/azure-devops/golang/stages/30-tests/go-with-registry.yaml
@@ -2,6 +2,11 @@ parameters:
   - name: 'DEPENDS_ON'
     type: object
     default: ''
+  # Extra environment variables forwarded to the test run (e.g. secret-backed
+  # settings that Azure Pipelines does not auto-inject into script steps).
+  - name: 'TEST_ENV'
+    type: object
+    default: {}
 
 stages:
   - stage: 'tests'
@@ -22,5 +27,7 @@ stages:
               command: 'login'
 
           - template: '../../abstracts/test.yaml'
+            parameters:
+              TEST_ENV: ${{ parameters.TEST_ENV }}
 
         continueOnError: false

--- a/azure-devops/golang/stages/30-tests/go.yaml
+++ b/azure-devops/golang/stages/30-tests/go.yaml
@@ -2,6 +2,11 @@ parameters:
   - name: 'DEPENDS_ON'
     type: object
     default: ''
+  # Extra environment variables forwarded to the test run (e.g. secret-backed
+  # settings that Azure Pipelines does not auto-inject into script steps).
+  - name: 'TEST_ENV'
+    type: object
+    default: {}
 
 stages:
   - stage: 'tests'
@@ -17,5 +22,7 @@ stages:
         steps:
           # $(Scripts.Directory) was already defined in the line below
           - template: '../../abstracts/test.yaml'
+            parameters:
+              TEST_ENV: ${{ parameters.TEST_ENV }}
 
         continueOnError: false


### PR DESCRIPTION
Adds a `TEST_ENV` object parameter to the Azure DevOps Go test stage (`azure-devops/golang/stages/30-tests/go.yaml`, `go-with-registry.yaml`) and the `azure-devops/golang/abstracts/test.yaml` abstract.

## Why
Azure Pipelines withholds **secret** variables from the process environment of script steps. Projects whose tests read secret-backed settings (tokens, passwords) therefore receive empty values and fail. This mirrors the existing precedent in `azure-devops/golang/stages/35-management/go.yaml`, which already maps a secret (`DEPENDENCY_TRACK_TOKEN`) into the step `env:`.

## What
- new `TEST_ENV` object parameter, mapped onto the `Run Tests` step `env:` via per-pair expansion
- forwarded through both `30-tests/go.yaml` and `go-with-registry.yaml`
- defaults to `{}`, so existing consumers are unaffected

## Usage
```yaml
- template: azure-devops/golang/stages/30-tests/go.yaml@pipelines
  parameters:
    TEST_ENV:
      MY_SECRET: $(MY_SECRET)
```