### PR TITLE
fix(azure-devops): forwarded WORKING_DIRECTORY to the javascript tests stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- forwarded `WORKING_DIRECTORY` to the JavaScript `30-tests` stage in `azure-devops/javascript/yarn-docker.yaml`, which only the `10-code-check` stage received. The tests stage and its `test-all`/`test-e2e` steps build every published path as `<WORKING_DIRECTORY>/<relative-path>`, so with the parameter unset it defaulted to the empty string and the coverage summary location resolved to the absolute `/cobertura.xml` at the filesystem root instead of the repository-root file. `PublishCodeCoverageResults@2` (with `failIfCoverageEmpty: true`) then reported "no coverage found" and failed the tests stage for every consumer, even when the repository produced a valid `cobertura.xml`. The call now passes `WORKING_DIRECTORY: "$(System.DefaultWorkingDirectory)"` exactly like the sibling `10-code-check` call, so the coverage summary resolves to the repository root
+
 ## [4.19.0] - 2026-07-27
 
 ### Added

--- a/azure-devops/javascript/yarn-docker.yaml
+++ b/azure-devops/javascript/yarn-docker.yaml
@@ -40,6 +40,7 @@ stages:
     parameters:
       RUN_BEFORE_TESTS: ${{ parameters.RUN_BEFORE_TESTS }}
       RUN_AFTER_TESTS: ${{ parameters.RUN_AFTER_TESTS }}
+      WORKING_DIRECTORY: "$(System.DefaultWorkingDirectory)"
 
   - template: 'stages/35-management/yarn.yaml'
     parameters:


### PR DESCRIPTION
## Problem

The shared Azure DevOps JavaScript pipeline template `azure-devops/javascript/yarn-docker.yaml` forwards the `WORKING_DIRECTORY` parameter to the `10-code-check` stage but not to the `30-tests` stage.

The tests stage and its `test-all` / `test-e2e` steps construct every published path as `<WORKING_DIRECTORY>/<relative-path>` (for the coverage summary, `<WORKING_DIRECTORY>/cobertura.xml`). Because the caller never forwarded the parameter, it defaulted to the empty string and the path resolved to the **absolute** `/cobertura.xml` at the filesystem root — which never matches the coverage file produced at the repository root.

As a result, `PublishCodeCoverageResults@2` (configured with `failIfCoverageEmpty: true`) reports **"no coverage found"** and fails the tests stage for every consumer of this template, even when the repository generates a valid `cobertura.xml`.

## Fix

Forward `WORKING_DIRECTORY: "$(System.DefaultWorkingDirectory)"` to the `30-tests` template call, exactly as the sibling `10-code-check` call already does. The coverage summary then resolves to the repository root. The `stages/30-tests/yarn.yaml` template already declares and forwards the parameter down to both the `test-all` and `test-e2e` steps, so only the caller needed fixing.

This mirrors the golang template, whose tests stage publishes its coverage summary from the repository-root working directory as well.

## Change

`azure-devops/javascript/yarn-docker.yaml` — one line added to the `stages/30-tests/yarn.yaml` template call:

```yaml
  - template: 'stages/30-tests/yarn.yaml'
    parameters:
      RUN_BEFORE_TESTS: ${{ parameters.RUN_BEFORE_TESTS }}
      RUN_AFTER_TESTS: ${{ parameters.RUN_AFTER_TESTS }}
      WORKING_DIRECTORY: "$(System.DefaultWorkingDirectory)"   # added
```

`CHANGELOG.md` updated under `[Unreleased] > Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
