### PR TITLE
fix(golang): tested projects that keep the application under main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Fixed
 
 - propagated the version-tag release-recovery path to the `bundler`, `dotnet`, `gradle`, `npm`, `pdm`, and `yarn` library workflows, which were missing it. Their `delivery-release` job only fired on a `main`-branch bump merge, so a bump whose `main` run failed the quality gate could not be recovered by (re-)pushing its tag the way `maven-library.yaml` (and `composer`/`go`) already allowed — the job stayed skipped on the tag ref and no release was cut. All library workflows now share the same two-path condition
+- added `main/` to the directories the Go test script collects, so projects that keep the whole application under `main/` (a common shape for AWS Lambda handlers, whose build tooling expects the entry point in a fixed directory) are actually tested. Previously such a project either failed the tests stage outright with `No directories found to test`, or — when it also happened to have a `pkg/` — passed the stage while none of the tests under `main/` ever ran
 
 ## [4.18.0] - 2026-07-23
 

--- a/global/scripts/languages/golang/test/run.sh
+++ b/global/scripts/languages/golang/test/run.sh
@@ -28,6 +28,12 @@ directories=""
 [ -d "$(pwd)/cmd" ] && directories="$directories ./cmd/..."
 [ -d "$(pwd)/pkg" ] && directories="$directories ./pkg/..."
 [ -d "$(pwd)/internal" ] && directories="$directories ./internal/..."
+# Some Go projects (typically AWS Lambda handlers, where the build tooling
+# expects the entry point in a fixed directory) keep the whole application
+# under `main/` instead of `cmd/` + `internal/`. Without this, such a project
+# either fails outright with "No directories found to test" or, when it also
+# happens to have a `pkg/`, passes the stage while none of its tests run.
+[ -d "$(pwd)/main" ] && directories="$directories ./main/..."
 
 # check if directories is empty, meaning no directories were found
 if [ -z "$directories" ]; then


### PR DESCRIPTION
The Go test script only collected `cmd/`, `pkg/` and `internal/` as directories to test. Projects that keep the whole application under `main/` — a common shape for AWS Lambda handlers, whose build tooling expects the entry point in a fixed directory — were therefore handled wrongly in two different ways:

- with no `cmd/`, `pkg/` or `internal/` at all, the script hit `No directories found to test` and exited `1`, so the tests stage could never pass no matter what the project did;
- with a `pkg/` present alongside `main/`, the stage passed — but it only ran `./pkg/...`, so every test under `main/` was silently skipped. A project could have a green tests stage and a full test suite that had never executed in CI.

This adds `main/` to the collected directories, matching the existing `cmd`/`pkg`/`internal` lines. The change is additive and inert for projects that do not have a `main/` directory.

### Verification

Run against three real Go projects, using the script from this branch:

| Layout | Before | After |
|---|---|---|
| `main/` only | `No directories found to test`, exit 1 | `Testing code in the following directories: ./main/...`, exit 0 |
| `pkg/` + `main/`, tests under `main/` | `./pkg/...` only — tests never ran | `./pkg/... ./main/...` — the previously skipped tests run and pass |
| `pkg/` + `main/`, no tests | `./pkg/...`, exit 0 | `./pkg/... ./main/...`, exit 0 |

`shellcheck -s sh` reports nothing new for the file (the three pre-existing informational findings are unchanged).
