### PR TITLE
fix(azure-devops): run javascript e2e on the default pool by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed the JavaScript `30-tests` stage's `test:e2e` job failing the whole `tests` stage when no self-hosted pool is configured: `SELF_HOSTED_POOL` defaulted to the literal `"$(SELF_HOSTED_POOL)"`, which resolved to a non-existent pool and raised a pool-validity error at job start (before `continueOnError` could apply). It now defaults to an empty string, so `test:e2e` runs on the default pool by default; setting `SELF_HOSTED_POOL` (forwarded from `azure-devops/javascript/yarn-docker.yaml`) is an optional override to run e2e on a dedicated self-hosted pool for heavy workloads
+
 ## [4.19.1] - 2026-07-29
 
 ### Fixed

--- a/azure-devops/javascript/stages/30-tests/yarn.yaml
+++ b/azure-devops/javascript/stages/30-tests/yarn.yaml
@@ -1,7 +1,7 @@
 parameters:
-  - name: 'SELF_HOSTED_POOL' # optional parameter for heavy workloads within JS language
+  - name: 'SELF_HOSTED_POOL' # optional pool for the heavy e2e job; empty runs e2e on the default pool
     type: 'string'
-    default: "$(SELF_HOSTED_POOL)"
+    default: ''
   - name: 'WORKING_DIRECTORY'
     type: 'string'
     default: ''

--- a/azure-devops/javascript/yarn-docker.yaml
+++ b/azure-devops/javascript/yarn-docker.yaml
@@ -12,6 +12,11 @@ parameters:
   - name: 'RUN_AFTER_TESTS'
     type: 'string'
     default: 'echo "No after script"'
+  # Optional self-hosted pool for the heavy e2e job. Empty (the default) runs
+  # e2e on the standard/default pool; set it to run e2e on a dedicated pool.
+  - name: 'SELF_HOSTED_POOL'
+    type: 'string'
+    default: ''
 
   - name: 'RUN_BEFORE_MANAGEMENT'
     type: 'string'
@@ -41,6 +46,7 @@ stages:
       RUN_BEFORE_TESTS: ${{ parameters.RUN_BEFORE_TESTS }}
       RUN_AFTER_TESTS: ${{ parameters.RUN_AFTER_TESTS }}
       WORKING_DIRECTORY: "$(System.DefaultWorkingDirectory)"
+      SELF_HOSTED_POOL: ${{ parameters.SELF_HOSTED_POOL }}
 
   - template: 'stages/35-management/yarn.yaml'
     parameters:


### PR DESCRIPTION
### Problem
The JavaScript `30-tests` stage's `test:e2e` job defaulted `SELF_HOSTED_POOL` to the literal `"$(SELF_HOSTED_POOL)"`. When a consumer doesn't define that variable it resolves to a non-existent pool name, and the job raises a **pool-validity error at job start** — which happens *before* `continueOnError` can apply, so it fails the whole `tests` stage instead of being tolerated.

### Fix
Default `SELF_HOSTED_POOL` to an empty string. The `pool:` override is already guarded by `${{ if ne(parameters.SELF_HOSTED_POOL, '') }}`, so with the empty default the `test:e2e` job simply **runs on the default pool** like every other job. Running e2e on a dedicated self-hosted pool becomes an **optional** feature: set `SELF_HOSTED_POOL` (now also forwarded through `azure-devops/javascript/yarn-docker.yaml`) and the job pins to it.

- `azure-devops/javascript/stages/30-tests/yarn.yaml`: `SELF_HOSTED_POOL` default `"$(SELF_HOSTED_POOL)"` → `''` (e2e job otherwise unchanged).
- `azure-devops/javascript/yarn-docker.yaml`: added and forwarded the optional `SELF_HOSTED_POOL` parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)