### PR TITLE
fix(golang): map GIT_HTTPS_TOKEN secret into config.sh steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 - added a `VERSION` variable to `makefiles/golang.mk`, derived from the latest versioned heading in the consuming project's `CHANGELOG.md` (then the most recent Git tag, then `dev`). Go projects that bake `-X main.version=$(VERSION)` now report the current `CHANGELOG.md` version from `make build`/`make install` even when Git tags lag behind a release, fixing stale `version` and `self-update` output. A project's own `VERSION ?=` line (included after this file) is transparently overridden; an explicit `VERSION` from the environment or command line still wins
 
+### Fixed
+
+- fixed Go pipelines hanging on private module download (e.g. the CodeQL autobuild stuck on `dev.azure.com/<org>/.../core.git/v4`) whenever the consumer stores `GIT_HTTPS_TOKEN` as a *secret* pipeline variable. Azure DevOps does not auto-inject secret variables into a step's environment, so the `config.sh` sourced by `global/scripts/languages/golang/init/run.sh` (and the standalone CodeQL `global/scripts/tools/codeql/run.sh`) read an empty `GIT_HTTPS_TOKEN`, producing a `https://pat:@.../core` URL that fails authentication (`401`); git then blocks on an interactive credential prompt with no TTY, so the job hangs to timeout instead of failing fast. The token is now mapped explicitly via `env: GIT_HTTPS_TOKEN: $(GIT_HTTPS_TOKEN)` on every step that runs `config.sh`: `azure-devops/golang/abstracts/go.yaml` (covering code-check, the `govulncheck` security job, tests, management, and ARM delivery via `arm.yaml`), `azure-devops/global/stages/20-security/codeql.yaml` (which runs as its own job and sources `config.sh` itself), and `azure-devops/golang/stages/40-delivery/lambda.yaml` (which inlines the init step). Tool scripts (`golangci-lint`, `test`, `cyclonedx`) are unaffected: they do not source `config.sh` and inherit the `git config --global` set by the init step within the same job
+
 ## [4.12.3] - 2026-06-22
 
 ### Fixed

--- a/azure-devops/global/stages/20-security/codeql.yaml
+++ b/azure-devops/global/stages/20-security/codeql.yaml
@@ -9,6 +9,11 @@ jobs:
       - template: '../../abstracts/scripts-repo.yaml'
       - script: $(Scripts.Directory)/global/scripts/tools/codeql/run.sh "${{ parameters.CODEQL_LANGUAGE }}"
         continueOnError: true
+        env:
+          # CodeQL runs as its own job and sources config.sh itself; a secret
+          # GIT_HTTPS_TOKEN must be mapped explicitly for the Go autobuild to
+          # authenticate git when downloading private modules.
+          GIT_HTTPS_TOKEN: $(GIT_HTTPS_TOKEN)
 
       - task: 'PublishPipelineArtifact@1'
         inputs:

--- a/azure-devops/golang/abstracts/go.yaml
+++ b/azure-devops/golang/abstracts/go.yaml
@@ -9,6 +9,10 @@ steps:
   - template: '../../global/abstracts/scripts-repo.yaml'
   - script: $(Scripts.Directory)/global/scripts/languages/golang/init/run.sh
     displayName: 'Load Custom Configuration'
+    env:
+      # Secret variables are not auto-injected as env vars; map it explicitly
+      # so config.sh can authenticate git for private Go module downloads.
+      GIT_HTTPS_TOKEN: $(GIT_HTTPS_TOKEN)
 
   - task: 'GoTool@0'
     inputs:

--- a/azure-devops/golang/stages/40-delivery/lambda.yaml
+++ b/azure-devops/golang/stages/40-delivery/lambda.yaml
@@ -47,6 +47,11 @@ stages:
           - script: $(Scripts.Directory)/global/scripts/languages/golang/init/run.sh
             displayName: 'Load Custom Configuration'
             continueOnError: true
+            env:
+              # Secret variables are not auto-injected as env vars; map it
+              # explicitly so config.sh can authenticate git for private Go
+              # module downloads during the SAM/go build.
+              GIT_HTTPS_TOKEN: $(GIT_HTTPS_TOKEN)
 
           - task: 'Cache@2'
             inputs:


### PR DESCRIPTION
When GIT_HTTPS_TOKEN is stored as a secret pipeline variable, Azure DevOps no longer auto-injects it as an environment variable, so the config.sh sourced by init/run.sh (and CodeQL's run.sh) reads an empty token. The resulting https://pat:@.../core URL fails auth (401) and git blocks on a credential prompt, hanging private module download (e.g. CodeQL autobuild stuck on core.git/v4).

Map the secret via env: on every step that runs config.sh:
- azure-devops/golang/abstracts/go.yaml (code-check, govulncheck, tests, management, and ARM delivery via arm.yaml)
- azure-devops/global/stages/20-security/codeql.yaml (standalone job)
- azure-devops/golang/stages/40-delivery/lambda.yaml (inlined init step)

Tool scripts (golangci-lint, test, cyclonedx) do not source config.sh; they inherit the git config set by the init step in the same job.

## :vertical_traffic_light: Quality checklist

- [ ] Did you add the changes in the `CHANGELOG.md`?
