### PR TITLE
fix(delivery): mapped the pipeline identity into the Go Lambda delivery init step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Fixed
 
+- mapped `System.AccessToken` into the `env:` of the `Load Custom Configuration` step of the Azure DevOps Go Lambda delivery stage (`azure-devops/golang/stages/40-delivery/lambda.yaml`), the last template that sourced the Go init script without it. The step runs the project `config.sh`, which authenticates private Go module fetches with the built-in pipeline identity; without the mapping the token is empty, the fetch gets `401`, and `go build` inside `sam build` fails with the misleading `no secure protocol found for repository` (Go reports an authentication failure as if no usable protocol existed). The defect stayed hidden for as long as the job's Go module cache kept hitting, then broke delivery on the first cold-cache build. Aliasing the token through the `variables:` block is not a workaround: a variable that expands a secret is itself treated as a secret and is still withheld from the process environment
 - propagated the version-tag release-recovery path to the `bundler`, `dotnet`, `gradle`, `npm`, `pdm`, and `yarn` library workflows, which were missing it. Their `delivery-release` job only fired on a `main`-branch bump merge, so a bump whose `main` run failed the quality gate could not be recovered by (re-)pushing its tag the way `maven-library.yaml` (and `composer`/`go`) already allowed — the job stayed skipped on the tag ref and no release was cut. All library workflows now share the same two-path condition
 
 ## [4.18.0] - 2026-07-23

--- a/azure-devops/golang/stages/40-delivery/lambda.yaml
+++ b/azure-devops/golang/stages/40-delivery/lambda.yaml
@@ -46,6 +46,14 @@ stages:
 
           - script: $(Scripts.Directory)/global/scripts/languages/golang/init/run.sh
             displayName: 'Load Custom Configuration'
+            # init/run.sh sources the project `config.sh`, which may authenticate
+            # private module fetches with the built-in pipeline identity. Azure
+            # Pipelines withholds secret-like values (including System.AccessToken)
+            # from the script environment unless mapped here. Aliasing it through
+            # the `variables:` block does not work: a variable that expands a
+            # secret is itself treated as a secret, so it is still withheld.
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             continueOnError: true
 
           - task: 'Cache@2'


### PR DESCRIPTION
## Problem

`azure-devops/golang/stages/40-delivery/lambda.yaml` runs `Load Custom Configuration`, which sources the consumer project's `config.sh`. That script commonly authenticates private Go module fetches with the built-in pipeline identity — it reads the token from the environment and writes it into a global git `http.<url>.extraheader`.

Azure Pipelines withholds secret-like values (including `System.AccessToken`) from a script's environment unless they are mapped per step with `env:`. Two other templates already do this:

- `azure-devops/golang/abstracts/go.yaml` (code check / security / tests)
- `azure-devops/global/stages/20-security/codeql.yaml`

The Go Lambda delivery stage was the last Azure DevOps template sourcing the Go init script **without** the mapping. So in the delivery job the token is empty, `config.sh` writes a credential-less header, the private module fetch gets `401`, and `go build` (invoked through `sam build`) fails with:

```
go: downloading <private module>
somefile.go:6:2: no secure protocol found for repository
```

That message is Go's VCS resolver reporting that every secure scheme it pinged failed — an authentication failure wearing a protocol-failure costume, which makes this a genuinely hard failure to diagnose.

**Why it hid for so long:** the delivery job's `Cache@2` for `$(GOPATH)` uses an exact `go.sum` hash as its key and has no `restoreKeys`. As long as the cache kept hitting, the modules were already present and nothing ever touched the VCS. The first cold-cache build after a dependency bump took the first real fetch and broke delivery outright.

## Fix

Add the same `env:` mapping the sibling templates already carry.

## Evidence

In a single build of one consumer repository, same commit and same `config.sh`, the script logs a warning when it finds no token:

| Job | Token mechanism | warning emitted |
|---|---|---|
| tests | per-step `env:` mapping | no |
| lint | per-step `env:` mapping | no |
| govulncheck | per-step `env:` mapping | no |
| **delivery** | **none** | **yes** |

I first tried aliasing the token through the pipeline's `variables:` block instead, so every stage would inherit it. **That does not work, and it is worth recording why:** Azure Pipelines propagates secret-ness through variable expansion. A variable whose value expands a secret is itself treated as a secret, and secrets are withheld from the process environment. Such a variable is still expanded in *task inputs* (which is why a `$(VAR)` reference inside a script body works), but a script reading it from `env` sees nothing. Only a per-step `env:` mapping delivers it.

Compile-verified with the Azure DevOps pipeline preview API against a consumer pipeline with this branch pinned as the template ref: the delivery stage went from zero `SYSTEM_ACCESSTOKEN` mappings to one, attached to the `Load Custom Configuration` task.

## Possible follow-up (not in this PR)

The delivery `Cache@2` has no `restoreKeys`, unlike its sibling in `azure-devops/golang/abstracts/go.yaml`. Adding them would make dependency bumps a partial cache hit rather than a total miss.
