### PR TITLE
test(golang): covered the ./... fallback for non-conventional module layouts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -761,8 +761,8 @@ Test scripts are located in `.github/tests/`.
 #### Pipeline-Specific Issues
 
 **Issue: "No directories found to test it" (Go projects)**
-- **Cause:** Go project structure doesn't match expected layout
-- **Solution:** Ensure your project has `cmd/`, `pkg/`, or `internal/` directories
+- **Cause:** a Go module that uses none of the `cmd/`, `pkg/`, or `internal/` directories (packages kept at the repository root or under a differently named directory)
+- **Solution:** none required -- the test runner now falls back to testing the whole module (`./...`) when none of those directories exist; modules that do use them keep their existing, narrower test scope
 
 **Issue: "golangci-lint: command not found"**
 - **Cause:** golangci-lint not installed or not in PATH

--- a/.github/tests/test-go-validation.sh
+++ b/.github/tests/test-go-validation.sh
@@ -417,6 +417,90 @@ else
   exit 1
 fi
 
+# Test 5: Project with a non-conventional layout (no cmd/, pkg/ or internal/)
+echo ""
+echo "Test 5: Non-conventional module layout (./... fallback)"
+echo "======================================================="
+
+TEST_DIR_FLAT="/tmp/go-test-validation-flat-layout"
+rm -rf "$TEST_DIR_FLAT"
+mkdir -p "$TEST_DIR_FLAT/main"
+
+cat > "$TEST_DIR_FLAT/go.mod" << 'EOF'
+module github.com/test/validation-flat-layout
+
+go 1.25.1
+EOF
+
+# Production code kept at the repository root instead of under cmd/pkg/internal
+cat > "$TEST_DIR_FLAT/calculator.go" << 'EOF'
+package calculator
+
+func Add(a, b int) int {
+	return a + b
+}
+
+func UncoveredFunction() string {
+	return "not tested"
+}
+EOF
+
+cat > "$TEST_DIR_FLAT/calculator_test.go" << 'EOF'
+package calculator
+
+import "testing"
+
+func TestAdd(t *testing.T) {
+	result := Add(5, 3)
+	if result != 8 {
+		t.Errorf("Add(5, 3) = %d; want 8", result)
+	}
+}
+EOF
+
+# Entry point kept under main/ rather than the conventional cmd/
+cat > "$TEST_DIR_FLAT/main/main.go" << 'EOF'
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println(greeting())
+}
+
+func greeting() string {
+	return "flat layout entry point"
+}
+EOF
+
+cd "$TEST_DIR_FLAT" || exit 1
+echo "Running non-conventional layout test (should fall back to ./...)..."
+FALLBACK_LOG="/tmp/go-test-validation-flat-layout.log"
+if /home/runner/work/pipelines/pipelines/global/scripts/languages/golang/test/run.sh > "$FALLBACK_LOG" 2>&1; then
+  cat "$FALLBACK_LOG"
+  echo "✓ Test 5 PASSED: Non-conventional layout handled via ./... fallback"
+
+  # Verify the runner logged the fallback instead of aborting with a hard error
+  if grep -q "falling back to ./..." "$FALLBACK_LOG"; then
+    echo "✓ Runner logged the ./... fallback"
+  else
+    echo "✗ ERROR: Runner did not log the ./... fallback"
+    exit 1
+  fi
+
+  # Verify the root package was discovered by the ./... fallback
+  if grep -q "calculator.go" coverage.txt; then
+    echo "✓ Root package discovered via ./... fallback and included in coverage"
+  else
+    echo "✗ ERROR: Root package missing from coverage report"
+    exit 1
+  fi
+else
+  cat "$FALLBACK_LOG"
+  echo "✗ Test 5 FAILED: Non-conventional layout scenario"
+  exit 1
+fi
+
 echo ""
 echo "=== All Tests Completed Successfully ==="
 echo "The modified Go test script correctly:"
@@ -431,6 +515,7 @@ echo "✓ Generates synthetic coverage for projects with source but no tests"
 echo "✓ Provides individual function visibility in untested packages"
 echo "✓ Avoids Go 1.25.1 covdata tool dependency issues"
 echo "✓ Handles gocovmerge overlap merge errors gracefully with fallback strategy"
+echo "✓ Falls back to ./... for non-conventional layouts (no cmd/, pkg/ or internal/)"
 echo ""
 echo "Coverage now provides complete visibility into codebase coverage!"
 echo "Test validation completed successfully!"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added a non-conventional-layout scenario to the Go test-runner validation harness (`.github/tests/test-go-validation.sh`) that exercises the `./...` fallback: a module with none of `cmd/`, `pkg/`, or `internal/` (packages kept at the repository root and an entry point under `main/`) now asserts that the runner logs the fallback, tests the whole module, and reports coverage — so a future refactor cannot silently regress the fallback without turning the test red. Also refreshed the "No directories found to test it" troubleshooting entries in `README.md` and `.github/copilot-instructions.md`, which still described the removed hard failure, to document the automatic `./...` fallback
+
 ### Fixed
 
 - mapped `System.AccessToken` into the `env:` of the `Load Custom Configuration` step of the Azure DevOps Go Lambda delivery stage (`azure-devops/golang/stages/40-delivery/lambda.yaml`), the last template that sourced the Go init script without it. The step runs the project `config.sh`, which authenticates private Go module fetches with the built-in pipeline identity; without the mapping the token is empty, the fetch gets `401`, and `go build` inside `sam build` fails with the misleading `no secure protocol found for repository` (Go reports an authentication failure as if no usable protocol existed). The defect stayed hidden for as long as the job's Go module cache kept hitting, then broke delivery on the first cold-cache build. Aliasing the token through the `variables:` block is not a workaround: a variable that expands a secret is itself treated as a secret and is still withheld from the process environment

--- a/README.md
+++ b/README.md
@@ -894,9 +894,9 @@ Two mechanisms guard against this:
 
 **Issue: "No directories found to test it" (Go projects)**
 
-- **Cause:** Go project structure does not match the expected layout
-- **Solution:** Ensure your project has `cmd/`, `pkg/`, or `internal/` directories
-- **Alternative:** Modify the test script to include your custom directories
+- **Cause:** a Go module that uses none of the `cmd/`, `pkg/`, or `internal/` directories -- for example one that keeps its packages at the repository root or under a differently named directory
+- **Solution:** none required -- the test runner now falls back to testing the whole module (`./...`) when none of those directories exist, so the run proceeds instead of aborting
+- **Note:** modules that do use `cmd/`, `pkg/`, or `internal/` keep their existing, narrower test scope
 
 **Issue: "golangci-lint: command not found"**
 


### PR DESCRIPTION
Follows up the Copilot review feedback on #521 (already merged, so its review threads can't be resolved in place).

#521 made the Go test runner (`global/scripts/languages/golang/test/run.sh`) fall back to `./...` when a module has none of `cmd/`, `pkg/`, or `internal/`. Two review comments asked for follow-ups; this PR addresses both.

## 1. Test coverage for the fallback path

The existing scenarios in `.github/tests/test-go-validation.sh` all use `cmd/`/`pkg/`/`internal/`, so the new `./...` fallback was never exercised — a future refactor could silently regress it. Added a scenario for a non-conventional layout: a module with none of those three directories, keeping its packages at the repository root and an entry point under `main/`. It asserts that the runner:

- logs the `./...` fallback (`No cmd/, pkg/ or internal/ directory found - falling back to ./...`),
- discovers the root package and reports coverage over `./...`,
- completes successfully.

## 2. Troubleshooting docs

The "No directories found to test it" entries in `README.md` and `.github/copilot-instructions.md` still described a hard failure requiring `cmd/`/`pkg/`/`internal/`. Updated both to document the automatic `./...` fallback, so they no longer send readers down a now-wrong path.

## Validation

- ran the full `.github/tests/test-go-validation.sh` harness locally — all scenarios pass, including the new one (runner logs the fallback; coverage reported over `./...`).
- `bash -n` and `shellcheck -S warning` clean on the added lines.
- `CHANGELOG.md` updated under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
