### PR TITLE
feat(codeql): allowed the SARIF upload to be turned off

### DIFF
--- a/.github/workflows/bundler-library.yaml
+++ b/.github/workflows/bundler-library.yaml
@@ -47,6 +47,7 @@ jobs:
 #   permissions:
 #     checks: 'write' # tests-test_all (test results annotations)
 #     security-events: 'write' # security-sast_codeql
+#     actions: 'read' # security-sast_codeql (required only on a private repository)
 #     contents: 'write' # delivery-release
 #
 # This workflow validates a Bundler (Ruby) library/gem and creates a release tag when

--- a/.github/workflows/bundler.yaml
+++ b/.github/workflows/bundler.yaml
@@ -167,3 +167,4 @@ jobs:
 #
 #   permissions:
 #     security-events: 'write' # security-sast_codeql
+#     actions: 'read' # security-sast_codeql (required only on a private repository)

--- a/.github/workflows/composer-library.yaml
+++ b/.github/workflows/composer-library.yaml
@@ -55,6 +55,7 @@ jobs:
 #   permissions:
 #     checks: 'write' # tests-test_all (test results annotations)
 #     security-events: 'write' # security-sast_codeql
+#     actions: 'read' # security-sast_codeql (required only on a private repository)
 #     contents: 'write' # delivery-release
 #
 # This workflow validates a Composer (PHP) library and creates a release tag when

--- a/.github/workflows/dotnet-library.yaml
+++ b/.github/workflows/dotnet-library.yaml
@@ -47,6 +47,7 @@ jobs:
 #   permissions:
 #     checks: 'write' # tests-test_all (test results annotations)
 #     security-events: 'write' # security-sast_codeql
+#     actions: 'read' # security-sast_codeql (required only on a private repository)
 #     contents: 'write' # delivery-release
 #
 # This workflow validates a .NET library/NuGet package and creates a release tag when

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -132,3 +132,4 @@ jobs:
 #
 #   permissions:
 #     security-events: 'write' # security-sast_codeql
+#     actions: 'read' # security-sast_codeql (required only on a private repository)

--- a/.github/workflows/go-binary.yaml
+++ b/.github/workflows/go-binary.yaml
@@ -106,6 +106,7 @@ jobs:
 #   permissions:
 #     checks: 'write' # code_check-style_golangci_lint
 #     security-events: 'write' # security-sast_codeql
+#     actions: 'read' # security-sast_codeql (required only on a private repository)
 #     contents: 'write' # delivery-release
 #     packages: 'write' # delivery-docker (only when deliver_docker: true, to push to ghcr.io)
 #

--- a/.github/workflows/go-library.yaml
+++ b/.github/workflows/go-library.yaml
@@ -69,6 +69,7 @@ jobs:
 #   permissions:
 #     checks: 'write' # code_check-style_golangci_lint
 #     security-events: 'write' # security-sast_codeql
+#     actions: 'read' # security-sast_codeql (required only on a private repository)
 #     contents: 'write' # delivery-release
 #
 # workflow_dispatch inputs can only be defined in the workflow that is directly triggered

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -210,3 +210,4 @@ jobs:
 # permissions:
 #   checks: 'write' # code_check-style_golangci_lint, tests-test_all (test results annotations)
 #   security-events: 'write' # security-sast_codeql
+#   actions: 'read' # security-sast_codeql (required only on a private repository)

--- a/.github/workflows/gradle-docker.yaml
+++ b/.github/workflows/gradle-docker.yaml
@@ -6,6 +6,14 @@ on:
         required: false
         type: string
         default: ''
+      codeql_upload:
+        description: |
+          Whether sast:codeql uploads its SARIF results ('always', 'failure-only' or 'never').
+          Set to 'never' on a private repository without GitHub Advanced Security, where code
+          scanning is unavailable and only the upload -- not the analysis -- fails.
+        required: false
+        type: string
+        default: 'always'
     secrets:
       sonar_token:
         description: 'SonarQube authentication token'
@@ -19,6 +27,7 @@ jobs:
     uses: 'rios0rios0/pipelines/.github/workflows/gradle.yaml@main'
     with:
       sonar_host: ${{ inputs.sonar_host }}
+      codeql_upload: '${{ inputs.codeql_upload }}'
     secrets:
       sonar_token: ${{ secrets.sonar_token }}
       NVD_API_KEY: ${{ secrets.NVD_API_KEY }}

--- a/.github/workflows/gradle-library.yaml
+++ b/.github/workflows/gradle-library.yaml
@@ -8,6 +8,14 @@ on:
         required: false
         type: string
         default: ''
+      codeql_upload:
+        description: |
+          Whether sast:codeql uploads its SARIF results ('always', 'failure-only' or 'never').
+          Set to 'never' on a private repository without GitHub Advanced Security, where code
+          scanning is unavailable and only the upload -- not the analysis -- fails.
+        required: false
+        type: string
+        default: 'always'
       tag_prefixes:
         type: 'string'
         required: false
@@ -25,6 +33,7 @@ jobs:
     uses: 'rios0rios0/pipelines/.github/workflows/gradle.yaml@main'
     with:
       sonar_host: '${{ inputs.sonar_host }}'
+      codeql_upload: '${{ inputs.codeql_upload }}'
     secrets:
       NVD_API_KEY: '${{ secrets.NVD_API_KEY }}'
       sonar_token: '${{ secrets.sonar_token }}'
@@ -63,6 +72,7 @@ jobs:
 #   permissions:
 #     checks: 'write' # tests-test_all (test results annotations)
 #     security-events: 'write' # security-sast_codeql
+#     actions: 'read' # security-sast_codeql (required only on a private repository)
 #     contents: 'write' # delivery-release
 #
 # This workflow validates a Gradle (Java/Kotlin) library and creates a release tag when

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -8,6 +8,14 @@ on:
         required: false
         type: string
         default: ''
+      codeql_upload:
+        description: |
+          Whether sast:codeql uploads its SARIF results ('always', 'failure-only' or 'never').
+          Set to 'never' on a private repository without GitHub Advanced Security, where code
+          scanning is unavailable and only the upload -- not the analysis -- fails.
+        required: false
+        type: string
+        default: 'always'
     secrets:
       NVD_API_KEY:
         required: false
@@ -63,6 +71,7 @@ jobs:
       - uses: 'rios0rios0/pipelines/github/global/stages/20-security/codeql@main'
         with:
           codeql_language: 'java-kotlin'
+          upload: '${{ inputs.codeql_upload }}'
     needs: [ 'code_check-style_checkstyle', 'code_check-quality_proguard' ]
     if: "!startsWith(github.ref, 'refs/tags/')"
 
@@ -217,4 +226,5 @@ jobs:
 #
 #   permissions:
 #     security-events: 'write' # security-sast_codeql
+#     actions: 'read' # security-sast_codeql (required only on a private repository)
 #     checks: 'write' # tests-test_all (test results annotations)

--- a/.github/workflows/maven-docker.yaml
+++ b/.github/workflows/maven-docker.yaml
@@ -6,6 +6,14 @@ on:
         required: false
         type: string
         default: ''
+      codeql_upload:
+        description: |
+          Whether sast:codeql uploads its SARIF results ('always', 'failure-only' or 'never').
+          Set to 'never' on a private repository without GitHub Advanced Security, where code
+          scanning is unavailable and only the upload -- not the analysis -- fails.
+        required: false
+        type: string
+        default: 'always'
     secrets:
       sonar_token:
         description: 'SonarQube authentication token'
@@ -19,6 +27,7 @@ jobs:
     uses: 'rios0rios0/pipelines/.github/workflows/maven.yaml@main'
     with:
       sonar_host: ${{ inputs.sonar_host }}
+      codeql_upload: '${{ inputs.codeql_upload }}'
     secrets:
       sonar_token: ${{ secrets.sonar_token }}
       NVD_API_KEY: ${{ secrets.NVD_API_KEY }}

--- a/.github/workflows/maven-library.yaml
+++ b/.github/workflows/maven-library.yaml
@@ -8,6 +8,14 @@ on:
         required: false
         type: string
         default: ''
+      codeql_upload:
+        description: |
+          Whether sast:codeql uploads its SARIF results ('always', 'failure-only' or 'never').
+          Set to 'never' on a private repository without GitHub Advanced Security, where code
+          scanning is unavailable and only the upload -- not the analysis -- fails.
+        required: false
+        type: string
+        default: 'always'
       tag_prefixes:
         type: 'string'
         required: false
@@ -25,6 +33,7 @@ jobs:
     uses: 'rios0rios0/pipelines/.github/workflows/maven.yaml@main'
     with:
       sonar_host: '${{ inputs.sonar_host }}'
+      codeql_upload: '${{ inputs.codeql_upload }}'
     secrets:
       NVD_API_KEY: '${{ secrets.NVD_API_KEY }}'
       sonar_token: '${{ secrets.sonar_token }}'
@@ -71,6 +80,7 @@ jobs:
 #   permissions:
 #     checks: 'write' # tests-test_all (test results annotations)
 #     security-events: 'write' # security-sast_codeql
+#     actions: 'read' # security-sast_codeql (required only on a private repository)
 #     contents: 'write' # delivery-release
 #
 # This workflow validates a Maven (Java) library and creates a release tag when

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -8,6 +8,14 @@ on:
         required: false
         type: string
         default: ''
+      codeql_upload:
+        description: |
+          Whether sast:codeql uploads its SARIF results ('always', 'failure-only' or 'never').
+          Set to 'never' on a private repository without GitHub Advanced Security, where code
+          scanning is unavailable and only the upload -- not the analysis -- fails.
+        required: false
+        type: string
+        default: 'always'
     secrets:
       NVD_API_KEY:
         required: false
@@ -63,6 +71,7 @@ jobs:
       - uses: 'rios0rios0/pipelines/github/global/stages/20-security/codeql@main'
         with:
           codeql_language: 'java-kotlin'
+          upload: '${{ inputs.codeql_upload }}'
     needs: [ 'code_check-style_maven_verify', 'code_check-quality_proguard' ]
     if: "!startsWith(github.ref, 'refs/tags/')"
 
@@ -217,4 +226,5 @@ jobs:
 #
 #   permissions:
 #     security-events: 'write' # security-sast_codeql
+#     actions: 'read' # security-sast_codeql (required only on a private repository)
 #     checks: 'write' # tests-test_all (test results annotations)

--- a/.github/workflows/npm-library.yaml
+++ b/.github/workflows/npm-library.yaml
@@ -60,6 +60,7 @@ jobs:
 #   permissions:
 #     checks: 'write' # tests-test_all (test results annotations)
 #     security-events: 'write' # security-sast_codeql
+#     actions: 'read' # security-sast_codeql (required only on a private repository)
 #     contents: 'write' # delivery-release
 #
 # This workflow validates an npm (JavaScript/TypeScript) library and creates a release tag

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -249,5 +249,6 @@ jobs:
 #
 #   permissions:
 #     security-events: 'write' # security-sast_codeql
+#     actions: 'read' # security-sast_codeql (required only on a private repository)
 #     pull-requests: 'write' # tests-test_all (coverage report comment)
 #     checks: 'write' # tests-test_all (test results annotations)

--- a/.github/workflows/pdm-library.yaml
+++ b/.github/workflows/pdm-library.yaml
@@ -47,6 +47,7 @@ jobs:
 #   permissions:
 #     checks: 'write' # tests-test_all (test results annotations)
 #     security-events: 'write' # security-sast_codeql
+#     actions: 'read' # security-sast_codeql (required only on a private repository)
 #     contents: 'write' # delivery-release
 #
 # This workflow validates a PDM (Python) library and creates a release tag when

--- a/.github/workflows/pdm.yaml
+++ b/.github/workflows/pdm.yaml
@@ -151,3 +151,4 @@ jobs:
 #
 # permissions:
 #   security-events: 'write' # security-sast_codeql
+#   actions: 'read' # security-sast_codeql (required only on a private repository)

--- a/.github/workflows/terra.yaml
+++ b/.github/workflows/terra.yaml
@@ -372,3 +372,4 @@ jobs:
 #
 #   permissions:
 #     security-events: 'write' # security-sast_codeql
+#     actions: 'read' # security-sast_codeql (required only on a private repository)

--- a/.github/workflows/yarn-library.yaml
+++ b/.github/workflows/yarn-library.yaml
@@ -60,6 +60,7 @@ jobs:
 #   permissions:
 #     checks: 'write' # tests-test_all (test results annotations)
 #     security-events: 'write' # security-sast_codeql
+#     actions: 'read' # security-sast_codeql (required only on a private repository)
 #     contents: 'write' # delivery-release
 #
 # This workflow validates a Yarn (JavaScript/TypeScript) library and creates a release tag

--- a/.github/workflows/yarn.yaml
+++ b/.github/workflows/yarn.yaml
@@ -260,5 +260,6 @@ jobs:
 #
 #   permissions:
 #     security-events: 'write' # security-sast_codeql
+#     actions: 'read' # security-sast_codeql (required only on a private repository)
 #     pull-requests: 'write' # tests-test_all (coverage report comment)
 #     checks: 'write' # tests-test_all (test results annotations)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Added
 
 - exposed an `IMAGE_NAME` parameter on the Azure DevOps delivery templates so a consumer repository can override the published image name instead of always deriving it from the repository name. The shared `azure-devops/global/stages/40-delivery/docker.yaml` step already honored `IMAGE_NAME`, but the `golang`, `javascript`, and `python` delivery wrappers (and the javascript `steps/delivery.yaml`) never forwarded it; they now pass it through, defaulting to the empty string so the repository name is still used when unset and existing pipelines are unaffected. This lets two repositories that share the same name publish distinct images to the same registry
+- added an `upload` input to the `20-security/codeql` action, forwarded as `codeql_upload` by the Maven and Gradle workflows (`maven.yaml`, `gradle.yaml` and their `-library` / `-docker` wrappers). Uploading SARIF results requires code scanning, which on a private repository means GitHub Advanced Security; without it the CodeQL analysis still succeeds and only the upload fails, taking the whole `sast:codeql` job down with it. Such a repository can now pass `codeql_upload: 'never'` to keep the scan running as a build-breaking check without the alerts. The default of `'always'` leaves every existing consumer unchanged
+
+### Changed
+
+- documented `actions: 'read'` alongside `security-events: 'write'` in the recommended permissions of every workflow that runs `sast:codeql`. The CodeQL action reads the workflow run through an endpoint that is public on a public repository but permission-gated on a private one, where omitting it fails the job with "Resource not accessible by integration"
 
 ## [4.17.0] - 2026-07-22
 

--- a/github/global/stages/20-security/codeql/action.yaml
+++ b/github/global/stages/20-security/codeql/action.yaml
@@ -2,6 +2,15 @@ inputs:
   codeql_language:
     description: 'CodeQL language to analyze (e.g., go, python, java-kotlin, javascript-typescript, csharp)'
     required: true
+  upload:
+    description: |
+      Whether to upload the SARIF results to code scanning ('always', 'failure-only' or 'never').
+      Uploading requires code scanning to be enabled on the repository, which on a private
+      repository means GitHub Advanced Security. Without it the analysis itself still succeeds and
+      only the upload fails, taking the whole job down with it -- set this to 'never' on such a
+      repository to keep the scan running as a build-breaking check without the alerts.
+    required: false
+    default: 'always'
 
 runs:
   using: 'composite'
@@ -36,3 +45,4 @@ runs:
       uses: 'github/codeql-action/analyze@v4'
       with:
         category: '/language:${{ inputs.codeql_language }}'
+        upload: '${{ inputs.upload }}'


### PR DESCRIPTION
## Why

`sast:codeql` cannot pass on a **private** repository without GitHub Advanced Security.

The analysis itself works fine — CodeQL builds the database, runs the queries and exports SARIF. Only the final **upload** fails, because code scanning is not enabled:

```
CodeQL scanned 13 out of 13 Java files in this invocation.
##[group]Uploading code scanning results
##[error]Please verify that the necessary features are enabled:
         Code scanning is not enabled for this repository.
```

The job then fails, and because `tests > test:all` (and the rest of the graph) `needs:` it, everything downstream is skipped too — so a whole pipeline goes red over an upload that the repository plan cannot perform.

Verified on `rios0rios0/challenge-nubank` and `rios0rios0/challenge-wex` (both private → `GET /code-scanning/alerts` returns `403`), versus `rios0rios0/caa` (public → `200`).

## What

- added an `upload` input to `github/global/stages/20-security/codeql/action.yaml`, passed straight to `github/codeql-action/analyze` (`always` | `failure-only` | `never`)
- forwarded it as `codeql_upload` through `maven.yaml` / `gradle.yaml` and their `-library` and `-docker` wrappers
- documented `actions: 'read'` next to `security-events: 'write'` in the recommended permissions of every workflow that runs `sast:codeql`

A repository without Advanced Security can now opt out of the upload and keep CodeQL as a build-breaking check:

```yaml
jobs:
  default:
    uses: 'rios0rios0/pipelines/.github/workflows/maven-library.yaml@main'
    with:
      codeql_upload: 'never'
```

## Compatibility

The default is `'always'`, so every existing consumer behaves exactly as before. The change is additive — 86 insertions, no deletions.

### On `actions: 'read'`

Separate from the upload: the CodeQL action resolves its workflow run through an endpoint that is public on a public repository but permission-gated on a private one. Omitting the permission fails the job with `Resource not accessible by integration`, which is why it is now documented.

## Testing

`make test` could not be run in the authoring environment (the suite hardcodes `/home/runner/...` CI paths). The change is YAML-only and touches no script the suite covers; all modified YAML was parse-checked.