### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,7 @@ This repository provides comprehensive SDLC pipeline templates for GitHub Action
 ## Quick Reference
 
 **Essential Commands:**
-- `make test` - Run all validation tests (Go, Lambda, YAML merge, Trivy merge, SonarQube, release tag, tftest-gen, order-check, docker-multi-arch, basic-checks, dependency-check)
+- `make test` - Run all validation tests (Go, Lambda, YAML merge, Trivy merge, SonarQube, release tag, tftest-gen, order-check, docker-multi-arch, basic-checks, dependency-check, goreleaser-prepare, release-version-extraction, release-reconcile)
 - `make test-go-script` - Test Go script changes specifically
 - `make test-lambda` - Test Lambda template validation specifically
 - `make test-yaml-merge` - Test YAML merge validation specifically
@@ -643,7 +643,7 @@ docker build -t test-image -f global/containers/awscli.latest/Dockerfile global/
 
 ### Test Suite Usage
 ```bash
-# Run all validation tests (Go, Lambda, YAML merge, Trivy merge, SonarQube, release tag, tftest-gen, order-check, docker-multi-arch, basic-checks, dependency-check)
+# Run all validation tests (Go, Lambda, YAML merge, Trivy merge, SonarQube, release tag, tftest-gen, order-check, docker-multi-arch, basic-checks, dependency-check, goreleaser-prepare, release-version-extraction, release-reconcile)
 make test
 
 # Run individual test suites
@@ -659,6 +659,8 @@ make test-docker-multi-arch
 make test-basic-checks
 make test-dependency-check
 make test-goreleaser-prepare
+make test-release-version-extraction
+make test-release-reconcile
 ```
 
 Test scripts are located in `.github/tests/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 - added a non-conventional-layout scenario to the Go test-runner validation harness (`.github/tests/test-go-validation.sh`) that exercises the `./...` fallback: a module with none of `cmd/`, `pkg/`, or `internal/` (packages kept at the repository root and an entry point under `main/`) now asserts that the runner logs the fallback, tests the whole module, and reports coverage — so a future refactor cannot silently regress the fallback without turning the test red. Also refreshed the "No directories found to test it" troubleshooting entries in `README.md` and `.github/copilot-instructions.md`, which still described the removed hard failure, to document the automatic `./...` fallback
 
+### Changed
+
+- refreshed the `make test` command listing in `CLAUDE.md` and `.github/copilot-instructions.md` to enumerate the `test-goreleaser-prepare`, `test-release-version-extraction`, and `test-release-reconcile` sub-targets, which the Makefile's aggregate `test` target already runs but the docs' summary parenthetical (and the copilot per-target block) still omitted
+
 ### Fixed
 
 - mapped `System.AccessToken` into the `env:` of the `Load Custom Configuration` step of the Azure DevOps Go Lambda delivery stage (`azure-devops/golang/stages/40-delivery/lambda.yaml`), the last template that sourced the Go init script without it. The step runs the project `config.sh`, which authenticates private Go module fetches with the built-in pipeline identity; without the mapping the token is empty, the fetch gets `401`, and `go build` inside `sam build` fails with the misleading `no secure protocol found for repository` (Go reports an authentication failure as if no usable protocol existed). The defect stayed hidden for as long as the job's Go module cache kept hitting, then broke delivery on the first cold-cache build. Aliasing the token through the `variables:` block is not a workaround: a variable that expands a secret is itself treated as a secret and is still withheld from the process environment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ A CI/CD pipeline templates library providing reusable workflows for **GitHub Act
 ## Commands
 
 ```bash
-make test              # Run all validation tests (Go, Lambda, YAML merge, Trivy merge, SonarQube, release tag, tftest-gen, order-check, docker-multi-arch, basic-checks, dependency-check)
+make test              # Run all validation tests (Go, Lambda, YAML merge, Trivy merge, SonarQube, release tag, tftest-gen, order-check, docker-multi-arch, basic-checks, dependency-check, goreleaser-prepare, release-version-extraction, release-reconcile)
 make test-go-script    # Test Go validation script only
 make test-lambda       # Test Lambda template validation only
 make test-yaml-merge   # Test YAML merge validation only


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.