### PR TITLE
feat(trivy): added TRIVY_PINNED_VERSION fallback (default v0.72.0) to trivy install scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Added
 
-- added an env-overridable `TRIVY_PINNED_VERSION` (default `v0.72.0`, the most recent release) last-resort fallback to the Trivy install path in `global/scripts/tools/trivy/run.sh`, `run-sca.sh`, and `global/scripts/languages/terraform/cyclonedx/run.sh`. The normal path still installs the `latest` Trivy, but when the upstream `install.sh` `latest` tag lookup transiently fails — a rate-limited or empty GitHub response makes it log `unable to find ''` and drop no binary, historically reding `sast:trivy` / `sca:trivy` mid-run — the scripts now retry once against the explicit pinned release before failing the stage. Set `TRIVY_PINNED_VERSION` to any tag from https://github.com/aquasecurity/trivy/releases to override. Mirrors the existing `HADOLINT_PINNED_VERSION` hardening
+- added an env-overridable `TRIVY_PINNED_VERSION` (default `v0.72.0`) last-resort fallback to the Trivy install path in `global/scripts/tools/trivy/run.sh`, `run-sca.sh`, and `global/scripts/languages/terraform/cyclonedx/run.sh`. The normal path still installs the `latest` Trivy, but when the upstream `install.sh` `latest` tag lookup transiently fails — a rate-limited or empty GitHub response makes it log `unable to find ''` and drop no binary, historically failing `sast:trivy` / `sca:trivy` mid-run — the scripts now retry once against the explicit pinned release before failing the stage. Set `TRIVY_PINNED_VERSION` to any tag from https://github.com/aquasecurity/trivy/releases to override. Mirrors the existing `HADOLINT_PINNED_VERSION` hardening
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added an env-overridable `TRIVY_PINNED_VERSION` (default `v0.72.0`, the most recent release) last-resort fallback to the Trivy install path in `global/scripts/tools/trivy/run.sh`, `run-sca.sh`, and `global/scripts/languages/terraform/cyclonedx/run.sh`. The normal path still installs the `latest` Trivy, but when the upstream `install.sh` `latest` tag lookup transiently fails — a rate-limited or empty GitHub response makes it log `unable to find ''` and drop no binary, historically reding `sast:trivy` / `sca:trivy` mid-run — the scripts now retry once against the explicit pinned release before failing the stage. Set `TRIVY_PINNED_VERSION` to any tag from https://github.com/aquasecurity/trivy/releases to override. Mirrors the existing `HADOLINT_PINNED_VERSION` hardening
+
 ### Fixed
 
 - fixed the `report:dependency-track` job failing with `curl: (22) ... HTTP 400` for every Python integrator: `global/scripts/languages/python/cyclonedx/run.sh` generated the BOM with `cyclonedx-py environment` (which emits no root `metadata.component`) and then hand-built the component via `jq` with only `name` and `version`, omitting the schema-required `component.type`, so Dependency-Track (>= 4.11, BOM validation on by default) rejected every upload — and because the job runs with `continueOnError`/`allow_failure`, builds finished `partiallySucceeded` while no SBOM was ever ingested. The root component is now populated by `cyclonedx-py` itself from the project's `pyproject.toml` (`--pyproject`), and since not every PDM project is an application, the component type is derived from PDM's own library marker under `[tool.pdm]` (`distribution = true`, or the older `package-type = "library"`, yields `library`; anything else defaults to `application`), with a `CYCLONEDX_MC_TYPE` environment variable available to force any valid CycloneDX type per project. Only `version` is still injected via `jq`, since PEP 621 allows it to stay dynamic and be resolved by the build backend

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ All `run.sh` scripts follow this pattern:
 | Tool(s) | Install method |
 |------------------------------------------------|------------------------------------------------------------------------------------|
 | `codeql`, `gitleaks`, `hadolint`, `shellcheck` | self-contained release binary downloaded from the project's GitHub releases         |
-| `trivy`                                        | upstream `install.sh`, wrapped in a retry-with-backoff loop                         |
+| `trivy`                                        | upstream `install.sh` (retry-with-backoff loop, then a pinned-version fallback)     |
 | `semgrep`                                      | installed from PyPI into an isolated `python3 -m venv` — Semgrep ships no binary    |
 | `sonarqube`                                    | expects `sonar-scanner` to already be on the runner                                 |
 | `dependency-track`                             | no tool binary — uploads the CycloneDX BOM with `curl`                              |

--- a/global/scripts/languages/terraform/cyclonedx/run.sh
+++ b/global/scripts/languages/terraform/cyclonedx/run.sh
@@ -31,14 +31,14 @@ if ! command -v trivy > /dev/null 2>&1; then
   # `|| true` keeps `set -e` from aborting so the pinned fallback below can
   # run when the `latest` tag lookup transiently fails (a rate-limited or
   # empty GitHub response drops no binary).
-  curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp || true
+  curl -fsSL --show-error https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp || true
   # Last-resort fallback to an explicit, known-good version. Override the
   # pin via TRIVY_PINNED_VERSION (any tag from
   # https://github.com/aquasecurity/trivy/releases, e.g. v0.72.0).
   if [ ! -x /tmp/trivy ]; then
     : "${TRIVY_PINNED_VERSION:=v0.72.0}"
     echo "Trivy 'latest' install failed; falling back to pinned $TRIVY_PINNED_VERSION..." >&2
-    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp "$TRIVY_PINNED_VERSION" || true
+    curl -fsSL --show-error https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp "$TRIVY_PINNED_VERSION" || true
   fi
   if [ ! -x /tmp/trivy ]; then
     echo "ERROR: Trivy install failed (latest and pinned ${TRIVY_PINNED_VERSION:-v0.72.0}). See install output above." >&2

--- a/global/scripts/languages/terraform/cyclonedx/run.sh
+++ b/global/scripts/languages/terraform/cyclonedx/run.sh
@@ -28,7 +28,22 @@ bomFile="$BOM_PATH/bom.json"
 # `global/scripts/tools/trivy/run.sh`).
 if ! command -v trivy > /dev/null 2>&1; then
   echo "Downloading Trivy..."
-  curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp
+  # `|| true` keeps `set -e` from aborting so the pinned fallback below can
+  # run when the `latest` tag lookup transiently fails (a rate-limited or
+  # empty GitHub response drops no binary).
+  curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp || true
+  # Last-resort fallback to an explicit, known-good version. Override the
+  # pin via TRIVY_PINNED_VERSION (any tag from
+  # https://github.com/aquasecurity/trivy/releases, e.g. v0.72.0).
+  if [ ! -x /tmp/trivy ]; then
+    : "${TRIVY_PINNED_VERSION:=v0.72.0}"
+    echo "Trivy 'latest' install failed; falling back to pinned $TRIVY_PINNED_VERSION..." >&2
+    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp "$TRIVY_PINNED_VERSION" || true
+  fi
+  if [ ! -x /tmp/trivy ]; then
+    echo "ERROR: Trivy install failed (latest and pinned ${TRIVY_PINNED_VERSION:-v0.72.0}). See install output above." >&2
+    exit 1
+  fi
   export PATH="/tmp:$PATH"
 fi
 

--- a/global/scripts/tools/trivy/run-sca.sh
+++ b/global/scripts/tools/trivy/run-sca.sh
@@ -43,8 +43,26 @@ if ! command -v trivy > /dev/null 2>&1; then
     fi
     attempt=$((attempt + 1))
   done
+  # Last-resort fallback: the retry loop above installs the `latest`
+  # Trivy, whose tag lookup can transiently fail (a rate-limited or empty
+  # GitHub response makes upstream `install.sh` log `unable to find ''`
+  # and drop no binary). Before failing the whole stage, try once more
+  # against an explicit, known-good version so a flaky `latest` lookup
+  # alone cannot red the pipeline. Override the pin via TRIVY_PINNED_VERSION
+  # (any tag from https://github.com/aquasecurity/trivy/releases, e.g. v0.72.0).
   if [ ! -x /tmp/trivy ]; then
-    echo "ERROR: Trivy install failed after $maxAttempts attempts (last exit=$installerStatus). Common causes include a GitHub API rate limit on the 'latest' tag lookup, transient network failures, raw.githubusercontent.com being blocked, or upstream GitHub downtime. Last installer/curl output:" >&2
+    : "${TRIVY_PINNED_VERSION:=v0.72.0}"
+    echo "Trivy 'latest' install failed after $maxAttempts attempts; falling back to pinned $TRIVY_PINNED_VERSION..." >&2
+    : > "$installerLog"
+    installerStatus=0
+    {
+      curl -fsSL --show-error https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh 2>>"$installerLog" \
+        | sh -s -- -b /tmp "$TRIVY_PINNED_VERSION" >>"$installerLog" 2>&1
+    } || installerStatus=$?
+    [ -s "$installerLog" ] && sed 's/^/  | /' "$installerLog" >&2
+  fi
+  if [ ! -x /tmp/trivy ]; then
+    echo "ERROR: Trivy install failed after $maxAttempts 'latest' attempts and a pinned ${TRIVY_PINNED_VERSION:-v0.72.0} fallback (last exit=$installerStatus). Common causes include a GitHub API rate limit on the 'latest' tag lookup, transient network failures, raw.githubusercontent.com being blocked, or upstream GitHub downtime. Last installer/curl output:" >&2
     [ -s "$installerLog" ] && sed 's/^/  | /' "$installerLog" >&2
     echo "Re-run the pipeline or pin a Trivy version explicitly." >&2
     rm -f "$installerLog"

--- a/global/scripts/tools/trivy/run-sca.sh
+++ b/global/scripts/tools/trivy/run-sca.sh
@@ -59,7 +59,6 @@ if ! command -v trivy > /dev/null 2>&1; then
       curl -fsSL --show-error https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh 2>>"$installerLog" \
         | sh -s -- -b /tmp "$TRIVY_PINNED_VERSION" >>"$installerLog" 2>&1
     } || installerStatus=$?
-    [ -s "$installerLog" ] && sed 's/^/  | /' "$installerLog" >&2
   fi
   if [ ! -x /tmp/trivy ]; then
     echo "ERROR: Trivy install failed after $maxAttempts 'latest' attempts and a pinned ${TRIVY_PINNED_VERSION:-v0.72.0} fallback (last exit=$installerStatus). Common causes include a GitHub API rate limit on the 'latest' tag lookup, transient network failures, raw.githubusercontent.com being blocked, or upstream GitHub downtime. Last installer/curl output:" >&2

--- a/global/scripts/tools/trivy/run.sh
+++ b/global/scripts/tools/trivy/run.sh
@@ -60,7 +60,6 @@ if ! command -v trivy > /dev/null 2>&1; then
       curl -fsSL --show-error https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh 2>>"$installerLog" \
         | sh -s -- -b /tmp "$TRIVY_PINNED_VERSION" >>"$installerLog" 2>&1
     } || installerStatus=$?
-    [ -s "$installerLog" ] && sed 's/^/  | /' "$installerLog" >&2
   fi
   if [ ! -x /tmp/trivy ]; then
     echo "ERROR: Trivy install failed after $maxAttempts 'latest' attempts and a pinned ${TRIVY_PINNED_VERSION:-v0.72.0} fallback (last exit=$installerStatus). Common causes include a GitHub API rate limit on the 'latest' tag lookup, transient network failures, raw.githubusercontent.com being blocked, or upstream GitHub downtime. Last installer/curl output:" >&2

--- a/global/scripts/tools/trivy/run.sh
+++ b/global/scripts/tools/trivy/run.sh
@@ -44,8 +44,26 @@ if ! command -v trivy > /dev/null 2>&1; then
     fi
     attempt=$((attempt + 1))
   done
+  # Last-resort fallback: the retry loop above installs the `latest`
+  # Trivy, whose tag lookup can transiently fail (a rate-limited or empty
+  # GitHub response makes upstream `install.sh` log `unable to find ''`
+  # and drop no binary). Before failing the whole stage, try once more
+  # against an explicit, known-good version so a flaky `latest` lookup
+  # alone cannot red the pipeline. Override the pin via TRIVY_PINNED_VERSION
+  # (any tag from https://github.com/aquasecurity/trivy/releases, e.g. v0.72.0).
   if [ ! -x /tmp/trivy ]; then
-    echo "ERROR: Trivy install failed after $maxAttempts attempts (last exit=$installerStatus). Common causes include a GitHub API rate limit on the 'latest' tag lookup, transient network failures, raw.githubusercontent.com being blocked, or upstream GitHub downtime. Last installer/curl output:" >&2
+    : "${TRIVY_PINNED_VERSION:=v0.72.0}"
+    echo "Trivy 'latest' install failed after $maxAttempts attempts; falling back to pinned $TRIVY_PINNED_VERSION..." >&2
+    : > "$installerLog"
+    installerStatus=0
+    {
+      curl -fsSL --show-error https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh 2>>"$installerLog" \
+        | sh -s -- -b /tmp "$TRIVY_PINNED_VERSION" >>"$installerLog" 2>&1
+    } || installerStatus=$?
+    [ -s "$installerLog" ] && sed 's/^/  | /' "$installerLog" >&2
+  fi
+  if [ ! -x /tmp/trivy ]; then
+    echo "ERROR: Trivy install failed after $maxAttempts 'latest' attempts and a pinned ${TRIVY_PINNED_VERSION:-v0.72.0} fallback (last exit=$installerStatus). Common causes include a GitHub API rate limit on the 'latest' tag lookup, transient network failures, raw.githubusercontent.com being blocked, or upstream GitHub downtime. Last installer/curl output:" >&2
     [ -s "$installerLog" ] && sed 's/^/  | /' "$installerLog" >&2
     echo "Re-run the pipeline or pin a Trivy version explicitly." >&2
     rm -f "$installerLog"


### PR DESCRIPTION
## What
Adds an env-overridable `TRIVY_PINNED_VERSION` (default `v0.72.0`, the most recent release) last-resort fallback to the three Trivy install sites: `global/scripts/tools/trivy/run.sh`, `run-sca.sh`, and `global/scripts/languages/terraform/cyclonedx/run.sh`.

## Why
All three install Trivy via the upstream `install.sh`, which resolves the `latest` tag from GitHub. That lookup is rate-limited and occasionally returns an empty body — `install.sh` logs `unable to find ''`, drops no binary, and the subsequent `trivy` calls exit `127`, reding `sast:trivy` / `sca:trivy` for an infrastructure reason. The existing retry loop handles transient blips; this adds a deterministic floor.

## Behavior
- Normal path unchanged: still installs the `latest` Trivy.
- Only when the `latest` install fails after retries (binary absent) do the scripts retry once against the explicit pinned release before failing the stage.
- Override with `TRIVY_PINNED_VERSION=<tag>` (any tag from https://github.com/aquasecurity/trivy/releases).
- Mirrors the existing `HADOLINT_PINNED_VERSION` hardening.

## Verification
- `shellcheck --severity=warning` (the CI gate) — clean on all three scripts
- `sh -n` syntax — clean
- `install.sh -b <dir> v0.72.0` installs trivy 0.72.0 (the exact fallback command)
- `make test-basic-checks` — 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
