### PR TITLE
feat(helm): added a SonarQube analysis stage to the Helm chart pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added a SonarQube analysis stage (`35-management`) to the Helm chart pipeline (`azure-devops/helm/helm-chart.yaml`), bringing it in line with the Go, Python, JavaScript and Terraform templates that already run the scanner. The new `azure-devops/helm/stages/35-management/helm.yaml` reuses the shared `azure-devops/global/stages/35-management/sonarqube.yaml` job with `DOWNLOAD_COVERAGE_ARTIFACT: false` (Helm charts produce no coverage artifact, so the download step is skipped to avoid turning the job yellow). Chart repositories that extend `azure-devops/helm/helm-chart.yaml` now report to SonarQube on every non-tag build with no per-repository change
+
 ## [4.16.0] - 2026-07-16
 
 ### Added

--- a/azure-devops/helm/helm-chart.yaml
+++ b/azure-devops/helm/helm-chart.yaml
@@ -1,4 +1,5 @@
 stages:
   - template: 'stages/10-code-check/helm.yaml'
   - template: 'stages/20-security/helm.yaml'
+  - template: 'stages/35-management/helm.yaml'
   - template: 'stages/40-delivery/helm.yaml'

--- a/azure-devops/helm/stages/35-management/helm.yaml
+++ b/azure-devops/helm/stages/35-management/helm.yaml
@@ -1,0 +1,12 @@
+stages:
+  - stage: 'management'
+    displayName: 'management'
+    condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')))
+    jobs:
+      - template: '../../../global/stages/35-management/sonarqube.yaml'
+        parameters:
+          # Helm chart repositories don't produce a `coverage` artifact, so the
+          # default download step would emit `##[error]Artifact coverage was not
+          # found` and turn the job yellow. Skip it (mirrors the Terraform
+          # management stage, which has no coverage either).
+          DOWNLOAD_COVERAGE_ARTIFACT: false


### PR DESCRIPTION
## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?

---

Brings the Helm chart pipeline (`azure-devops/helm/helm-chart.yaml`) in line with the Go, Python, JavaScript and Terraform templates, which already run a SonarQube scan in their `35-management` stage — Helm was the only language template without one.

- New `azure-devops/helm/stages/35-management/helm.yaml` reuses the shared `global/stages/35-management/sonarqube.yaml` job with `DOWNLOAD_COVERAGE_ARTIFACT: false` (Helm charts produce no coverage artifact, so the download step is skipped to avoid turning the job yellow — the same choice the Terraform management stage already makes).
- Wired into `helm/helm-chart.yaml` between `20-security` and `40-delivery`.

Backward-compatible: repositories that extend `helm/helm-chart.yaml` start reporting to SonarQube on every non-tag build with no per-repository change; the stage is gated off tags, matching the other management stages.
