### PR TITLE
fix(azure-devops): render helm code-check with ci/*-values.yaml when present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Fixed
 
 - fixed the JavaScript `30-tests` stage's `test:e2e` job failing the whole `tests` stage when no self-hosted pool is configured: `SELF_HOSTED_POOL` defaulted to the literal `"$(SELF_HOSTED_POOL)"`, which resolved to a non-existent pool and raised a pool-validity error at job start (before `continueOnError` could apply). It now defaults to an empty string, so `test:e2e` runs on the default pool by default; setting `SELF_HOSTED_POOL` (forwarded from `azure-devops/javascript/yarn-docker.yaml`) is an optional override to run e2e on a dedicated self-hosted pool for heavy workloads
+- fixed the Helm `10-code-check` stage's `helm lint`/`helm template` validation failing for charts that declare `required` values without defaults (a recommended practice to prevent stale or misconfigured deploys): the commands ran with no values, so any such chart failed the hard code-check gate and skipped every downstream stage (including SonarQube analysis). The step now renders against the chart's `ci/*-values.yaml` example files when present (the chart-testing convention), and keeps the previous no-values behaviour when there are none
 
 ## [4.19.1] - 2026-07-29
 

--- a/azure-devops/helm/stages/10-code-check/helm.yaml
+++ b/azure-devops/helm/stages/10-code-check/helm.yaml
@@ -13,7 +13,7 @@ stages:
             inputs:
               helmVersionToInstall: 'latest'
 
-          - script: |
+          - bash: |
               set -euo pipefail
               # Charts that declare `required` values without defaults (a good
               # practice to prevent stale or misconfigured deploys) cannot be

--- a/azure-devops/helm/stages/10-code-check/helm.yaml
+++ b/azure-devops/helm/stages/10-code-check/helm.yaml
@@ -13,8 +13,23 @@ stages:
             inputs:
               helmVersionToInstall: 'latest'
 
-          - script: helm lint .
-            displayName: 'Run Helm lint'
-
-          - script: helm template . > /dev/null
-            displayName: 'Run Helm template validation'
+          - script: |
+              set -euo pipefail
+              # Charts that declare `required` values without defaults (a good
+              # practice to prevent stale or misconfigured deploys) cannot be
+              # rendered with no values, so a plain `helm lint`/`helm template`
+              # fails. If the chart ships example values under `ci/` (the
+              # chart-testing convention, `ci/*-values.yaml`), render against
+              # them so validation passes; with no such files the behaviour is
+              # unchanged (renders with the chart defaults).
+              values_args=()
+              shopt -s nullglob
+              for file in ci/*-values.yaml; do
+                values_args+=(--values "$file")
+              done
+              if [ ${#values_args[@]} -gt 0 ]; then
+                echo "Rendering with CI example values: ${values_args[*]}"
+              fi
+              helm lint . "${values_args[@]}"
+              helm template . "${values_args[@]}" > /dev/null
+            displayName: 'Run Helm lint and template validation'


### PR DESCRIPTION
## Problem

The Helm `10-code-check` stage validates charts with:

```sh
helm lint .
helm template . > /dev/null
```

Both run with **no values**. Charts that declare `required` values without a default in `values.yaml` — a recommended practice to prevent stale or misconfigured deployments — therefore fail rendering, which fails the hard `code check` gate and skips every downstream stage (including the SonarQube analysis in `35-management`). Such a chart can never get a green pipeline even when it is perfectly valid.

## Fix

Render `helm lint`/`helm template` against the chart's example values under `ci/` when present — the well-established [chart-testing](https://github.com/helm/chart-testing) convention (`ci/*-values.yaml`):

```sh
values_args=()
shopt -s nullglob
for file in ci/*-values.yaml; do
  values_args+=(--values "$file")
done
helm lint . "${values_args[@]}"
helm template . "${values_args[@]}" > /dev/null
```

- **Backward compatible:** when a chart has no `ci/*-values.yaml`, `values_args` is empty and the commands run exactly as before (rendering with the chart defaults).
- A chart that needs required values simply adds `ci/ci-values.yaml` with example values (kept out of the packaged chart via `.helmignore`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)