### PR TITLE
fix(sonarqube): waited for the server before scanning so a restart stops failing builds

### DIFF
--- a/global/scripts/tools/sonarqube/run.sh
+++ b/global/scripts/tools/sonarqube/run.sh
@@ -128,9 +128,32 @@ fi
 #
 # turning a transient infrastructure blip into a red pipeline. Wait for the server
 # to report it can accept an analysis before scanning.
-SONAR_WAIT_TIMEOUT="${SONAR_WAIT_TIMEOUT:-300}"
-SONAR_WAIT_INTERVAL="${SONAR_WAIT_INTERVAL:-10}"
-SONAR_MAX_ATTEMPTS="${SONAR_MAX_ATTEMPTS:-3}"
+# These three tunables are used in numeric comparisons and arithmetic under
+# `set -e`, so a caller passing `5m`, `300s` or an empty string would abort the
+# script with "Illegal number" before the scanner ever ran — the exact opposite
+# of this wrapper's purpose. A zero interval would also spin without ever
+# advancing the budget. Fall back to the default whenever the value is not an
+# integer at or above the stated minimum.
+sonar_int_or_default() {
+  # $1 name (for the warning), $2 supplied value, $3 default, $4 minimum
+  case "$2" in
+    '' | *[!0-9]*) ;;
+    *)
+      if [ "$2" -ge "$4" ]; then
+        printf '%s' "$2"
+        return 0
+      fi
+      ;;
+  esac
+  echo "$1='$2' is not an integer >= $4; falling back to $3." >&2
+  printf '%s' "$3"
+}
+
+# A timeout of 0 is legitimate — it means "do not wait" — but the interval and
+# the attempt count must both be at least 1 to make progress.
+SONAR_WAIT_TIMEOUT=$(sonar_int_or_default SONAR_WAIT_TIMEOUT "${SONAR_WAIT_TIMEOUT-300}" 300 0)
+SONAR_WAIT_INTERVAL=$(sonar_int_or_default SONAR_WAIT_INTERVAL "${SONAR_WAIT_INTERVAL-10}" 10 1)
+SONAR_MAX_ATTEMPTS=$(sonar_int_or_default SONAR_MAX_ATTEMPTS "${SONAR_MAX_ATTEMPTS-3}" 3 1)
 
 # Resolve the server URL from the environment, falling back to the properties file.
 sonar_host_url() {

--- a/global/scripts/tools/sonarqube/run.sh
+++ b/global/scripts/tools/sonarqube/run.sh
@@ -117,4 +117,97 @@ else
   fi
 fi
 
-sonar-scanner
+# SonarQube commonly runs as a single replica, so any restart — a node scale-down,
+# a chart upgrade, an OOM — leaves its ingress answering `503 Service Temporarily
+# Unavailable` for as long as the JVM and the embedded Elasticsearch take to boot.
+# The scanner queries the server on its very first call, so it used to fail the
+# build outright with:
+#
+#   ERROR Failed to query server version: GET .../api/server/version failed with
+#   HTTP 503 Service Unavailable
+#
+# turning a transient infrastructure blip into a red pipeline. Wait for the server
+# to report it can accept an analysis before scanning.
+SONAR_WAIT_TIMEOUT="${SONAR_WAIT_TIMEOUT:-300}"
+SONAR_WAIT_INTERVAL="${SONAR_WAIT_INTERVAL:-10}"
+SONAR_MAX_ATTEMPTS="${SONAR_MAX_ATTEMPTS:-3}"
+
+# Resolve the server URL from the environment, falling back to the properties file.
+sonar_host_url() {
+  if [ -n "${SONAR_HOST_URL:-}" ]; then
+    printf '%s' "${SONAR_HOST_URL%/}"
+    return 0
+  fi
+  sed -n 's/^[[:space:]]*sonar\.host\.url[[:space:]]*=[[:space:]]*//p' sonar-project.properties 2>/dev/null |
+    tail -n 1 | sed 's#/*$##'
+}
+
+# Succeeds only when SonarQube is ready to accept an analysis. `STARTING`,
+# `DB_MIGRATION_NEEDED` and `DB_MIGRATION_RUNNING` are all "not yet" — the scanner
+# would be rejected in each of those states.
+sonar_is_up() {
+  _status_body=$(curl -sS --noproxy '*' --max-time 10 "$1/api/system/status" 2>/dev/null) || return 1
+  case "$_status_body" in
+    *'"status":"UP"'*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Blocks until SonarQube is up or the budget runs out. Exhausting the budget is
+# deliberately NOT fatal here: the scanner runs anyway so the real error is what
+# fails the build, rather than this wrapper masking it with a timeout message.
+wait_for_sonar() {
+  _url=$(sonar_host_url)
+  if [ -z "$_url" ]; then
+    echo "Neither SONAR_HOST_URL nor sonar.host.url is set; skipping the availability check."
+    return 0
+  fi
+
+  _waited=0
+  while ! sonar_is_up "$_url"; do
+    if [ "$_waited" -ge "$SONAR_WAIT_TIMEOUT" ]; then
+      echo "SonarQube at $_url did not become available within ${SONAR_WAIT_TIMEOUT}s; running the scanner anyway so the underlying error surfaces." >&2
+      return 0
+    fi
+    echo "SonarQube at $_url is not ready yet (waited ${_waited}s of ${SONAR_WAIT_TIMEOUT}s); retrying in ${SONAR_WAIT_INTERVAL}s..."
+    sleep "$SONAR_WAIT_INTERVAL"
+    _waited=$((_waited + SONAR_WAIT_INTERVAL))
+  done
+
+  if [ "$_waited" -gt 0 ]; then
+    echo "SonarQube became available after ${_waited}s."
+  fi
+  return 0
+}
+
+wait_for_sonar
+
+# Retry ONLY when the server dropped out mid-analysis. A failure while the server
+# is still up is a genuine one — a failed quality gate, a bad configuration, an
+# unparseable report — and must surface on the first attempt instead of being
+# retried three times and reported minutes late.
+attempt=1
+while :; do
+  set +e
+  sonar-scanner
+  scanner_status=$?
+  set -e
+
+  if [ "$scanner_status" -eq 0 ]; then
+    break
+  fi
+
+  scanner_url=$(sonar_host_url)
+  if [ -z "$scanner_url" ] || sonar_is_up "$scanner_url"; then
+    exit "$scanner_status"
+  fi
+
+  if [ "$attempt" -ge "$SONAR_MAX_ATTEMPTS" ]; then
+    echo "SonarQube was still unreachable after ${SONAR_MAX_ATTEMPTS} attempts; giving up." >&2
+    exit "$scanner_status"
+  fi
+
+  echo "SonarQube became unreachable during the analysis; waiting for it to come back (attempt ${attempt} of ${SONAR_MAX_ATTEMPTS})." >&2
+  attempt=$((attempt + 1))
+  wait_for_sonar
+done


### PR DESCRIPTION
## Problem

SonarQube commonly runs as a single replica. Any restart — a node scale-down, a chart upgrade, an OOM — leaves its ingress answering `503 Service Temporarily Unavailable` for as long as the JVM and embedded Elasticsearch take to boot (minutes, if the data directory is an `emptyDir` and the search index has to be rebuilt).

`run.sh` ended in a bare `sonar-scanner`, and the scanner queries the server on its very first call. So the build died immediately with:

```
ERROR Failed to query server version: GET https://<host>/api/server/version failed with HTTP 503 Service Unavailable
INFO EXECUTION FAILURE
```

A transient infrastructure blip became a red pipeline, in every repository that uses these scripts.

Observed on 2026-07-30: the cluster autoscaler evicted the SonarQube pod three times inside one hour, and two unrelated pipelines (`backend/relayer-http` build 55662, `frontend/app` build 55641) failed within 40 seconds of each other purely because their scans landed during a boot.

## Changes

- **Wait for readiness before scanning.** Poll `/api/system/status` until the server reports `UP`, bounded by `SONAR_WAIT_TIMEOUT` (default 300s, interval `SONAR_WAIT_INTERVAL`, default 10s). `STARTING`, `DB_MIGRATION_NEEDED` and `DB_MIGRATION_RUNNING` all count as "not yet", since the scanner is rejected in each of those states.
- **Never mask a real error.** If the budget is exhausted the scanner runs anyway, so the genuine failure is what fails the build rather than a wrapper timeout message.
- **Retry only for the right reason.** A scan that fails while the server is still `UP` is a genuine failure — a failed quality gate, a bad configuration, an unparseable report — and exits on the first attempt. Only a server that has gone away mid-analysis triggers a retry (`SONAR_MAX_ATTEMPTS`, default 3).
- **No new required configuration.** The host is read from `SONAR_HOST_URL`, falling back to `sonar.host.url` in `sonar-project.properties`; if neither is set the check is skipped and behaviour is unchanged.

## Verification

`sh -n` and `make shellcheck` are clean (POSIX `sh`, no bashisms).

Behaviour tested against the live server while it was genuinely flapping:

| Case | Result |
|---|---|
| Real server reachable | `UP` detected |
| Unreachable host (`127.0.0.1:59999`) | reported not-up, no hang |
| Trailing slash in `SONAR_HOST_URL` | stripped |
| No env var, `sonar.host.url` in properties | resolved from file |
| Nothing configured | check skipped, returns 0 |
| Budget exhausted | returned 0 after exactly the budget, scan proceeds |

## Note

This makes CI tolerant of the restart; it does not stop the restart. The root cause on our side is a SonarQube deployment with no `cluster-autoscaler.kubernetes.io/safe-to-evict` annotation, no PodDisruptionBudget, and an `emptyDir` data volume — fixed separately in the infrastructure repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)