### PR TITLE
fix(delivery): propagate tag release-recovery to all library workflows

### DIFF
--- a/.github/workflows/bundler-library.yaml
+++ b/.github/workflows/bundler-library.yaml
@@ -28,7 +28,15 @@ jobs:
         with:
           tag_prefix: '${{ matrix.prefix }}'
     needs: [ 'bundler' ]
-    if: "github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(github.event.head_commit.message, 'chore/bump-') || contains(github.event.head_commit.message, 'chore(bump)'))"
+    # Cut on a main-branch bump merge, OR on a version-tag push so a bump whose
+    # main run failed the quality gate can be recovered by (re-)pushing its tag.
+    # The two triggers are gated separately with explicit status functions: the
+    # main path keeps success() (never release when the gate failed), while the
+    # tag path uses !cancelled() so it still runs when the gate SKIPS on tags —
+    # every job in bundler.yaml skips on refs/tags/*, which makes the `bundler` need
+    # conclude "skipped", and an implicit success() would then skip delivery too.
+    # 40-delivery/release derives the version from the tag ref on the tag path.
+    if: "(success() && github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(github.event.head_commit.message, 'chore/bump-') || contains(github.event.head_commit.message, 'chore(bump)'))) || (!cancelled() && startsWith(github.ref, 'refs/tags/'))"
 
 
 # 1 - this file MUST be inside ".github/workflows" because of GitHub Actions limitations

--- a/.github/workflows/dotnet-library.yaml
+++ b/.github/workflows/dotnet-library.yaml
@@ -28,7 +28,15 @@ jobs:
         with:
           tag_prefix: '${{ matrix.prefix }}'
     needs: [ 'dotnet' ]
-    if: "github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(github.event.head_commit.message, 'chore/bump-') || contains(github.event.head_commit.message, 'chore(bump)'))"
+    # Cut on a main-branch bump merge, OR on a version-tag push so a bump whose
+    # main run failed the quality gate can be recovered by (re-)pushing its tag.
+    # The two triggers are gated separately with explicit status functions: the
+    # main path keeps success() (never release when the gate failed), while the
+    # tag path uses !cancelled() so it still runs when the gate SKIPS on tags —
+    # every job in dotnet.yaml skips on refs/tags/*, which makes the `dotnet` need
+    # conclude "skipped", and an implicit success() would then skip delivery too.
+    # 40-delivery/release derives the version from the tag ref on the tag path.
+    if: "(success() && github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(github.event.head_commit.message, 'chore/bump-') || contains(github.event.head_commit.message, 'chore(bump)'))) || (!cancelled() && startsWith(github.ref, 'refs/tags/'))"
 
 
 # 1 - this file MUST be inside ".github/workflows" because of GitHub Actions limitations

--- a/.github/workflows/gradle-library.yaml
+++ b/.github/workflows/gradle-library.yaml
@@ -53,7 +53,15 @@ jobs:
         with:
           tag_prefix: '${{ matrix.prefix }}'
     needs: [ 'gradle' ]
-    if: "github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(github.event.head_commit.message, 'chore/bump-') || contains(github.event.head_commit.message, 'chore(bump)'))"
+    # Cut on a main-branch bump merge, OR on a version-tag push so a bump whose
+    # main run failed the quality gate can be recovered by (re-)pushing its tag.
+    # The two triggers are gated separately with explicit status functions: the
+    # main path keeps success() (never release when the gate failed), while the
+    # tag path uses !cancelled() so it still runs when the gate SKIPS on tags —
+    # every job in gradle.yaml skips on refs/tags/*, which makes the `gradle` need
+    # conclude "skipped", and an implicit success() would then skip delivery too.
+    # 40-delivery/release derives the version from the tag ref on the tag path.
+    if: "(success() && github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(github.event.head_commit.message, 'chore/bump-') || contains(github.event.head_commit.message, 'chore(bump)'))) || (!cancelled() && startsWith(github.ref, 'refs/tags/'))"
 
 
 # 1 - this file MUST be inside ".github/workflows" because of GitHub Actions limitations

--- a/.github/workflows/npm-library.yaml
+++ b/.github/workflows/npm-library.yaml
@@ -41,7 +41,15 @@ jobs:
         with:
           tag_prefix: '${{ matrix.prefix }}'
     needs: [ 'npm' ]
-    if: "github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(github.event.head_commit.message, 'chore/bump-') || contains(github.event.head_commit.message, 'chore(bump)'))"
+    # Cut on a main-branch bump merge, OR on a version-tag push so a bump whose
+    # main run failed the quality gate can be recovered by (re-)pushing its tag.
+    # The two triggers are gated separately with explicit status functions: the
+    # main path keeps success() (never release when the gate failed), while the
+    # tag path uses !cancelled() so it still runs when the gate SKIPS on tags —
+    # every job in npm.yaml skips on refs/tags/*, which makes the `npm` need
+    # conclude "skipped", and an implicit success() would then skip delivery too.
+    # 40-delivery/release derives the version from the tag ref on the tag path.
+    if: "(success() && github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(github.event.head_commit.message, 'chore/bump-') || contains(github.event.head_commit.message, 'chore(bump)'))) || (!cancelled() && startsWith(github.ref, 'refs/tags/'))"
 
 
 # 1 - this file MUST be inside ".github/workflows" because of GitHub Actions limitations

--- a/.github/workflows/pdm-library.yaml
+++ b/.github/workflows/pdm-library.yaml
@@ -28,7 +28,15 @@ jobs:
         with:
           tag_prefix: '${{ matrix.prefix }}'
     needs: [ 'pdm' ]
-    if: "github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(github.event.head_commit.message, 'chore/bump-') || contains(github.event.head_commit.message, 'chore(bump)'))"
+    # Cut on a main-branch bump merge, OR on a version-tag push so a bump whose
+    # main run failed the quality gate can be recovered by (re-)pushing its tag.
+    # The two triggers are gated separately with explicit status functions: the
+    # main path keeps success() (never release when the gate failed), while the
+    # tag path uses !cancelled() so it still runs when the gate SKIPS on tags —
+    # every job in pdm.yaml skips on refs/tags/*, which makes the `pdm` need
+    # conclude "skipped", and an implicit success() would then skip delivery too.
+    # 40-delivery/release derives the version from the tag ref on the tag path.
+    if: "(success() && github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(github.event.head_commit.message, 'chore/bump-') || contains(github.event.head_commit.message, 'chore(bump)'))) || (!cancelled() && startsWith(github.ref, 'refs/tags/'))"
 
 
 # 1 - this file MUST be inside ".github/workflows" because of GitHub Actions limitations

--- a/.github/workflows/yarn-library.yaml
+++ b/.github/workflows/yarn-library.yaml
@@ -41,7 +41,15 @@ jobs:
         with:
           tag_prefix: '${{ matrix.prefix }}'
     needs: [ 'yarn' ]
-    if: "github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(github.event.head_commit.message, 'chore/bump-') || contains(github.event.head_commit.message, 'chore(bump)'))"
+    # Cut on a main-branch bump merge, OR on a version-tag push so a bump whose
+    # main run failed the quality gate can be recovered by (re-)pushing its tag.
+    # The two triggers are gated separately with explicit status functions: the
+    # main path keeps success() (never release when the gate failed), while the
+    # tag path uses !cancelled() so it still runs when the gate SKIPS on tags —
+    # every job in yarn.yaml skips on refs/tags/*, which makes the `yarn` need
+    # conclude "skipped", and an implicit success() would then skip delivery too.
+    # 40-delivery/release derives the version from the tag ref on the tag path.
+    if: "(success() && github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(github.event.head_commit.message, 'chore/bump-') || contains(github.event.head_commit.message, 'chore(bump)'))) || (!cancelled() && startsWith(github.ref, 'refs/tags/'))"
 
 
 # 1 - this file MUST be inside ".github/workflows" because of GitHub Actions limitations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- propagated the version-tag release-recovery path to the `bundler`, `dotnet`, `gradle`, `npm`, `pdm`, and `yarn` library workflows, which were missing it. Their `delivery-release` job only fired on a `main`-branch bump merge, so a bump whose `main` run failed the quality gate could not be recovered by (re-)pushing its tag the way `maven-library.yaml` (and `composer`/`go`) already allowed — the job stayed skipped on the tag ref and no release was cut. All library workflows now share the same two-path condition
+
 ## [4.18.0] - 2026-07-23
 
 ### Added


### PR DESCRIPTION
## Why

The `delivery-release` job in the `bundler`, `dotnet`, `gradle`, `npm`, `pdm`, and `yarn` library workflows only fired on a `main`-branch bump merge:

```yaml
if: "github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(... 'chore/bump-') || contains(... 'chore(bump)'))"
```

`maven-library.yaml` (and `composer`/`go`) also carry a **second path** so that a bump whose `main` run failed the quality gate can be recovered by (re-)pushing its version tag — the gate jobs all skip on tags, leaving only the delivery step to run. These six workflows were never given that path.

**This bit a real release:** `challenge-nubank` (gradle) merged a `0.2.3` bump while its `main` run was red, so `delivery-release` was skipped; pushing the `0.2.3` tag to recover it skipped the job again (wrong `github.ref`), and no release was cut. The maven sibling `challenge-wex` recovered its `0.2.4` fine because `maven-library` already had the path.

## What

All six workflows now share the exact two-path condition maven-library uses:

```yaml
if: "(success() && github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(... 'chore/bump-') || contains(... 'chore(bump)'))) || (!cancelled() && startsWith(github.ref, 'refs/tags/'))"
```

- **main path** stays behind `success()` — never release when the gate failed;
- **tag path** behind `!cancelled()` — still runs when the gate SKIPS on the tag ref (an implicit `success()` would skip delivery because the reusable-workflow need concludes "skipped" on tags).

The same explanatory comment block from maven-library is copied to each, with the inner-workflow name adapted. Purely additive — no existing consumer behavior changes on the `main` path.

## Coverage after this change

| have tag-path before | added here |
|---|---|
| maven, composer, go-library, go-binary | bundler, dotnet, gradle, npm, pdm, yarn |