### PR TITLE
fix(goreleaser): detected the main package with the Go toolchain

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,7 @@ This repository provides comprehensive SDLC pipeline templates for GitHub Action
 - `make test-docker-multi-arch` - Test 40-delivery/docker multi-arch contract specifically
 - `make test-basic-checks` - Test basic-checks changelog validation (chlog fragments + legacy CHANGELOG.md) specifically
 - `make test-dependency-check` - Test the OWASP Dependency-Check NVD cache / API-key contract specifically
+- `make test-goreleaser-prepare` - Test the GoReleaser main package detection specifically
 - `bash global/scripts/shared/cleanup.sh` - Clean up build reports
 - `docker --version && make --version && go version` - Check dependencies
 
@@ -655,6 +656,7 @@ make test-order-check
 make test-docker-multi-arch
 make test-basic-checks
 make test-dependency-check
+make test-goreleaser-prepare
 ```
 
 Test scripts are located in `.github/tests/`.

--- a/.github/tests/test-goreleaser-prepare.sh
+++ b/.github/tests/test-goreleaser-prepare.sh
@@ -46,6 +46,21 @@ func main() {}
 EOF
 }
 
+# Same, but with the package clause written verbatim, so the fallback's reading
+# of it can be exercised against every shape the compiler accepts.
+write_main_package_with_clause() {
+  local dir="$1"
+  local clause="$2"
+  mkdir -p "$dir"
+  printf '%s\n\nfunc main() {}\n' "$clause" > "$dir/main.go"
+}
+
+write_main_package_with_crlf() {
+  local dir="$1"
+  mkdir -p "$dir"
+  printf 'package main\r\n\r\nfunc main() {}\r\n' > "$dir/main.go"
+}
+
 # A package whose *test* embeds a whole sample program as a fixture. This is the
 # shape that broke autobump: both `package main` and `func main()` appear in the
 # file, but only inside a raw string literal.
@@ -155,6 +170,32 @@ PROJECT="$(new_project 'fixture-only')"
 write_package_with_embedded_program "$PROJECT/internal/domain/commands"
 assert_main "never treats a fixture's embedded program as the entry point" \
   '.' "$(generated_main "$PROJECT" 'fixture-only')"
+
+# The next three drop go.mod so the toolchain cannot be used and the fallback's
+# reading of the package clause is what is under test. A clause the compiler
+# accepts must be recognized — otherwise detection silently reports "no main
+# package" and releases the repository root, which is the failure this whole
+# script exists to prevent.
+PROJECT="$(new_project 'clause-comment')"
+rm "$PROJECT/go.mod"
+write_main_package_with_clause "$PROJECT/cmd/clause-comment" 'package main // entry point'
+assert_main "accepts a package clause carrying a trailing comment" \
+  './cmd/clause-comment' "$(generated_main "$PROJECT" 'clause-comment')"
+
+PROJECT="$(new_project 'clause-crlf')"
+rm "$PROJECT/go.mod"
+write_main_package_with_crlf "$PROJECT/cmd/clause-crlf"
+assert_main "accepts a package clause with CRLF line endings" \
+  './cmd/clause-crlf' "$(generated_main "$PROJECT" 'clause-crlf')"
+
+# ...but the clause still has to be `main` and not merely start with it: without
+# a boundary after the package name, `package maintenance` reads as an entry
+# point, and the tree below has no real one to fall back to.
+PROJECT="$(new_project 'boundary')"
+rm "$PROJECT/go.mod"
+write_main_package_with_clause "$PROJECT/internal/maintenance" 'package maintenance'
+assert_main "does not read package maintenance as package main" \
+  '.' "$(generated_main "$PROJECT" 'boundary')"
 
 # A project shipping its own config must be left exactly as it is.
 PROJECT="$(new_project 'owned')"

--- a/.github/tests/test-goreleaser-prepare.sh
+++ b/.github/tests/test-goreleaser-prepare.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Regression test for global/scripts/languages/golang/goreleaser/prepare.sh.
+#
+# The script chooses the package GoReleaser builds. It used to do that with
+# `grep -rl "^func main()" | head -1` — a text search that cannot tell a real
+# entry point apart from a `func main()` sitting inside a raw string literal. In
+# a repository whose tests build sample programs as fixtures it therefore picked
+# the test's package, and the delivery stage failed with "does not contain a main
+# function" *after* the release stage had already published the tag and the
+# GitHub Release, leaving a version with no binaries attached to it.
+#
+# Runs the real script against fixture project trees and asserts on the `main:`
+# entry it writes into .goreleaser.yaml.
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PREPARE="$REPO_ROOT/global/scripts/languages/golang/goreleaser/prepare.sh"
+WORKSPACE="$(mktemp -d)"
+trap 'rm -rf "$WORKSPACE"' EXIT
+
+export SCRIPTS_DIR="$REPO_ROOT"
+export GOTOOLCHAIN='local' # keep the fixtures hermetic: never download a toolchain
+
+new_project() {
+  local name="$1"
+  local dir="$WORKSPACE/$name"
+  mkdir -p "$dir"
+  printf 'module example.com/%s\n\ngo 1.21\n' "$name" > "$dir/go.mod"
+  printf '%s' "$dir"
+}
+
+write_main_package() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat > "$dir/main.go" << 'EOF'
+package main
+
+func main() {}
+EOF
+}
+
+# A package whose *test* embeds a whole sample program as a fixture. This is the
+# shape that broke autobump: both `package main` and `func main()` appear in the
+# file, but only inside a raw string literal.
+write_package_with_embedded_program() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat > "$dir/commands.go" << 'EOF'
+package commands
+
+func UpdateVersion() {}
+EOF
+  cat > "$dir/update_version_test.go" << 'EOF'
+package commands
+
+import "testing"
+
+func TestUpdateSwaggerVersion(t *testing.T) {
+	mainGoContent := `package main
+
+// @title Example API
+// @version 1.2.3
+func main() {}
+`
+	if mainGoContent == "" {
+		t.Fatal("unreachable")
+	}
+}
+EOF
+}
+
+# Reads back the package GoReleaser was told to build.
+configured_main() {
+  sed -n "s/^[[:space:]]*-[[:space:]]*main:[[:space:]]*'\(.*\)'[[:space:]]*\$/\1/p" "$1/.goreleaser.yaml" | head -1
+}
+
+# Runs the real script inside a project and echoes the `main:` it generated.
+generated_main() {
+  local dir="$1"
+  shift
+  (cd "$dir" && "$PREPARE" "$@" > /dev/null)
+  configured_main "$dir"
+}
+
+assert_main() {
+  local description="$1"
+  local expected="$2"
+  local actual="$3"
+
+  if [ "$actual" = "$expected" ]; then
+    echo -e "${GREEN}PASS${NC} $description"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}FAIL${NC} $description (expected='$expected', actual='$actual')"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+echo "=== GoReleaser main package detection ==="
+
+# The regression itself: `internal/` is walked before `cmd/`, so a `head -1` text
+# search picks the test fixture and never even sees the real entry point.
+PROJECT="$(new_project 'autobump')"
+write_main_package "$PROJECT/cmd/autobump"
+write_package_with_embedded_program "$PROJECT/internal/domain/commands"
+assert_main "ignores a func main() embedded in a test fixture" \
+  './cmd/autobump' "$(generated_main "$PROJECT" 'autobump')"
+
+# The same tree without a go.mod, so the toolchain cannot be used and the text
+# search runs as a fallback. It must reach the same conclusion.
+PROJECT="$(new_project 'autobump-no-module')"
+rm "$PROJECT/go.mod"
+write_main_package "$PROJECT/cmd/autobump"
+write_package_with_embedded_program "$PROJECT/internal/domain/commands"
+assert_main "ignores the fixture in the fallback text search too" \
+  './cmd/autobump' "$(generated_main "$PROJECT" 'autobump')"
+
+PROJECT="$(new_project 'rooted')"
+write_main_package "$PROJECT"
+assert_main "detects a main package at the repository root" \
+  '.' "$(generated_main "$PROJECT" 'rooted')"
+
+PROJECT="$(new_project 'multi')"
+write_main_package "$PROJECT/cmd/api"
+write_main_package "$PROJECT/cmd/worker"
+assert_main "prefers the main package named after the binary" \
+  './cmd/worker' "$(generated_main "$PROJECT" 'worker')"
+
+PROJECT="$(new_project 'pinned')"
+write_main_package "$PROJECT/cmd/pinned"
+assert_main "honours an explicit binary path" \
+  './cmd/pinned' "$(generated_main "$PROJECT" 'pinned' './cmd/pinned')"
+
+PROJECT="$(new_project 'unprefixed')"
+write_main_package "$PROJECT/cmd/unprefixed"
+assert_main "normalizes an explicit path given without a ./ prefix" \
+  './cmd/unprefixed' "$(generated_main "$PROJECT" 'unprefixed' 'cmd/unprefixed')"
+
+PROJECT="$(new_project 'headless')"
+assert_main "falls back to the root when there is no main package" \
+  '.' "$(generated_main "$PROJECT" 'headless')"
+
+# No real entry point anywhere, only the sample program embedded in a fixture.
+# The embedded program is the sole `func main()` in the tree, so a text search
+# cannot help but select it — which pins the bug independently of the order the
+# filesystem happens to hand directories back in.
+PROJECT="$(new_project 'fixture-only')"
+write_package_with_embedded_program "$PROJECT/internal/domain/commands"
+assert_main "never treats a fixture's embedded program as the entry point" \
+  '.' "$(generated_main "$PROJECT" 'fixture-only')"
+
+# A project shipping its own config must be left exactly as it is.
+PROJECT="$(new_project 'owned')"
+write_main_package "$PROJECT/cmd/owned"
+printf "version: 2\nproject_name: 'owned'\nbuilds:\n  - main: './cmd/custom'\n" > "$PROJECT/.goreleaser.yaml"
+(cd "$PROJECT" && "$PREPARE" 'owned' > /dev/null)
+assert_main "keeps a project's own .goreleaser.yaml" \
+  './cmd/custom' "$(configured_main "$PROJECT")"
+
+echo ""
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+[ "$TESTS_FAILED" -eq 0 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `.github/tests/test-goreleaser-prepare.sh` (wired into `make test`, and listed in `CLAUDE.md` and `.github/copilot-instructions.md` alongside the other targets), which runs `prepare.sh` against fixture project trees and asserts on the `main:` it writes: that an entry point embedded in a test fixture is never selected (with and without the Go toolchain available), that a root-level `main` package resolves to `.`, that the binary's own `cmd/<name>` wins when a repository ships several, that an explicit `binary_path` is honoured and normalized, and that a project's own `.goreleaser.yaml` is left untouched
+
+### Fixed
+
+- fixed the `delivery:binary` job selecting the wrong package to build, which fails GoReleaser with `build for <name> does not contain a main function` — and does so *after* the release job has already published the tag and the GitHub Release, so the version stays up with no binaries attached to it and nothing to download or self-update from. When a consumer does not pin `binary_path`, `global/scripts/languages/golang/goreleaser/prepare.sh` located the entry point with `grep -rl "^func main()" --include="*.go" . | head -1`. That search is textual: it does not skip `_test.go`, does not read the package clause, and cannot tell that a match sits inside a raw string literal — so in a repository whose tests build sample Go programs as fixtures it matched the fixture, and since `grep -r` walks `internal/` before `cmd/`, `head -1` returned it and the real entry point was never even considered ([autobump#271](https://github.com/rios0rios0/autobump/pull/271) shows the failure: `Auto-detected main package at: ././internal/domain/commands`). Detection now asks the Go toolchain which packages are actually `main` (`go list -e -f '{{if eq .Name "main"}}{{.Dir}}{{end}}' ./...`), which reads the package clause and ignores tests and `testdata/`; when several exist, the one named after the binary is released, so a repository shipping `./cmd/api` and `./cmd/worker` no longer gets whichever sorted first. The text search is kept only as a fallback for when the toolchain is unavailable, and is now strict: `_test.go`, `testdata/` and `vendor/` are skipped and the file must actually declare `package main`
+- fixed the generated `main:` being malformed even when detection happened to pick the right directory: it was built as `"./$(dirname "$DETECTED")"` over a path that already began with `./`, emitting `././cmd/app`, and a root-level entry point came out as `./.`. Paths are now normalized to the `./path` form GoReleaser expects, with the project root collapsing to `.`, and an explicitly passed `binary_path` is normalized the same way so that `cmd/app` and `./cmd/app` behave identically
+- fixed `prepare.sh` aborting with `SCRIPTS_DIR: unbound variable` when run outside the pipeline: the script runs under `set -u`, so the `[ -z "$SCRIPTS_DIR" ]` guard that was meant to derive the directory when the caller had not exported it could only ever crash, leaving its fallback unreachable
+
 ## [4.15.0] - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Added
 
-- added `.github/tests/test-goreleaser-prepare.sh` (wired into `make test`, and listed in `CLAUDE.md` and `.github/copilot-instructions.md` alongside the other targets), which runs `prepare.sh` against fixture project trees and asserts on the `main:` it writes: that an entry point embedded in a test fixture is never selected (with and without the Go toolchain available), that a root-level `main` package resolves to `.`, that the binary's own `cmd/<name>` wins when a repository ships several, that an explicit `binary_path` is honoured and normalized, and that a project's own `.goreleaser.yaml` is left untouched
+- added `.github/tests/test-goreleaser-prepare.sh` (wired into `make test`, and listed in `CLAUDE.md` and `.github/copilot-instructions.md` alongside the other targets), which runs `prepare.sh` against fixture project trees and asserts on the `main:` it writes: that an entry point embedded in a test fixture is never selected (with and without the Go toolchain available), that a root-level `main` package resolves to `.`, that the binary's own `cmd/<name>` wins when a repository ships several, that an explicit `binary_path` is honoured and normalized, that the fallback reads every package clause the compiler accepts — a trailing comment, a CRLF line ending — without mistaking `package maintenance` for one, and that a project's own `.goreleaser.yaml` is left untouched
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ make test-order-check  # Test the Terragrunt file-ordering checker/fixer only
 make test-docker-multi-arch  # Test 40-delivery/docker multi-arch contract only
 make test-basic-checks # Test basic-checks changelog validation (chlog fragments + legacy CHANGELOG.md) only
 make test-dependency-check  # Test the OWASP Dependency-Check NVD cache / API-key contract only
+make test-goreleaser-prepare  # Test the GoReleaser main package detection only
 make build-and-push NAME=<image> TAG=<tag>  # Build and push a container image
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -62,5 +62,9 @@ test-dependency-check:
 	@echo "Running OWASP Dependency-Check NVD cache/API-key validation..."
 	@./.github/tests/test-dependency-check.sh
 
-test: test-go-script test-lambda test-yaml-merge test-trivy-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-docker-multi-arch test-basic-checks test-dependency-check
+test-goreleaser-prepare:
+	@echo "Running GoReleaser main package detection validation..."
+	@./.github/tests/test-goreleaser-prepare.sh
+
+test: test-go-script test-lambda test-yaml-merge test-trivy-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-docker-multi-arch test-basic-checks test-dependency-check test-goreleaser-prepare
 	@echo "All tests completed successfully!"

--- a/global/scripts/languages/golang/goreleaser/prepare.sh
+++ b/global/scripts/languages/golang/goreleaser/prepare.sh
@@ -41,7 +41,11 @@ list_main_dirs_with_go() {
 
 # Fallback for when the Go toolchain is unavailable. Still far stricter than a
 # bare `func main()` search: test files, `testdata/` and `vendor/` are skipped,
-# and the file must actually declare `package main`.
+# and the file must actually declare `package main` — in any shape the compiler
+# accepts, so padding, a CRLF line ending and a trailing comment all count, while
+# `package maintenance` does not. The clause has to start at column 0 though:
+# gofmt guarantees that for real code, and withholding it is what keeps an
+# indented sample program inside a raw string literal from passing for one.
 list_main_dirs_with_grep() {
   local file
   while IFS= read -r file; do
@@ -49,7 +53,7 @@ list_main_dirs_with_grep() {
     case "$file" in
       *_test.go) continue ;;
     esac
-    if grep -q '^package main$' "$file"; then
+    if grep -qE '^package[[:space:]]+main([[:space:]]|//|/\*|$)' "$file"; then
       dirname "$file"
     fi
   done <<< "$(grep -rl '^func main()' --include='*.go' --exclude-dir='testdata' --exclude-dir='vendor' . 2>/dev/null || true)"

--- a/global/scripts/languages/golang/goreleaser/prepare.sh
+++ b/global/scripts/languages/golang/goreleaser/prepare.sh
@@ -4,11 +4,75 @@ set -euo pipefail
 BINARY_NAME="${1:?Binary name is required as the first argument}"
 BINARY_PATH="${2:-.}" # Optional, defaults to "."
 
-if [ -z "$SCRIPTS_DIR" ]; then
+if [ -z "${SCRIPTS_DIR:-}" ]; then
   SCRIPTS_DIR="$(echo "$(dirname "$(realpath "$0")")" | sed 's|\(.*pipelines\).*|\1|')"
 fi
 
 TEMPLATE="$SCRIPTS_DIR/global/scripts/languages/golang/goreleaser/.goreleaser.yaml"
+PROJECT_ROOT="$(realpath "$PWD")"
+
+# Renders a package directory the way GoReleaser wants it: relative to the
+# project root, prefixed with "./". Absolute directories (what `go list` prints)
+# are made relative, and the project root itself collapses to "." — so neither
+# "././cmd/app" nor "./." can be emitted.
+to_package_path() {
+  local path="${1%/}"
+  path="${path#./}"
+
+  if [ "$path" != "${path#/}" ]; then
+    path="$(realpath --relative-to="$PROJECT_ROOT" "$path" 2>/dev/null || printf '%s' "$path")"
+  fi
+
+  if [ -z "$path" ] || [ "$path" = "." ]; then
+    printf '.'
+  else
+    printf './%s' "$path"
+  fi
+}
+
+# Lists the directory of every `main` package by asking the Go toolchain, which
+# is the only trustworthy source. It reads the package clause and skips test
+# files and `testdata/`, so — unlike a text search — it cannot be fooled by a
+# `func main()` that lives inside a raw string literal. Repositories whose tests
+# build sample programs as fixtures do contain exactly that.
+list_main_dirs_with_go() {
+  go list -e -f '{{if eq .Name "main"}}{{.Dir}}{{end}}' ./... 2>/dev/null | grep -v '^$' || true
+}
+
+# Fallback for when the Go toolchain is unavailable. Still far stricter than a
+# bare `func main()` search: test files, `testdata/` and `vendor/` are skipped,
+# and the file must actually declare `package main`.
+list_main_dirs_with_grep() {
+  local file
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    case "$file" in
+      *_test.go) continue ;;
+    esac
+    if grep -q '^package main$' "$file"; then
+      dirname "$file"
+    fi
+  done <<< "$(grep -rl '^func main()' --include='*.go' --exclude-dir='testdata' --exclude-dir='vendor' . 2>/dev/null || true)"
+}
+
+# A repository may ship several binaries (./cmd/api, ./cmd/worker, ...). Release
+# the one named after the binary being built, and fall back to the first found.
+pick_main_dir() {
+  local candidates="$1"
+  local preferred=""
+  local dir=""
+
+  while IFS= read -r dir; do
+    [ -n "$dir" ] || continue
+    if [ "$(basename "$dir")" = "$BINARY_NAME" ]; then
+      printf '%s' "$dir"
+      return 0
+    fi
+    [ -n "$preferred" ] || preferred="$dir"
+  done <<< "$candidates"
+
+  printf '%s' "$preferred"
+}
 
 # Step 1: Check if project already has a goreleaser config
 if [ -f ".goreleaser.yaml" ] || [ -f ".goreleaser.yml" ]; then
@@ -16,16 +80,26 @@ if [ -f ".goreleaser.yaml" ] || [ -f ".goreleaser.yml" ]; then
   exit 0
 fi
 
-# Step 2: Auto-detect binary path if not provided or set to default
+# Step 2: Auto-detect the main package unless the caller pinned one
 if [ "$BINARY_PATH" = "." ]; then
-  DETECTED=$(grep -rl "^func main()" --include="*.go" . 2>/dev/null | head -1 || true)
-  if [ -n "$DETECTED" ]; then
-    BINARY_PATH="./$(dirname "$DETECTED")"
+  CANDIDATES=""
+  if command -v go > /dev/null 2>&1 && [ -f "go.mod" ]; then
+    CANDIDATES="$(list_main_dirs_with_go)"
+  fi
+  if [ -z "$CANDIDATES" ]; then
+    CANDIDATES="$(list_main_dirs_with_grep)"
+  fi
+
+  MAIN_DIR="$(pick_main_dir "$CANDIDATES")"
+  if [ -n "$MAIN_DIR" ]; then
+    BINARY_PATH="$(to_package_path "$MAIN_DIR")"
     echo "Auto-detected main package at: $BINARY_PATH"
   else
     echo "Warning: Could not detect main package, using root (.)"
     BINARY_PATH="."
   fi
+else
+  BINARY_PATH="$(to_package_path "$BINARY_PATH")"
 fi
 
 # Step 3: Copy template and replace placeholders


### PR DESCRIPTION
## Problem

`delivery:binary` builds the wrong package and fails GoReleaser with:

```
⨯ release failed after 0s
  │ build failed: build for autobump does not contain a main function
```

It fails **after** `delivery:release` has already published the tag and the GitHub Release, so the version stays up with no binaries attached to it — nothing to download, and nothing for a `self-update` command to fetch. This is what just happened to [autobump `2.33.1`](https://github.com/rios0rios0/autobump/actions/runs/29358047458/job/87171565619) (0 assets; `2.32.0` has 7).

## Root cause

When a consumer does not pin `binary_path`, `goreleaser/prepare.sh` located the entry point like this:

```bash
DETECTED=$(grep -rl "^func main()" --include="*.go" . | head -1)
BINARY_PATH="./$(dirname "$DETECTED")"
```

That search is textual. It does not skip `_test.go`, does not read the package clause, and cannot tell that a match sits inside a raw string literal. autobump's Swagger version-bumping tests build a sample program as a fixture:

```go
mainGoContent := `package main

// @title Example API
// @version 1.2.3
func main() {}
`
```

`grep -r` walks `internal/` before `cmd/`, so `head -1` returned that test file and the real `cmd/autobump/main.go` was never even considered:

```
Auto-detected main package at: ././internal/domain/commands
Generated .goreleaser.yaml for 'autobump' (main: ././internal/domain/commands)
```

`internal/domain/commands` is package `commands`, not `main` — so GoReleaser had nothing to build. Any repository that embeds a Go program in a fixture, a testdata file, or a README-generation snippet is exposed to the same trap, and it only detonates at release time.

The `././` in that log is a second, independent bug: the path was built as `"./$(dirname "$DETECTED")"` over a value that already began with `./`. A root-level entry point came out as `./.`.

## Fix

Ask the Go toolchain which packages are actually `main`, since it reads the package clause and ignores tests and `testdata/`:

```bash
go list -e -f '{{if eq .Name "main"}}{{.Dir}}{{end}}' ./...
```

- when a repository ships several binaries, the one **named after the binary** is released — so `./cmd/api` + `./cmd/worker` no longer resolves to whichever sorted first;
- the text search is kept only as a fallback for when the toolchain is unavailable, and is now strict: `_test.go`, `testdata/` and `vendor/` are skipped and the file must actually declare `package main`;
- generated paths are normalized to the `./path` form, with the project root collapsing to `.`, and an explicit `binary_path` is normalized the same way so `cmd/app` and `./cmd/app` behave identically;
- `[ -z "$SCRIPTS_DIR" ]` ran under `set -u`, so the guard meant to derive `SCRIPTS_DIR` when a caller had not exported it could only ever abort with `unbound variable` — its fallback was unreachable. Now `${SCRIPTS_DIR:-}`.

## Tests

`.github/tests/test-goreleaser-prepare.sh` (new, wired into `make test`) runs the real script against fixture project trees and asserts on the `main:` it writes. Against the **old** script 6 of its 9 assertions fail, reproducing the production log exactly (`././internal/domain/commands`); against the new one all 9 pass.

```
=== GoReleaser main package detection ===
PASS ignores a func main() embedded in a test fixture
PASS ignores the fixture in the fallback text search too
PASS detects a main package at the repository root
PASS prefers the main package named after the binary
PASS honours an explicit binary path
PASS normalizes an explicit path given without a ./ prefix
PASS falls back to the root when there is no main package
PASS never treats a fixture's embedded program as the entry point
PASS keeps a project's own .goreleaser.yaml
```

The `fixture-only` case pins the bug independently of filesystem walk order: the embedded program is the sole `func main()` in the tree, so a text search cannot help but select it.

`shellcheck --severity=warning` (the `lint-scripts` CI gate) is clean on `prepare.sh`. Note that `make test-go-script` and `make test-yaml-merge` fail identically on pristine `main` in a local checkout (the former hardcodes a `/home/runner/work/...` CI path); they are unaffected by this change.

## Related

[autobump#271](https://github.com/rios0rios0/autobump/pull/271) pins `binary_path` explicitly on the consumer side, which unblocks that release now without waiting on this merge. This PR is what stops the next repository from hitting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)