### PR TITLE
chore(git): ignored compiled binaries and root-level test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,17 @@ __pycache__/
 
 # Local report output emitted by the scripts when run at a repo root
 build/reports/
+
+# Compiled tool binaries. `bin/golangci-lint` and the tor-proxy health binary were
+# committed by accident and carried ~45 MB through every clone until they were purged
+# from history; ignoring the directory keeps a stray `make` run from re-adding them.
+bin/
+
+# Test, coverage and SAST output written to the repo root when the scripts are run
+# from a project that does not set REPORT_PATH. `build/reports/` above covers the
+# normal case; these are the root-level fallbacks.
+/cobertura.xml
+/coverage.txt
+/coverage.xml
+/junit.xml
+/reports/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- ignored the compiled tool binaries (`bin/`) and the root-level test, coverage and SAST outputs (`cobertura.xml`, `coverage.txt`, `coverage.xml`, `junit.xml`, `reports/`) that the scripts write when run from a project that does not set `REPORT_PATH`. `bin/golangci-lint` and `global/containers/tor-proxy.latest/health/health` had been committed by accident and carried roughly 45 MB through every clone; both were purged from the history, and these entries stop a stray `make` run from re-adding them
+
 ### Fixed
 
 - fixed the Java `sca:dependency-check` job timing out at 30 minutes on every run, which left it permanently red and produced no report. Two independent causes: (1) an NVD API key was treated as sufficient to use the NVD API, but a *cold* database bootstrap paginates ~350k records and a shared CI egress IP sustains only ~30 records/s even authenticated — over 3 hours, so no timeout short of the 6h job cap could have helped; (2) `github/java/stages/20-security/dependency-check/action.yaml` saved the cache under `always()`, so a killed run published its half-written database, the next run restored it, Dependency-Check rejected it and restarted the full download, and the loop could never escape. `global/scripts/languages/java/dependency-check/run.sh` now chooses the update mechanism by *database state* rather than by credential: a cold or partial database is bootstrapped from the rate-limit-free NVD datafeed regardless of the key, and the authenticated API is used only for the delta once a complete database is restored. Completion is recorded with a `.owasp/.odc-complete` marker that `run.sh` clears before running and writes only after the analysis returns, and the GitHub Actions `cache/save` step is gated on it so a partial database is never cached again


### PR DESCRIPTION
Follow-up to the history rewrite that purged two accidentally committed binaries. Replaces #509, which was auto-closed when its branch was removed during the rewrite.

`bin/golangci-lint` (36 MB) and `global/containers/tor-proxy.latest/health/health` (9 MB) were the **only** blobs over 1 MB in the repository — roughly 45 MB carried through every clone. Both were already absent from `main` but still reachable from history, and have now been removed from every commit. The packed repository went from **32 MB to 3.2 MB**.

Nothing currently prevents them coming back: `bin/` was not ignored, so a `make` run that builds the linter locally would re-commit it. This adds that guard.

It also ignores the root-level test/coverage/SAST outputs (`cobertura.xml`, `coverage.txt`, `coverage.xml`, `junit.xml`, `reports/`) that the scripts emit when run from a project that does not set `REPORT_PATH`. `build/reports/` was already covered; these are the fallbacks. Not hypothetical — those exact files were accidentally staged into a PR earlier in this work because nothing ignored them.

`make test-basic-checks` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)