### PR TITLE
fix(dependency-check): stopped the NVD database being rebuilt on every run

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,7 @@ This repository provides comprehensive SDLC pipeline templates for GitHub Action
 ## Quick Reference
 
 **Essential Commands:**
-- `make test` - Run all validation tests (Go, Lambda, YAML merge, Trivy merge, SonarQube, release tag, tftest-gen, order-check, docker-multi-arch, basic-checks)
+- `make test` - Run all validation tests (Go, Lambda, YAML merge, Trivy merge, SonarQube, release tag, tftest-gen, order-check, docker-multi-arch, basic-checks, dependency-check)
 - `make test-go-script` - Test Go script changes specifically
 - `make test-lambda` - Test Lambda template validation specifically
 - `make test-yaml-merge` - Test YAML merge validation specifically
@@ -18,6 +18,7 @@ This repository provides comprehensive SDLC pipeline templates for GitHub Action
 - `make test-order-check` - Test the Terragrunt file-ordering checker/fixer specifically
 - `make test-docker-multi-arch` - Test 40-delivery/docker multi-arch contract specifically
 - `make test-basic-checks` - Test basic-checks changelog validation (chlog fragments + legacy CHANGELOG.md) specifically
+- `make test-dependency-check` - Test the OWASP Dependency-Check NVD cache / API-key contract specifically
 - `bash global/scripts/shared/cleanup.sh` - Clean up build reports
 - `docker --version && make --version && go version` - Check dependencies
 
@@ -123,7 +124,7 @@ This repository provides comprehensive SDLC pipeline templates for GitHub Action
 | **Trivy SCA**              | Dependency vulnerability scanning | All        | `global/scripts/tools/trivy/run-sca.sh`        |
 | **govulncheck**            | Go vulnerability scanning         | Go         | `global/scripts/languages/golang/govulncheck/` |
 | **Safety**                 | Python dependency scanning        | Python     | `pdm run safety-scan`                          |
-| **OWASP Dependency-Check** | Java dependency scanning          | Java       | `./gradlew dependencyCheckAnalyze`             |
+| **OWASP Dependency-Check** | Java dependency scanning          | Java       | `global/scripts/languages/java/dependency-check/` |
 | **yarn npm audit**         | JS/Node.js dependency scanning    | JavaScript | `yarn npm audit --recursive`                   |
 | **npm audit**              | JS/Node.js dependency scanning    | JavaScript | `npm audit --audit-level=high`                 |
 | **Composer Audit**         | PHP dependency scanning           | PHP        | `composer audit`                               |
@@ -639,7 +640,7 @@ docker build -t test-image -f global/containers/awscli.latest/Dockerfile global/
 
 ### Test Suite Usage
 ```bash
-# Run all validation tests (Go, Lambda, YAML merge, Trivy merge, SonarQube, release tag, tftest-gen, order-check, docker-multi-arch, basic-checks)
+# Run all validation tests (Go, Lambda, YAML merge, Trivy merge, SonarQube, release tag, tftest-gen, order-check, docker-multi-arch, basic-checks, dependency-check)
 make test
 
 # Run individual test suites
@@ -653,6 +654,7 @@ make test-tftest-gen
 make test-order-check
 make test-docker-multi-arch
 make test-basic-checks
+make test-dependency-check
 ```
 
 Test scripts are located in `.github/tests/`.

--- a/.github/tests/test-dependency-check.sh
+++ b/.github/tests/test-dependency-check.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+set -e
+
+# Test script for the OWASP Dependency-Check runner
+# (global/scripts/languages/java/dependency-check/run.sh).
+#
+# The job this guards used to run for 5h45m and get cancelled, because the NVD API key never reached
+# the tool (both plugins ignore a bare NVD_API_KEY environment variable) and the CVE database was
+# never written to the directory the pipelines cached. Every assertion below pins one leg of that
+# failure, so the regression cannot come back silently.
+#
+# The Maven and Gradle cases are exercised for real: a stub build tool is put on PATH, run.sh is
+# invoked, and the recorded argv is asserted against. That checks what the tool is actually told,
+# rather than what the script looks like it says.
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export SCRIPTS_DIR
+RUN_SH="$SCRIPTS_DIR/global/scripts/languages/java/dependency-check/run.sh"
+INIT_GRADLE="$SCRIPTS_DIR/global/scripts/languages/java/dependency-check/init.gradle"
+ACTION="$SCRIPTS_DIR/github/java/stages/20-security/dependency-check/action.yaml"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_true() {
+  local description="$1"
+  local condition="$2"
+  if eval "$condition"; then
+    echo -e "${GREEN}  PASS: $description${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}  FAIL: $description${NC}"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+WORK_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+# Stands up a throwaway project with a stub build tool on PATH that records the argv it was called
+# with, runs the script against it, and leaves the result in $ARGV for assertions.
+run_against_stub() {
+  local buildFile="$1" # 'pom.xml' or 'build.gradle'
+  local stubName="$2"  # 'mvn' or 'gradle'
+  shift 2
+
+  local projectDir="$WORK_DIR/project"
+  rm -rf "$projectDir"
+  mkdir -p "$projectDir/bin"
+  touch "$projectDir/$buildFile"
+
+  local argvFile="$projectDir/argv.txt"
+  cat > "$projectDir/bin/$stubName" <<EOF
+#!/usr/bin/env sh
+printf '%s\n' "\$@" > '$argvFile'
+EOF
+  chmod +x "$projectDir/bin/$stubName"
+
+  (
+    cd "$projectDir"
+    # `env -i` would drop PATH; unset only the variables under test so each case starts clean.
+    unset NVD_API_KEY NVD_DATAFEED_URL NVD_VALID_FOR_HOURS DEPENDENCY_CHECK_DATA_DIR
+    export PATH="$projectDir/bin:$PATH"
+    export SCRIPTS_DIR
+    env "$@" "$RUN_SH" > "$projectDir/stdout.txt" 2>&1
+  )
+
+  ARGV="$(cat "$argvFile")"
+  STDOUT="$(cat "$projectDir/stdout.txt")"
+}
+
+# =============================================================================
+# Test 1: Maven — the API key reaches the plugin, and does so without leaking
+# =============================================================================
+echo "TEST 1: Maven passes the NVD API key by variable name, never by value"
+# given a project with an NVD API key in the environment
+# when dependency-check runs
+run_against_stub 'pom.xml' 'mvn' NVD_API_KEY='super-secret-key-value'
+# then the plugin is told which variable to read the key from...
+assert_true "passes -DnvdApiKeyEnvironmentVariable so the plugin reads NVD_API_KEY itself" \
+  "grep -qx -- '-DnvdApiKeyEnvironmentVariable=NVD_API_KEY' <<< \"\$ARGV\""
+# ...and the key itself never lands in argv, where `mvn -X` would print it (GHSA-qqhq-8r2c-c3f5)
+assert_true "never puts the key's value on the command line" \
+  "! grep -q 'super-secret-key-value' <<< \"\$ARGV\""
+assert_true "never uses the leaky -DnvdApiKey property" \
+  "! grep -q -- '-DnvdApiKey=' <<< \"\$ARGV\""
+# and with a key it uses the authenticated API rather than the datafeed
+assert_true "does not fall back to the datafeed when a key is present" \
+  "! grep -q -- '-DnvdDatafeedUrl' <<< \"\$ARGV\""
+
+# =============================================================================
+# Test 2: Maven — the CVE database is pinned to the cached directory
+# =============================================================================
+echo "TEST 2: Maven pins the CVE database into the directory the pipelines cache"
+# given no explicit data directory
+# when dependency-check runs
+run_against_stub 'pom.xml' 'mvn' NVD_API_KEY='k'
+# then the database goes to ./.owasp -- the path every platform caches -- as an absolute path,
+# because both plugins reject a relative one. Left to itself Maven would default it into
+# ~/.m2/repository/org/owasp/dependency-check-data/, which the pipelines never cached.
+assert_true "passes an absolute -DdataDirectory ending in /.owasp" \
+  "grep -qE -- '^-DdataDirectory=/.*/\.owasp$' <<< \"\$ARGV\""
+assert_true "reuses a cached database for 24h instead of the 4h default" \
+  "grep -qx -- '-DnvdValidForHours=24' <<< \"\$ARGV\""
+assert_true "honours DEPENDENCY_CHECK_DATA_DIR when set" \
+  "run_against_stub 'pom.xml' 'mvn' NVD_API_KEY='k' DEPENDENCY_CHECK_DATA_DIR='/tmp/custom-nvd'; \
+   grep -qx -- '-DdataDirectory=/tmp/custom-nvd' <<< \"\$ARGV\""
+
+# =============================================================================
+# Test 3: no API key falls back to the datafeed, never to the throttled API
+# =============================================================================
+echo "TEST 3: a keyless run uses the NVD datafeed instead of the rate-limited API"
+# given no API key at all
+# when dependency-check runs
+run_against_stub 'pom.xml' 'mvn'
+# then it downloads NIST's gzipped feeds rather than paginating ~174 API pages at 5 requests/30s
+assert_true "falls back to the NVD datafeed" \
+  "grep -q -- '-DnvdDatafeedUrl=https://nvd.nist.gov/feeds/json/cve/2.0/' <<< \"\$ARGV\""
+assert_true "does not claim an API key it does not have" \
+  "! grep -q -- '-DnvdApiKeyEnvironmentVariable' <<< \"\$ARGV\""
+assert_true "warns that the run would be faster and fresher with a key" \
+  "grep -q 'nvd.nist.gov/developers/request-an-api-key' <<< \"\$STDOUT\""
+# and an explicit mirror still wins over the default
+assert_true "honours a self-hosted NVD_DATAFEED_URL mirror" \
+  "run_against_stub 'pom.xml' 'mvn' NVD_DATAFEED_URL='https://mirror.internal/nvd/'; \
+   grep -qx -- '-DnvdDatafeedUrl=https://mirror.internal/nvd/' <<< \"\$ARGV\""
+
+# =============================================================================
+# Test 4: Azure DevOps leaves undefined variables unexpanded
+# =============================================================================
+echo "TEST 4: an unexpanded Azure DevOps macro is not mistaken for an API key"
+# given Azure DevOps passed `$(NVD_API_KEY)` verbatim because the variable is not defined
+# when dependency-check runs
+run_against_stub 'pom.xml' 'mvn' NVD_API_KEY='$(NVD_API_KEY)'
+# then it is treated as no key. Handing that string to the NVD earns a 403 on every request, which is
+# worse than no key at all: the datafeed fallback would never engage.
+assert_true "treats the literal macro as an absent key" \
+  "! grep -q -- '-DnvdApiKeyEnvironmentVariable' <<< \"\$ARGV\""
+assert_true "falls back to the datafeed instead" \
+  "grep -q -- '-DnvdDatafeedUrl=' <<< \"\$ARGV\""
+
+# =============================================================================
+# Test 5: Gradle is configured through an init script
+# =============================================================================
+echo "TEST 5: Gradle is configured through an init script, not a dead env var"
+# given a Gradle project
+# when dependency-check runs
+run_against_stub 'build.gradle' 'gradle' NVD_API_KEY='k'
+# then the settings are injected via --init-script. The Gradle plugin reads them ONLY from its
+# `dependencyCheck` extension -- it consults neither the environment nor system properties -- so the
+# OWASP_PATH export the pipelines used to rely on was a no-op and the database silently went to
+# $GRADLE_USER_HOME/dependency-check-data/, never into the cached directory.
+assert_true "invokes dependencyCheckAnalyze" \
+  "grep -qx 'dependencyCheckAnalyze' <<< \"\$ARGV\""
+assert_true "passes --init-script" \
+  "grep -qx -- '--init-script' <<< \"\$ARGV\""
+assert_true "points --init-script at the shipped init.gradle" \
+  "grep -qx -- '.*/global/scripts/languages/java/dependency-check/init.gradle' <<< \"\$ARGV\""
+assert_true "the init script it points at exists" "[ -f '$INIT_GRADLE' ]"
+assert_true "the init script writes the API key into the dependencyCheck extension" \
+  "grep -q 'extension.nvd.apiKey = apiKey' '$INIT_GRADLE'"
+assert_true "the init script writes the data directory into the dependencyCheck extension" \
+  "grep -q 'extension.data.directory = dataDirectory' '$INIT_GRADLE'"
+assert_true "the init script applies after evaluation so it beats the project's own config" \
+  "grep -q 'projectsEvaluated' '$INIT_GRADLE'"
+
+# =============================================================================
+# Test 6: the dead configuration knobs are gone from every platform
+# =============================================================================
+echo "TEST 6: no platform relies on configuration the plugins ignore"
+cd "$SCRIPTS_DIR"
+# OWASP_PATH was never read by anything; the Gradle plugin has no such setting.
+assert_true "OWASP_PATH is gone repo-wide" \
+  "! grep -rq 'OWASP_PATH' .github/workflows github gitlab azure-devops global"
+# Setting -DdataDirectory through MAVEN_OPTS relied on Maven's system-property fallback; the mojo has
+# a real user property for it.
+assert_true "MAVEN_OPTS is no longer used to smuggle -DdataDirectory" \
+  "! grep -rq 'MAVEN_OPTS.*dataDirectory' .github/workflows gitlab azure-devops"
+# The one remaining bare `env: NVD_API_KEY` is the Azure step, which run.sh reads deliberately; no
+# platform may hand it to a plugin and assume it lands.
+assert_true "no workflow calls a dependency-check plugin directly any more" \
+  "! grep -rqE 'mvn .*dependency-check|gradlew? dependencyCheckAnalyze' .github/workflows gitlab azure-devops"
+
+# =============================================================================
+# Test 7: the GitHub cache survives the failure that used to empty it
+# =============================================================================
+echo "TEST 7: the GitHub NVD cache is written even when the job dies"
+# The old job used the all-in-one actions/cache, whose save runs in a post-job step that is skipped on
+# cancellation. The 5h45m run was cancelled, so nothing was ever cached, so the next run started cold
+# again -- the loop this splits apart.
+assert_true "restores with actions/cache/restore" \
+  "grep -q 'actions/cache/restore@v4' '$ACTION'"
+assert_true "saves with an explicit actions/cache/save step" \
+  "grep -q 'actions/cache/save@v4' '$ACTION'"
+assert_true "saves under always(), so a cancelled or failed run still keeps its progress" \
+  "grep -qE \"if: \\\"always\\(\\) && steps.restore_nvd.outputs.cache-hit\" '$ACTION'"
+assert_true "does not use the all-in-one actions/cache, whose save is skipped on cancellation" \
+  "! grep -qE 'uses: .actions/cache@' '$ACTION'"
+assert_true "keys the cache daily so the snapshot cannot go stale forever" \
+  "grep -q 'steps.date.outputs.date' '$ACTION'"
+assert_true "falls back to the most recent snapshot via restore-keys" \
+  "grep -q 'restore-keys' '$ACTION'"
+assert_true "checks out before restoring, so checkout cannot clean the restored database away" \
+  "[ \$(grep -n 'actions/checkout' '$ACTION' | cut -d: -f1) -lt \$(grep -n 'actions/cache/restore' '$ACTION' | cut -d: -f1) ]"
+
+# =============================================================================
+# Test 8: every platform caps the job, so a runaway download cannot burn minutes
+# =============================================================================
+echo "TEST 8: every platform bounds the job's runtime"
+assert_true "GitHub Actions: maven workflow has a timeout" \
+  "grep -q 'timeout-minutes: 30' .github/workflows/maven.yaml"
+assert_true "GitHub Actions: gradle workflow has a timeout" \
+  "grep -q 'timeout-minutes: 30' .github/workflows/gradle.yaml"
+assert_true "GitLab CI: maven job has a timeout" \
+  "grep -q \"timeout: '30 minutes'\" gitlab/java/stages/20-security/maven.yaml"
+assert_true "GitLab CI: gradle job has a timeout" \
+  "grep -q \"timeout: '30 minutes'\" gitlab/java/stages/20-security/gradle.yaml"
+assert_true "Azure DevOps: dependency-check job has a timeout" \
+  "grep -q 'timeoutInMinutes: 30' azure-devops/java/stages/20-security/java.yaml"
+
+# =============================================================================
+# Test 9: all three platforms run the same script
+# =============================================================================
+echo "TEST 9: all three platforms share one runner"
+assert_true "run.sh is executable" "[ -x '$RUN_SH' ]"
+assert_true "GitHub Actions calls the shared runner" \
+  "grep -q 'global/scripts/languages/java/dependency-check/run.sh' '$ACTION'"
+assert_true "GitLab CI (maven) calls the shared runner" \
+  "grep -q 'global/scripts/languages/java/dependency-check/run.sh' gitlab/java/stages/20-security/maven.yaml"
+assert_true "GitLab CI (gradle) calls the shared runner" \
+  "grep -q 'global/scripts/languages/java/dependency-check/run.sh' gitlab/java/stages/20-security/gradle.yaml"
+assert_true "Azure DevOps calls the shared runner" \
+  "grep -q 'global/scripts/languages/java/dependency-check/run.sh' azure-devops/java/stages/20-security/java.yaml"
+
+# =============================================================================
+echo
+echo "================================"
+echo -e "Tests passed: ${GREEN}$TESTS_PASSED${NC}"
+if [ "$TESTS_FAILED" -gt 0 ]; then
+  echo -e "Tests failed: ${RED}$TESTS_FAILED${NC}"
+  echo "================================"
+  exit 1
+fi
+echo "Tests failed: 0"
+echo "================================"
+echo -e "${GREEN}All dependency-check tests passed!${NC}"

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -115,39 +115,16 @@ jobs:
     name: 'security > sca:dependency-check'
     runs-on: 'ubuntu-latest'
     steps:
-      - name: 'Checkout code'
-        uses: 'actions/checkout@v6'
-
-      - name: 'Setup Java'
-        uses: 'actions/setup-java@v5'
+      - uses: 'rios0rios0/pipelines/github/java/stages/20-security/dependency-check@main'
         with:
-          distribution: 'temurin'
-          java-version: '21'
-          cache: 'gradle'
-
-      - name: 'Get current week number'
-        id: 'week'
-        run: echo "week=$(date +%Y-%W)" >> "$GITHUB_OUTPUT"
-        shell: 'bash'
-
-      - name: 'Cache NVD database'
-        uses: 'actions/cache@v4'
-        with:
-          path: '.owasp'
-          key: owasp-nvd-${{ runner.os }}-${{ steps.week.outputs.week }}
-          restore-keys: |
-            owasp-nvd-${{ runner.os }}-
-
-      - name: 'Run OWASP Dependency-Check'
-        run: |
-          mkdir -p '.owasp'
-          export OWASP_PATH="$(pwd)/.owasp"
-          ./gradlew dependencyCheckAnalyze
-        shell: 'bash'
-        env:
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+          nvd_api_key: ${{ secrets.NVD_API_KEY }}
+          build_tool: 'gradle'
     needs: [ 'code_check-style_checkstyle', 'code_check-quality_proguard' ]
     continue-on-error: true
+    # Building the CVE database is the only slow path left, and it is bounded rather than trusted: the
+    # job is killed at 30 minutes so a pathological NVD download can never again run for hours against
+    # the account's Actions minutes.
+    timeout-minutes: 30
     if: "!startsWith(github.ref, 'refs/tags/')"
 
 

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -115,39 +115,16 @@ jobs:
     name: 'security > sca:dependency-check'
     runs-on: 'ubuntu-latest'
     steps:
-      - name: 'Checkout code'
-        uses: 'actions/checkout@v6'
-
-      - name: 'Setup Java'
-        uses: 'actions/setup-java@v5'
+      - uses: 'rios0rios0/pipelines/github/java/stages/20-security/dependency-check@main'
         with:
-          distribution: 'temurin'
-          java-version: '21'
-          cache: 'maven'
-
-      - name: 'Get current week number'
-        id: 'week'
-        run: echo "week=$(date +%Y-%W)" >> "$GITHUB_OUTPUT"
-        shell: 'bash'
-
-      - name: 'Cache NVD database'
-        uses: 'actions/cache@v4'
-        with:
-          path: '.owasp'
-          key: owasp-nvd-${{ runner.os }}-${{ steps.week.outputs.week }}
-          restore-keys: |
-            owasp-nvd-${{ runner.os }}-
-
-      - name: 'Run OWASP Dependency-Check'
-        run: |
-          mkdir -p '.owasp'
-          export MAVEN_OPTS="$MAVEN_OPTS -DdataDirectory=$(pwd)/.owasp"
-          mvn org.owasp:dependency-check-maven:check
-        shell: 'bash'
-        env:
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+          nvd_api_key: ${{ secrets.NVD_API_KEY }}
+          build_tool: 'maven'
     needs: [ 'code_check-style_maven_verify', 'code_check-quality_proguard' ]
     continue-on-error: true
+    # Building the CVE database is the only slow path left, and it is bounded rather than trusted: the
+    # job is killed at 30 minutes so a pathological NVD download can never again run for hours against
+    # the account's Actions minutes.
+    timeout-minutes: 30
     if: "!startsWith(github.ref, 'refs/tags/')"
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,23 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `global/scripts/languages/java/dependency-check/`, a single Dependency-Check runner shared by GitHub Actions, GitLab CI and Azure DevOps. It resolves the CVE database into one absolute, cacheable directory (`.owasp/`), passes the API key by variable name, and reuses a cached database for 24h (`nvdValidForHours`) instead of Dependency-Check's 4h default. Gradle is configured through a shipped `init.gradle` applied with `--init-script`, because the Gradle plugin reads its settings *only* from the `dependencyCheck` extension — consuming projects need no `build.gradle` change
+- added an NVD datafeed fallback for projects with no API key: rather than paginating ~174 API pages against the anonymous rate limit, the scan downloads NIST's gzipped JSON feeds, which are not rate limited. Set `NVD_DATAFEED_URL` to point at a self-hosted [`vulnz`](https://github.com/jeremylong/open-vulnerability-cli) mirror instead. An API key remains strongly recommended, and the job says so in its log
+- added a 30-minute cap to the Dependency-Check job on all three platforms (`timeout-minutes`, `timeout`, `timeoutInMinutes`), so a pathological NVD download is bounded rather than trusted and can never again run for hours against the account's CI minutes
+- added Dependency-Check report publishing to GitHub Actions and Azure DevOps, which previously ran the scan and discarded the report. Reports are now written to `build/reports/dependency-check/` on every platform, in line with the other tools
+- added `.github/tests/test-dependency-check.sh` (wired into `make test`, and listed in `CLAUDE.md` and `.github/copilot-instructions.md` alongside the other targets), which runs the runner against a stub build tool and asserts on the arguments it actually passes — that the key reaches the plugin and never lands on the command line, that the database is pinned to the cached directory, that a keyless run falls back to the datafeed, and that the GitHub cache is saved under `always()`
+
 ### Changed
 
 - refreshed `.github/copilot-instructions.md` to list the `make test-trivy-merge` target and include Trivy merge in the `make test` aggregate description, matching the Makefile and `CLAUDE.md`
+
+### Fixed
+
+- fixed the OWASP Dependency-Check job downloading the whole NVD (~350k CVE records) on every run, which took upwards of 5h45m and had to be cancelled before it exhausted the account's CI minutes. Three defects stacked up: (1) the `NVD_API_KEY` secret was plumbed all the way to the job as an **environment variable**, which neither plugin reads — the Maven plugin wants a `nvdApiKey*` user property and the Gradle plugin wants the `dependencyCheck.nvd.apiKey` extension — so every run was silently unauthenticated and throttled to the NVD's 5-requests-per-30s anonymous limit, which is shared across every job leaving a hosted runner's IP; (2) the CVE database was never written where the pipelines cached it (Gradle's `OWASP_PATH` export was read by nothing, so the database went to `$GRADLE_USER_HOME/dependency-check-data/` while an empty `.owasp/` was cached), and Maven's data directory was smuggled in through `MAVEN_OPTS`; (3) GitHub Actions used the all-in-one `actions/cache`, whose save runs in a post-job step that is **skipped on cancellation** — so the cancelled run cached nothing and the next run started cold again, a loop the cache could never escape
+- fixed the NVD API key being passable in a way that leaks it: `-DnvdApiKey=<value>` puts the secret in the process arguments and in `mvn -X` output ([GHSA-qqhq-8r2c-c3f5](https://github.com/advisories/GHSA-qqhq-8r2c-c3f5)). The runner now passes `-DnvdApiKeyEnvironmentVariable=NVD_API_KEY`, handing the plugin the *name* of the variable so it reads the value itself
+- fixed an unexpanded Azure DevOps `$(NVD_API_KEY)` macro (what an undefined pipeline variable expands to) being forwarded to the NVD as a literal API key, which earns a 403 on every request
 
 ## [4.14.1] - 2026-07-10
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ A CI/CD pipeline templates library providing reusable workflows for **GitHub Act
 ## Commands
 
 ```bash
-make test              # Run all validation tests (Go, Lambda, YAML merge, Trivy merge, SonarQube, release tag, tftest-gen, order-check, docker-multi-arch, basic-checks)
+make test              # Run all validation tests (Go, Lambda, YAML merge, Trivy merge, SonarQube, release tag, tftest-gen, order-check, docker-multi-arch, basic-checks, dependency-check)
 make test-go-script    # Test Go validation script only
 make test-lambda       # Test Lambda template validation only
 make test-yaml-merge   # Test YAML merge validation only
@@ -20,6 +20,7 @@ make test-tftest-gen   # Test tftest-gen generator only
 make test-order-check  # Test the Terragrunt file-ordering checker/fixer only
 make test-docker-multi-arch  # Test 40-delivery/docker multi-arch contract only
 make test-basic-checks # Test basic-checks changelog validation (chlog fragments + legacy CHANGELOG.md) only
+make test-dependency-check  # Test the OWASP Dependency-Check NVD cache / API-key contract only
 make build-and-push NAME=<image> TAG=<tag>  # Build and push a container image
 ```
 
@@ -102,6 +103,18 @@ All `run.sh` scripts follow this pattern:
 | `dependency-track`                             | no tool binary — uploads the CycloneDX BOM with `curl`                              |
 
 Because the tools run directly on the host, the consuming CI job only needs the tool's own runtime dependencies (e.g. `python3` for `semgrep`, `git`/`jq`/`curl` for `gitleaks`) — not a Docker-in-Docker service.
+
+### OWASP Dependency-Check and the NVD
+
+`global/scripts/languages/java/dependency-check/run.sh` is the one runner all three platforms call for the Java `sca:dependency-check` job. Dependency-Check scans against a local H2 copy of the NVD (~350k CVE records), and **building that copy is the only expensive part of the job** — the NVD API rate limits it per source IP (5 requests/30s anonymous, 50 with a key), and hosted runners share their egress IPs, so an unauthenticated bootstrap does not finish. Three non-obvious constraints shape the design; do not "simplify" any of them away:
+
+| Constraint | Why |
+|------------|-----|
+| The API key must be passed as `-DnvdApiKeyEnvironmentVariable=NVD_API_KEY` (Maven) or written into the `dependencyCheck.nvd.apiKey` extension (Gradle) | **Neither plugin reads an `NVD_API_KEY` environment variable.** Exporting it is a no-op — the historical cause of hours-long unauthenticated runs. `-DnvdApiKey=<value>` does work but leaks the secret into `mvn -X` output ([GHSA-qqhq-8r2c-c3f5](https://github.com/advisories/GHSA-qqhq-8r2c-c3f5)), so the *variable name* is passed instead of the value |
+| Gradle is configured with `--init-script` (`init.gradle`), not properties | The Gradle plugin reads its settings **only** from the `dependencyCheck` extension — it consults neither the environment nor system properties. An init script injects them without asking every consuming project to edit its `build.gradle`. It applies on `projectsEvaluated`, so it wins over a project's own `dependencyCheck { }` block |
+| GitHub Actions uses split `actions/cache/restore` + `actions/cache/save` with `if: always()` | The all-in-one `actions/cache` saves in a post-job step that is **skipped on cancellation**. A cancelled Dependency-Check job therefore cached nothing, so the next run started cold and was cancelled again — a loop the cache could never escape |
+
+With no API key the runner falls back to NIST's gzipped JSON data feeds (`nvdDatafeedUrl`), which are not rate limited, so a keyless project still gets a usable scan. `NVD_DATAFEED_URL` overrides this with a self-hosted [`vulnz`](https://github.com/jeremylong/open-vulnerability-cli) mirror. The database is pinned to `.owasp/` (both plugins require an absolute path and otherwise default it into `~/.m2` / `$GRADLE_USER_HOME`, where the pipelines were not caching it) and reused for 24h via `nvdValidForHours`. The job is capped at 30 minutes on every platform so a pathological download is bounded rather than trusted. Covered by `.github/tests/test-dependency-check.sh`, which runs the script against a stub build tool and asserts on the argv it actually produces.
 
 ### Terra Test Tiers
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TAG := latest
 ROOT := global/containers
 CONTAINER_REGISTRY = ghcr.io/rios0rios0/pipelines
 
-.PHONY: login setup-buildx build-and-push test-go-script test-lambda test-yaml-merge test-trivy-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-docker-multi-arch test-basic-checks test
+.PHONY: login setup-buildx build-and-push test-go-script test-lambda test-yaml-merge test-trivy-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-docker-multi-arch test-basic-checks test-dependency-check test
 
 login:
 	docker login $(CONTAINER_REGISTRY)
@@ -58,5 +58,9 @@ test-basic-checks:
 	@echo "Running basic-checks changelog validation..."
 	@./.github/tests/test-basic-checks.sh
 
-test: test-go-script test-lambda test-yaml-merge test-trivy-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-docker-multi-arch test-basic-checks
+test-dependency-check:
+	@echo "Running OWASP Dependency-Check NVD cache/API-key validation..."
+	@./.github/tests/test-dependency-check.sh
+
+test: test-go-script test-lambda test-yaml-merge test-trivy-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-docker-multi-arch test-basic-checks test-dependency-check
 	@echo "All tests completed successfully!"

--- a/README.md
+++ b/README.md
@@ -620,7 +620,7 @@ Create these variable groups in Azure DevOps Library:
 | **Trivy SCA**              | Dependency vulnerability scanning | All        | `global/scripts/tools/trivy/run-sca.sh`        |
 | **govulncheck**            | Go vulnerability scanning         | Go         | `global/scripts/languages/golang/govulncheck/` |
 | **Safety**                 | Python dependency scanning        | Python     | `pdm run safety-scan`                          |
-| **OWASP Dependency-Check** | Java dependency scanning          | Java       | `./gradlew dependencyCheckAnalyze`             |
+| **OWASP Dependency-Check** | Java dependency scanning          | Java       | `global/scripts/languages/java/dependency-check/` |
 | **yarn npm audit**         | JS/Node.js dependency scanning    | JavaScript | `yarn npm audit --recursive`                   |
 | **npm audit**              | JS/Node.js dependency scanning    | JavaScript | `npm audit --audit-level=high`                 |
 | **Composer Audit**         | PHP dependency scanning           | PHP        | `composer audit`                               |
@@ -640,6 +640,31 @@ Every pipeline includes **basic checks** that run in parallel with linting durin
 
 1. **Rebase verification** — the PR/MR branch is rebased on top of the target branch (usually `main`). If the branch is behind, the pipeline fails with clear instructions to rebase. This enforces a linear commit history and prevents merge conflicts from reaching the test and delivery stages.
 2. **Changelog validation** — the `CHANGELOG.md` file was modified and new entries are placed under the `[Unreleased]` section. If entries appear below an existing version section (e.g., due to an erroneous rebase), the pipeline fails with instructions to fix the placement.
+
+### OWASP Dependency-Check and the NVD Database
+
+The Java `sca:dependency-check` job scans dependencies against a local copy of the [NVD](https://nvd.nist.gov/) (~350,000 CVE records). Building that copy is the only slow part of the job, and the NVD API rate limits it **per source IP**: 5 requests per rolling 30 seconds anonymously, 50 with an API key. Hosted CI runners share their egress IPs with every other project on the platform, so an unauthenticated first run spends most of its time in `429` backoff.
+
+**Set `NVD_API_KEY`.** Request a free key at [nvd.nist.gov/developers/request-an-api-key](https://nvd.nist.gov/developers/request-an-api-key), then expose it to the pipeline:
+
+| Platform       | How to provide it                                                                  |
+|----------------|------------------------------------------------------------------------------------|
+| GitHub Actions | Repository secret `NVD_API_KEY`; the wrapper workflows already forward it           |
+| GitLab CI      | Masked CI/CD variable `NVD_API_KEY`                                                 |
+| Azure DevOps   | Pipeline variable (or variable group) `NVD_API_KEY`                                 |
+
+Without a key the scan still works: it falls back to NIST's gzipped [JSON data feeds](https://nvd.nist.gov/vuln/data-feeds), which are not rate limited, and logs a warning. A key is still recommended — it is faster and keeps findings fresher.
+
+The database is cached at `.owasp/` on every platform and reused for 24 hours before Dependency-Check refreshes it, so the usual run is an incremental update rather than a rebuild. On GitHub Actions the cache key rotates daily and falls back to the most recent snapshot; note that a cache written on a PR branch is visible only to that branch, so the snapshot every PR restores from is the one written by the default branch. The job is capped at 30 minutes on all three platforms.
+
+Optional environment variables:
+
+| Variable                    | Default                                             | Purpose                                                              |
+|-----------------------------|-----------------------------------------------------|----------------------------------------------------------------------|
+| `NVD_API_KEY`               | *(unset)*                                           | Authenticates against the NVD API, raising the rate limit tenfold     |
+| `NVD_DATAFEED_URL`          | NIST's public feeds when no key is set              | Points at a self-hosted [`vulnz`](https://github.com/jeremylong/open-vulnerability-cli) mirror; `{0}` expands to each year |
+| `NVD_VALID_FOR_HOURS`       | `24`                                                | How long a cached database is reused before refreshing               |
+| `DEPENDENCY_CHECK_DATA_DIR` | `./.owasp`                                          | Where the CVE database lives — this is the directory to cache        |
 
 ### Language-Specific Tools
 

--- a/azure-devops/java/stages/20-security/java.yaml
+++ b/azure-devops/java/stages/20-security/java.yaml
@@ -21,23 +21,37 @@ stages:
 
         - job: 'sca_dependency_check'
           displayName: 'sca:dependency-check'
+          # Building the CVE database is the only slow path left, and it is bounded rather than
+          # trusted: the job is killed at 30 minutes so a pathological NVD download can never run for
+          # hours against the account's build minutes.
+          timeoutInMinutes: 30
           steps:
             - template: '../../abstracts/gradle.yaml'
-            - script: echo "##vso[task.setvariable variable=WEEK_NUMBER]$(date +%Y-%W)"
-              displayName: 'Get current week number'
+            - template: '../../../global/abstracts/scripts-repo.yaml'
+            # The key rotates daily so the stored snapshot cannot go stale forever, while restoreKeys
+            # falls back to the most recent snapshot on any other day, making the usual run an
+            # incremental update rather than a rebuild.
+            - script: echo "##vso[task.setvariable variable=NVD_CACHE_DATE]$(date -u +%Y-%m-%d)"
+              displayName: 'Get current date'
             - task: 'Cache@2'
               inputs:
-                key: "$(Agent.JobName)|owasp-nvd|$(WEEK_NUMBER)"
+                key: "owasp-nvd|$(Agent.OS)|$(NVD_CACHE_DATE)"
                 restoreKeys: |
-                  $(Agent.JobName)|owasp-nvd
+                  owasp-nvd|$(Agent.OS)
                 path: '.owasp'
               displayName: 'Cache NVD database'
               continueOnError: true
-            - script: |
-                mkdir -p '.owasp'
-                export OWASP_PATH="$(pwd)/.owasp"
-                ./gradlew dependencyCheckAnalyze
+            # NVD_API_KEY is optional but strongly recommended: define it as a pipeline variable to get
+            # the authenticated NVD rate limit. Without it the scan falls back to the NVD datafeed —
+            # the script's header explains why the unauthenticated API is not usable on shared agents.
+            - script: $(Scripts.Directory)/global/scripts/languages/java/dependency-check/run.sh
               displayName: 'Run OWASP Dependency-Check'
               env:
                 NVD_API_KEY: $(NVD_API_KEY)
+            - task: 'PublishPipelineArtifact@1'
+              inputs:
+                artifactName: 'dependency-check'
+                targetPath: 'build/reports/dependency-check'
+              displayName: 'Upload Report'
+              condition: always()
           continueOnError: true

--- a/github/java/stages/20-security/dependency-check/action.yaml
+++ b/github/java/stages/20-security/dependency-check/action.yaml
@@ -1,0 +1,89 @@
+inputs:
+  nvd_api_key:
+    description: 'NVD API key (https://nvd.nist.gov/developers/request-an-api-key). Without one the scan falls back to the NVD datafeed'
+    required: false
+    default: ''
+  nvd_datafeed_url:
+    description: "NVD datafeed to use instead of the API, e.g. a self-hosted 'vulnz' mirror ('{0}' expands to each year)"
+    required: false
+    default: ''
+  nvd_valid_for_hours:
+    description: 'How long a cached CVE database is reused before Dependency-Check refreshes it'
+    required: false
+    default: '24'
+  java_version:
+    description: 'Java version used to run the build tool'
+    required: false
+    default: '21'
+  build_tool:
+    description: "Dependency cache to prime through actions/setup-java: 'maven' or 'gradle'"
+    required: false
+    default: 'maven'
+
+runs:
+  using: 'composite'
+  steps:
+    # Checkout has to precede the cache restore: it cleans the workspace, which would take the
+    # restored CVE database with it.
+    - name: 'Checkout code'
+      uses: 'actions/checkout@v6'
+
+    - name: 'Setup Java'
+      uses: 'actions/setup-java@v5'
+      with:
+        distribution: 'temurin'
+        java-version: ${{ inputs.java_version }}
+        cache: ${{ inputs.build_tool }}
+
+    - name: 'Get Scripts'
+      uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
+
+    - name: 'Get current date'
+      id: 'date'
+      shell: 'bash'
+      run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+    # Restore and save are split deliberately. The all-in-one `actions/cache` only writes its cache in
+    # a post-job step that is skipped when the job is cancelled or fails -- so a Dependency-Check job
+    # that gets killed mid-download (the failure mode this job was stuck in) never persisted a single
+    # byte, and every subsequent run started from an empty database again. Saving explicitly with
+    # `always()` breaks that loop: whatever the run managed to download is kept and the next run
+    # resumes from it.
+    #
+    # The key rotates daily so the stored snapshot cannot go stale forever, while `restore-keys` falls
+    # back to the most recent snapshot on any other day, making the usual run an incremental update.
+    # Note that a cache written on a PR branch is only visible to that branch -- the snapshot every PR
+    # restores from is the one written by the default branch.
+    - name: 'Restore NVD database'
+      id: 'restore_nvd'
+      uses: 'actions/cache/restore@v4'
+      with:
+        path: '.owasp'
+        key: "owasp-nvd-${{ runner.os }}-${{ steps.date.outputs.date }}"
+        restore-keys: |
+          owasp-nvd-${{ runner.os }}-
+
+    - name: 'Run OWASP Dependency-Check'
+      shell: 'bash'
+      run: $SCRIPTS_DIR/global/scripts/languages/java/dependency-check/run.sh
+      env:
+        NVD_API_KEY: ${{ inputs.nvd_api_key }}
+        NVD_DATAFEED_URL: ${{ inputs.nvd_datafeed_url }}
+        NVD_VALID_FOR_HOURS: ${{ inputs.nvd_valid_for_hours }}
+
+    - name: 'Save NVD database'
+      uses: 'actions/cache/save@v4'
+      with:
+        path: '.owasp'
+        key: "owasp-nvd-${{ runner.os }}-${{ steps.date.outputs.date }}"
+      if: "always() && steps.restore_nvd.outputs.cache-hit != 'true'"
+
+    - name: 'Upload Report'
+      uses: 'actions/upload-artifact@v7'
+      with:
+        name: 'dependency-check'
+        path: 'build/reports/dependency-check/'
+        if-no-files-found: 'warn'
+        overwrite: 'true'
+        retention-days: 10
+      if: always()

--- a/gitlab/java/stages/20-security/gradle.yaml
+++ b/gitlab/java/stages/20-security/gradle.yaml
@@ -6,6 +6,7 @@ variables:
 
 include:
   - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/abstracts/default-variables.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/abstracts/scripts-repo.yaml'
   - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/20-security/semgrep.yaml'
   - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/20-security/gitleaks.yaml'
   - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/20-security/codeql.yaml'
@@ -16,18 +17,25 @@ include:
 sca:dependency-check:
   extends: '.dependency-check'
   stage: 'security (sca/sast)'
+  before_script:
+    # `.scripts-repo` clones this repository, so the job needs git. The gradle image is Alpine-based;
+    # install it only when it is genuinely missing, so an image that already ships it is left alone.
+    - command -v git > /dev/null 2>&1 || apk add --no-cache git
+    - !reference [ .gradle, before_script ]
+    - !reference [ .scripts-repo, before_script ]
   script:
-    - mkdir -p '.owasp'
-    - export OWASP_PATH="$(pwd)/.owasp" # the Dependency Check data path must be absolute
-    # NVD_API_KEY is optional — set it as a CI/CD variable to avoid NVD rate limits
-    - gradle dependencyCheckAnalyze
+    # NVD_API_KEY is optional but strongly recommended: set it as a CI/CD variable to get the
+    # authenticated NVD rate limit. Without it the scan falls back to the NVD datafeed — the script's
+    # header explains why the unauthenticated API is not a usable option on shared runners.
+    - $SCRIPTS_DIR/global/scripts/languages/java/dependency-check/run.sh
   artifacts:
     when: 'always'
     paths:
-      - "$PREFIX$REPORT_PATH/dependency-check-report.html"
+      - "$PREFIX$REPORT_PATH/dependency-check/"
     reports:
       dependency_scanning:
-        - "$PREFIX$REPORT_PATH/dependency-check-report.xml"
+        - "$PREFIX$REPORT_PATH/dependency-check/dependency-check-report.xml"
+  timeout: '30 minutes'
   allow_failure: true
 
 # TODO: check this https://gitlab.com/gitlab-org/gitlab/-/issues/299363

--- a/gitlab/java/stages/20-security/maven.yaml
+++ b/gitlab/java/stages/20-security/maven.yaml
@@ -4,6 +4,7 @@ variables:
 
 include:
   - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/abstracts/default-variables.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/abstracts/scripts-repo-debian.yaml'
   - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/2-security.yaml'
   - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/20-security/codeql.yaml'
   - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/20-security/hadolint.yaml'
@@ -17,14 +18,18 @@ sca:dependency-check:
   cache:
     paths: # this list can't be merged. It's not how YAML works (https://github.com/yaml/yaml/issues/48)
       - '.m2'
-      - '.owasp'
+      - '.owasp' # the H2 copy of the NVD — rebuilding it is the only slow part of this job
+  before_script:
+    - !reference [ .maven, before_script ]
+    - !reference [ .scripts-repo-debian, before_script ]
   script:
-    - mkdir -p '.owasp'
-    - export MAVEN_OPTS="$MAVEN_OPTS -DdataDirectory=$(pwd)/.owasp" # the Dependency Check data path must be absolute
-    # NVD_API_KEY is optional — set it as a CI/CD variable to avoid NVD rate limits
-    - mvn dependency-check:check
+    # NVD_API_KEY is optional but strongly recommended: set it as a CI/CD variable to get the
+    # authenticated NVD rate limit. Without it the scan falls back to the NVD datafeed — the script's
+    # header explains why the unauthenticated API is not a usable option on shared runners.
+    - $SCRIPTS_DIR/global/scripts/languages/java/dependency-check/run.sh
   artifacts:
     when: 'always'
     paths:
-      - "$REPORT_PATH/dependency-check-report.html"
+      - "$REPORT_PATH/dependency-check/"
+  timeout: '30 minutes'
   allow_failure: true

--- a/global/scripts/languages/java/dependency-check/init.gradle
+++ b/global/scripts/languages/java/dependency-check/init.gradle
@@ -1,0 +1,51 @@
+// Injected by global/scripts/languages/java/dependency-check/run.sh through `gradle --init-script`.
+//
+// The dependency-check Gradle plugin reads its NVD settings only from the `dependencyCheck` extension:
+// unlike the Maven plugin it has no user properties and consults neither the environment nor system
+// properties. Configuring it from CI therefore means either editing every consuming project's
+// build.gradle or writing the settings into the extension from the outside -- this is the latter.
+//
+// `projectsEvaluated` fires once every build script has run, so these values win over any
+// `dependencyCheck { }` block a project declares for local use.
+
+gradle.projectsEvaluated { instance ->
+    instance.rootProject.allprojects { project ->
+        def extension = project.extensions.findByName('dependencyCheck')
+        if (extension == null) {
+            return
+        }
+
+        def dataDirectory = System.getenv('DEPENDENCY_CHECK_DATA_DIR')
+        if (dataDirectory) {
+            extension.data.directory = dataDirectory
+        }
+
+        def reportDirectory = System.getenv('DEPENDENCY_CHECK_REPORT_DIR')
+        if (reportDirectory) {
+            extension.outputDirectory = reportDirectory
+            extension.format = 'ALL'
+        }
+
+        def apiKey = System.getenv('NVD_API_KEY')
+        if (apiKey) {
+            extension.nvd.apiKey = apiKey
+        }
+
+        // Set by run.sh to NIST's public feeds whenever no API key is available, so that a keyless
+        // project downloads a handful of gzipped files instead of walking into the rate-limited API.
+        def datafeedUrl = System.getenv('NVD_DATAFEED_URL')
+        if (datafeedUrl) {
+            extension.nvd.datafeedUrl = datafeedUrl
+        }
+
+        def validForHours = System.getenv('NVD_VALID_FOR_HOURS')
+        if (validForHours) {
+            extension.nvd.validForHours = validForHours.toInteger()
+        }
+
+        project.logger.lifecycle(
+                "dependency-check: data=${dataDirectory}, " +
+                "nvdApiKey=${apiKey ? 'present' : 'absent'}, " +
+                "nvdDatafeedUrl=${datafeedUrl ?: 'none (using the NVD API)'}")
+    }
+}

--- a/global/scripts/languages/java/dependency-check/run.sh
+++ b/global/scripts/languages/java/dependency-check/run.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env sh
+# OWASP Dependency-Check runner shared by the GitHub Actions, GitLab CI and Azure DevOps Java pipelines.
+#
+# Dependency-Check resolves findings against a local H2 copy of the NVD (~350k CVE records). Building
+# that copy is the expensive part, and the NVD API rate limits it *per source IP*: 5 requests per
+# rolling 30s unauthenticated, 50 with an API key. Hosted CI runners share their egress IPs with every
+# other project on the platform, so an unauthenticated bootstrap spends most of its time in 429 backoff
+# and does not finish in a usable amount of time (~174 pages, observed at 5h+ and still climbing).
+#
+# Three things keep that from happening here:
+#
+#   1. The API key reaches the tool. Neither plugin picks NVD_API_KEY up from the environment on its
+#      own -- Maven wants a `nvdApiKey*` user property, Gradle wants the `dependencyCheck.nvd.apiKey`
+#      extension -- so exporting the variable alone is a no-op. Maven is handed the *name* of the
+#      variable rather than its value: `-DnvdApiKey=...` would land the secret in `mvn -X` output
+#      (GHSA-qqhq-8r2c-c3f5), and `-DnvdApiKeyEnvironmentVariable` exists for exactly this reason.
+#
+#   2. With no key, the NVD datafeed replaces the API. The feeds are a handful of gzipped JSON files
+#      with no rate limit, so a keyless project still gets a usable scan instead of a hung job.
+#
+#   3. The database is pinned to one absolute, cacheable directory. The plugins otherwise default it
+#      into ~/.m2 and $GRADLE_USER_HOME respectively, where the pipelines were not caching it.
+#
+# Environment:
+#   NVD_API_KEY               NVD API key -- https://nvd.nist.gov/developers/request-an-api-key
+#   NVD_DATAFEED_URL          NVD datafeed to use instead of the API; '{0}' expands to each year
+#   NVD_VALID_FOR_HOURS       how long a cached database is reused before refreshing (default 24)
+#   DEPENDENCY_CHECK_DATA_DIR where the H2 database lives (default ./.owasp) -- this is what to cache
+
+set -e
+
+if [ -z "$SCRIPTS_DIR" ]; then
+  SCRIPTS_DIR="$(echo "$(dirname "$(realpath "$0")")" | sed 's|\(.*pipelines\).*|\1|')"
+  export SCRIPTS_DIR
+fi
+TOOL_NAME="dependency-check" . "$SCRIPTS_DIR/global/scripts/shared/cleanup.sh"
+
+# NIST's own JSON 2.0 feeds. Dependency-Check reconstructs the cache metadata from the `.meta` files
+# these ship, so no self-hosted mirror is needed; point NVD_DATAFEED_URL at a `vulnz` mirror to use one.
+DEFAULT_DATAFEED_URL='https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-{0}.json.gz'
+
+# Both plugins reject a relative data directory.
+dataDirectory="${DEPENDENCY_CHECK_DATA_DIR:-$(pwd)/.owasp}"
+case "$dataDirectory" in
+  /*) ;;
+  *) dataDirectory="$(pwd)/$dataDirectory" ;;
+esac
+mkdir -p "$dataDirectory"
+
+reportDirectory="$(pwd)/$REPORT_PATH"
+validForHours="${NVD_VALID_FOR_HOURS:-24}"
+datafeedUrl="${NVD_DATAFEED_URL:-}"
+
+# Azure DevOps substitutes nothing for an undefined variable: `$(NVD_API_KEY)` arrives verbatim. Left
+# alone it would be handed to the NVD as a key, earning 403s on every request -- worse than having no
+# key at all, because the datafeed fallback below would never engage.
+case "${NVD_API_KEY:-}" in
+  '$('*) NVD_API_KEY='' ;;
+esac
+case "${NVD_DATAFEED_URL:-}" in
+  '$('*) datafeedUrl='' ;;
+esac
+export NVD_API_KEY
+
+if [ -n "${NVD_API_KEY:-}" ]; then
+  echo "NVD API key found: updating over the authenticated NVD API (50 requests / 30s)."
+else
+  if [ -z "$datafeedUrl" ]; then
+    datafeedUrl="$DEFAULT_DATAFEED_URL"
+  fi
+  echo "WARNING: NVD_API_KEY is not set."
+  echo "WARNING: falling back to the NVD datafeed at $datafeedUrl."
+  echo "WARNING: the unauthenticated NVD API is limited to 5 requests / 30s shared across every job"
+  echo "WARNING: leaving this runner's IP, which is why a keyless API bootstrap does not finish."
+  echo "WARNING: request a free key at https://nvd.nist.gov/developers/request-an-api-key and expose"
+  echo "WARNING: it to this job as the NVD_API_KEY secret for faster and fresher scans."
+fi
+
+echo "Dependency-Check CVE database: $dataDirectory (reused for $validForHours hours before refreshing)."
+
+runMaven() {
+  # `nvdApiKeyEnvironmentVariable` passes the *name* of the variable, keeping the key itself out of the
+  # process arguments and out of `mvn -X` output.
+  set -- \
+    '--batch-mode' \
+    '--no-transfer-progress' \
+    'org.owasp:dependency-check-maven:check' \
+    "-DdataDirectory=$dataDirectory" \
+    "-Dodc.outputDirectory=$reportDirectory" \
+    '-Dformat=ALL' \
+    "-DnvdValidForHours=$validForHours"
+
+  if [ -n "${NVD_API_KEY:-}" ]; then
+    set -- "$@" '-DnvdApiKeyEnvironmentVariable=NVD_API_KEY'
+  fi
+  if [ -n "$datafeedUrl" ]; then
+    set -- "$@" "-DnvdDatafeedUrl=$datafeedUrl"
+  fi
+
+  mvn "$@"
+}
+
+runGradle() {
+  gradleCommand='gradle'
+  if [ -x './gradlew' ]; then
+    gradleCommand='./gradlew'
+  fi
+
+  # The Gradle plugin reads its settings only from the `dependencyCheck` extension -- it ignores every
+  # environment variable and system property. An init script writes them in without asking each
+  # consuming project to edit its build.gradle.
+  DEPENDENCY_CHECK_DATA_DIR="$dataDirectory" \
+  DEPENDENCY_CHECK_REPORT_DIR="$reportDirectory" \
+  NVD_DATAFEED_URL="$datafeedUrl" \
+  NVD_VALID_FOR_HOURS="$validForHours" \
+    "$gradleCommand" \
+    --init-script "$SCRIPTS_DIR/global/scripts/languages/java/dependency-check/init.gradle" \
+    dependencyCheckAnalyze
+}
+
+if [ -f 'pom.xml' ]; then
+  runMaven
+elif [ -f 'gradlew' ] || [ -f 'build.gradle' ] || [ -f 'build.gradle.kts' ]; then
+  runGradle
+else
+  echo "ERROR: no 'pom.xml' and no Gradle build script found in $(pwd)."
+  echo "ERROR: Dependency-Check runs against a Maven or Gradle project."
+  exit 1
+fi


### PR DESCRIPTION
## Problem

`sca:dependency-check` downloaded all ~350,000 NVD records on **every** run. The [reported run](https://github.com/rios0rios0/rest-arch/actions/runs/29241981157/job/86789992436?pr=80) reached **5h45m** and was still at 58% when it had to be cancelled to stop it burning the account's Actions minutes.

Cancelling it was also what kept it broken: it made the cache impossible to prime.

## Root causes

Three defects stacked up. Each one alone would have been survivable; together they made the job unable to ever succeed.

**1. The API key never reached the tool.** The `NVD_API_KEY` secret was plumbed correctly all the way to the job — and then handed over as an **environment variable**, which *neither plugin reads*. The Maven plugin takes a `nvdApiKey*` user property; the Gradle plugin reads `dependencyCheck.nvd.apiKey` from its extension. So every run was silently unauthenticated, throttled to the NVD's anonymous **5 requests / 30s** — a budget shared across *every job leaving that runner's IP*. That is why ~174 pages took hours rather than minutes.

**2. The database wasn't in the directory being cached.** Gradle's `export OWASP_PATH=...` was read by nothing (the plugin has no such setting), so the database went to `$GRADLE_USER_HOME/dependency-check-data/` while an **empty `.owasp/`** was faithfully cached. Maven's data directory was smuggled in through `MAVEN_OPTS`, relying on a system-property fallback rather than the real `-DdataDirectory` property.

**3. The cache could never be written.** GitHub Actions used the all-in-one `actions/cache`, whose save runs in a post-job step that is **skipped on cancellation**. The cancelled run cached nothing → the next run started cold → it was cancelled too. A loop the cache could never escape.

## The fix

One shared runner, `global/scripts/languages/java/dependency-check/run.sh`, now backs all three platforms:

| | Before | After |
|---|---|---|
| API key | `env: NVD_API_KEY` (ignored by both plugins) | `-DnvdApiKeyEnvironmentVariable=NVD_API_KEY` / `nvd.apiKey` extension |
| No key at all | ~174 throttled API pages → hours | NIST's gzipped data feeds → no rate limit |
| Database location | `~/.m2` / `$GRADLE_USER_HOME` (uncached) | `.owasp/`, absolute, cached |
| Cache on cancel/fail | lost | saved under `always()` |
| Worst case runtime | unbounded (5h45m observed) | capped at 30 min on all 3 platforms |

The key is passed by **variable name, not value**: `-DnvdApiKey=<value>` works, but puts the secret into `mvn -X` output ([GHSA-qqhq-8r2c-c3f5](https://github.com/advisories/GHSA-qqhq-8r2c-c3f5)). Gradle is configured via a shipped `init.gradle` applied with `--init-script`, because that plugin reads settings *only* from its extension — **consuming projects need no `build.gradle` change**.

Also fixed: an undefined Azure DevOps variable expands to the literal string `$(NVD_API_KEY)`, which was being forwarded to the NVD as an API key (earning a 403 on every request). It is now treated as absent.

## Action required by consumers

**Set an `NVD_API_KEY` secret** — request a free one at [nvd.nist.gov](https://nvd.nist.gov/developers/request-an-api-key). The wrapper workflows already forward it. Without a key the scan still works (via the data feeds) and logs a warning, but a key is faster and keeps findings fresher.

## Testing

`.github/tests/test-dependency-check.sh` (40 assertions, wired into `make test`) runs the script against a **stub build tool** and asserts on the argv it actually produces — so it verifies what the plugin is really told, not what the YAML looks like. It covers: the key reaching the plugin and never landing on the command line, the database being pinned to the cached directory, the keyless datafeed fallback, the Azure macro guard, and the `always()` cache save.

Mutation-checked: reintroducing the `-DnvdApiKey=<value>` leak makes exactly the 3 relevant assertions fail.

Verified locally: ShellCheck clean at CI severity, all 292 YAML files valid under CI's loader, and every `make test` target passing. (`test-go-script`, `test-yaml-merge` and `test-docker-multi-arch` fail identically on pristine `main` on this machine — they need CI's `mikefarah/yq` and a runner-specific path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)