### PR TITLE
feat(delivery): forward IMAGE_NAME through golang and js delivery wra…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- exposed an `IMAGE_NAME` parameter on the Azure DevOps delivery templates so a consumer repository can override the published image name instead of always deriving it from the repository name. The shared `azure-devops/global/stages/40-delivery/docker.yaml` step already honored `IMAGE_NAME`, but the `golang`, `javascript`, and `python` delivery wrappers (and the javascript `steps/delivery.yaml`) never forwarded it; they now pass it through, defaulting to the empty string so the repository name is still used when unset and existing pipelines are unaffected. This lets two repositories that share the same name publish distinct images to the same registry
+
 ## [4.17.0] - 2026-07-22
 
 ### Added

--- a/azure-devops/golang/stages/40-delivery/docker.yaml
+++ b/azure-devops/golang/stages/40-delivery/docker.yaml
@@ -5,6 +5,9 @@ parameters:
   - name: 'RUN_BEFORE_BUILD'
     type: 'string'
     default: ''
+  - name: 'IMAGE_NAME'
+    type: 'string'
+    default: ''
 
 stages:
   - stage: 'delivery'
@@ -25,5 +28,6 @@ stages:
               CONTAINER_REGISTRY_SERVICE_CONNECTION: "$(CONTAINER_REGISTRY_SERVICE_CONNECTION)"
               DOCKER_BUILD_ARGS: ${{ parameters.DOCKER_BUILD_ARGS }}
               RUN_BEFORE_BUILD: ${{ parameters.RUN_BEFORE_BUILD }}
+              IMAGE_NAME: ${{ parameters.IMAGE_NAME }}
 
       - template: '../../../global/stages/40-delivery/release.yaml'

--- a/azure-devops/javascript/stages/40-delivery/docker.yaml
+++ b/azure-devops/javascript/stages/40-delivery/docker.yaml
@@ -8,6 +8,9 @@ parameters:
   - name: 'RUN_AFTER_DELIVERY'
     type: 'string'
     default: 'echo "No after script"'
+  - name: 'IMAGE_NAME'
+    type: 'string'
+    default: ''
 
 stages:
   - stage: 'delivery'
@@ -26,6 +29,7 @@ stages:
               WORKING_DIRECTORY: "${{ parameters.WORKING_DIRECTORY }}"
               RUN_BEFORE_DELIVERY: ${{ parameters.RUN_BEFORE_DELIVERY }}
               RUN_AFTER_DELIVERY: ${{ parameters.RUN_AFTER_DELIVERY }}
+              IMAGE_NAME: ${{ parameters.IMAGE_NAME }}
         continueOnError: false
 
       - template: '../../../global/stages/40-delivery/release.yaml'

--- a/azure-devops/javascript/stages/40-delivery/steps/delivery.yaml
+++ b/azure-devops/javascript/stages/40-delivery/steps/delivery.yaml
@@ -14,6 +14,9 @@ parameters:
   - name: 'RUN_BEFORE_BUILD'
     type: 'string'
     default: ''
+  - name: 'IMAGE_NAME'
+    type: 'string'
+    default: ''
 
 steps:
   - script: ${{ parameters.RUN_BEFORE_DELIVERY }}
@@ -36,3 +39,4 @@ steps:
       DOCKER_BUILD_ARGS: "${{ parameters.DOCKER_BUILD_ARGS }}"
       WORKING_DIRECTORY: "${{ parameters.WORKING_DIRECTORY }}"
       RUN_BEFORE_BUILD: "${{ parameters.RUN_BEFORE_BUILD }}"
+      IMAGE_NAME: "${{ parameters.IMAGE_NAME }}"

--- a/azure-devops/python/stages/40-delivery/docker.yaml
+++ b/azure-devops/python/stages/40-delivery/docker.yaml
@@ -5,6 +5,9 @@ parameters:
   - name: 'RUN_BEFORE_BUILD'
     type: 'string'
     default: ''
+  - name: 'IMAGE_NAME'
+    type: 'string'
+    default: ''
 
 stages:
   - stage: 'delivery'
@@ -24,5 +27,6 @@ stages:
               CONTAINER_REGISTRY_SERVICE_CONNECTION: "$(CONTAINER_REGISTRY_SERVICE_CONNECTION)"
               DOCKER_BUILD_ARGS: "${{ parameters.DOCKER_BUILD_ARGS }}"
               RUN_BEFORE_BUILD: "${{ parameters.RUN_BEFORE_BUILD }}"
+              IMAGE_NAME: "${{ parameters.IMAGE_NAME }}"
 
       - template: '../../../global/stages/40-delivery/release.yaml'


### PR DESCRIPTION
…ppers

- add an IMAGE_NAME parameter to the golang and javascript 40-delivery wrappers
- forward IMAGE_NAME through the javascript steps/delivery.yaml to the global docker step
- default to empty so the repository name is still used when unset, keeping existing pipelines unaffected

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
