### PR TITLE
fix(cyclonedx): stopped failing on modules with several main packages

### DIFF
--- a/.github/tests/test-cyclonedx-main-detection.sh
+++ b/.github/tests/test-cyclonedx-main-detection.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Validation script for the Go CycloneDX generator's entry-point detection.
+#
+# The script under test picks between `cyclonedx-gomod app` (one binary) and
+# `cyclonedx-gomod mod` (the whole module). `app -main` accepts exactly ONE path, so a module
+# with two entry points used to hand it a newline-separated list and abort with
+# `invalid options: - main: "..." does not exist`, producing no BOM at all.
+#
+# `cyclonedx-gomod` itself is not invoked here: the decision, not the tool, is what regressed.
+# A stub on PATH records the command line the script would have run.
+
+set -euo pipefail
+
+echo "=== Testing Go CycloneDX entry-point detection ==="
+echo ""
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CYCLONEDX_SCRIPT="$SCRIPT_DIR/../../global/scripts/languages/golang/cyclonedx/run.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+print_result() {
+  local result=$1
+  local message=$2
+  if [ "$result" -eq 0 ]; then
+    echo -e "${GREEN}  PASS: $message${NC}"
+    ((TESTS_PASSED++)) || true
+  else
+    echo -e "${RED}  FAIL: $message${NC}"
+    ((TESTS_FAILED++)) || true
+  fi
+}
+
+TEST_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$TEST_DIR"; }
+trap cleanup EXIT
+
+# A fake GOPATH whose bin/ holds a cyclonedx-gomod that only records its arguments, plus a `go`
+# that answers `go env GOPATH` and swallows `go install` so nothing is downloaded.
+FAKE_GOPATH="$TEST_DIR/gopath"
+mkdir -p "$FAKE_GOPATH/bin" "$TEST_DIR/shim"
+
+cat > "$FAKE_GOPATH/bin/cyclonedx-gomod" <<'STUB'
+#!/usr/bin/env bash
+# Record the invocation, then write a placeholder BOM at the -output path.
+echo "$@" > "$INVOCATION_LOG"
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "-output" ]; then
+    mkdir -p "$(dirname "$arg")"
+    echo '{}' > "$arg"
+  fi
+  previous="$arg"
+done
+STUB
+chmod +x "$FAKE_GOPATH/bin/cyclonedx-gomod"
+
+cat > "$TEST_DIR/shim/go" <<STUB
+#!/usr/bin/env bash
+case "\$1 \${2:-}" in
+  "env GOPATH") echo "$FAKE_GOPATH" ;;
+  "install "*) exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$TEST_DIR/shim/go"
+
+# Run the generator inside a throwaway module laid out by the caller.
+# Usage: run_generator <workdir>
+run_generator() {
+  local workdir="$1"
+  export INVOCATION_LOG="$workdir/invocation.log"
+  : > "$INVOCATION_LOG"
+
+  (
+    cd "$workdir" || exit 1
+    PATH="$TEST_DIR/shim:$PATH" \
+    GOPATH="$FAKE_GOPATH" \
+    REPORT_PATH="build/reports" \
+    PREFIX="" \
+      sh "$CYCLONEDX_SCRIPT" > "$workdir/stdout.log" 2>&1
+  )
+}
+
+new_module() {
+  local workdir
+  workdir="$(mktemp -d "$TEST_DIR/module-XXXXXX")"
+  printf 'module example.test\n\ngo 1.24\n' > "$workdir/go.mod"
+  echo "$workdir"
+}
+
+# =============================================================================
+# Test 1: one entry point -> `app` mode, with that single path
+# =============================================================================
+echo "TEST 1: a module with ONE main package uses 'app' mode"
+workdir="$(new_module)"
+mkdir -p "$workdir/cmd"
+echo 'package main' > "$workdir/cmd/main.go"
+run_generator "$workdir"
+invocation="$(cat "$workdir/invocation.log")"
+if [[ "$invocation" == app\ * ]] && [[ "$invocation" == *"-main ./cmd"* ]]; then
+  print_result 0 "single main package resolves to 'app -main ./cmd'"
+else
+  print_result 1 "expected 'app ... -main ./cmd', got: $invocation"
+fi
+
+# =============================================================================
+# Test 2: two entry points -> `mod` mode, and never a multi-line -main
+# =============================================================================
+echo "TEST 2: a module with TWO main packages falls back to 'mod' mode"
+workdir="$(new_module)"
+mkdir -p "$workdir/cmd" "$workdir/cmd/worker"
+echo 'package main' > "$workdir/cmd/main.go"
+echo 'package main' > "$workdir/cmd/worker/main.go"
+run_generator "$workdir"
+invocation="$(cat "$workdir/invocation.log")"
+if [[ "$invocation" == mod\ * ]]; then
+  print_result 0 "two main packages resolve to 'mod' mode"
+else
+  print_result 1 "expected 'mod ...', got: $invocation"
+fi
+
+if [[ "$invocation" != *"-main"* ]]; then
+  print_result 0 "'mod' mode passes no -main flag"
+else
+  print_result 1 "-main must not be passed in 'mod' mode: $invocation"
+fi
+
+# The regression itself: a newline-separated list reaching -main.
+if [ "$(wc -l < "$workdir/invocation.log")" -eq 1 ]; then
+  print_result 0 "the invocation is a single line (no multi-line -main value)"
+else
+  print_result 1 "the invocation spans several lines: $invocation"
+fi
+
+# =============================================================================
+# Test 3: two entry points still produce a BOM
+# =============================================================================
+echo "TEST 3: a module with two main packages still writes a BOM"
+if [ -f "$workdir/build/reports/bom.json" ]; then
+  print_result 0 "bom.json exists for a multi-entry-point module"
+else
+  print_result 1 "no bom.json was written: $(cat "$workdir/stdout.log")"
+fi
+
+# =============================================================================
+# Test 4: a pkg/ directory keeps taking `mod` mode, unchanged
+# =============================================================================
+echo "TEST 4: a module with a pkg/ directory uses 'mod' mode"
+workdir="$(new_module)"
+mkdir -p "$workdir/pkg" "$workdir/cmd"
+echo 'package example' > "$workdir/pkg/example.go"
+echo 'package main' > "$workdir/cmd/main.go"
+run_generator "$workdir"
+invocation="$(cat "$workdir/invocation.log")"
+if [[ "$invocation" == mod\ * ]]; then
+  print_result 0 "pkg/ takes precedence and resolves to 'mod' mode"
+else
+  print_result 1 "expected 'mod ...', got: $invocation"
+fi
+
+# =============================================================================
+# Test 5: no entry point at all -> a clear failure, not a silent empty BOM
+# =============================================================================
+echo "TEST 5: a module with NO main package fails loudly"
+workdir="$(new_module)"
+mkdir -p "$workdir/internal"
+echo 'package internal' > "$workdir/internal/example.go"
+if run_generator "$workdir"; then
+  print_result 1 "expected a non-zero exit when no main package exists"
+else
+  print_result 0 "a module with no main package exits non-zero"
+fi
+
+if grep -q "Could not find a directory containing Go files" "$workdir/stdout.log"; then
+  print_result 0 "the failure names the missing entry point"
+else
+  print_result 1 "the failure message is missing: $(cat "$workdir/stdout.log")"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "=============================="
+echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"
+echo "=============================="
+[ "$TESTS_FAILED" -eq 0 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed CycloneDX BOM generation failing on every build of a Go module that holds MORE THAN ONE `main` package. `global/scripts/languages/golang/cyclonedx/run.sh` fed the raw, newline-separated output of `find ... -name main.go -exec dirname {} \;` straight into `cyclonedx-gomod app -main`, which accepts exactly one path — so a module with two entry points (a server plus a scheduled worker, a CLI plus its daemon) was rejected with `invalid options: - main: "..." does not exist`, no `bom.json` was ever written, and the SBOM upload that consumes it had nothing to send. The script now counts the `main` packages: exactly one still takes the `app` path unchanged, while several fall back to `cyclonedx-gomod mod`, which describes the MODULE rather than a single binary. That is the safe direction for vulnerability tracking — a module BOM is a superset of every binary's dependency set, so it can over-report a component but never miss one, whereas picking one `main` arbitrarily would silently drop whatever only the others import. Covered by `.github/tests/test-cyclonedx-main-detection.sh`
+
 ## [4.20.0] - 2026-08-01
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TAG := latest
 ROOT := global/containers
 CONTAINER_REGISTRY = ghcr.io/rios0rios0/pipelines
 
-.PHONY: login setup-buildx build-and-push test-go-script test-lambda test-yaml-merge test-trivy-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-terraform-validate test-docker-multi-arch test-basic-checks test-dependency-check test-goreleaser-prepare test-release-version-extraction test-release-reconcile test
+.PHONY: login setup-buildx build-and-push test-go-script test-cyclonedx-main test-lambda test-yaml-merge test-trivy-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-terraform-validate test-docker-multi-arch test-basic-checks test-dependency-check test-goreleaser-prepare test-release-version-extraction test-release-reconcile test
 
 login:
 	docker login $(CONTAINER_REGISTRY)
@@ -21,6 +21,10 @@ build-and-push:
 test-go-script:
 	@echo "Running Go test script validation..."
 	@./.github/tests/test-go-validation.sh
+
+test-cyclonedx-main:
+	@echo "Running Go CycloneDX entry-point detection validation..."
+	@./.github/tests/test-cyclonedx-main-detection.sh
 
 test-lambda:
 	@echo "Running Lambda template validation..."
@@ -78,5 +82,5 @@ test-release-reconcile:
 	@echo "Running release reconciliation validation..."
 	@./.github/tests/test-release-reconcile.sh
 
-test: test-go-script test-lambda test-yaml-merge test-trivy-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-terraform-validate test-docker-multi-arch test-basic-checks test-dependency-check test-goreleaser-prepare test-release-version-extraction test-release-reconcile
+test: test-go-script test-cyclonedx-main test-lambda test-yaml-merge test-trivy-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-terraform-validate test-docker-multi-arch test-basic-checks test-dependency-check test-goreleaser-prepare test-release-version-extraction test-release-reconcile
 	@echo "All tests completed successfully!"

--- a/global/scripts/languages/golang/cyclonedx/run.sh
+++ b/global/scripts/languages/golang/cyclonedx/run.sh
@@ -23,11 +23,29 @@ if [ -d "pkg" ]; then
   echo "Found 'pkg' directory, using 'cyclonedx-gomod mod' command..."
   "$(go env GOPATH)/bin/cyclonedx-gomod" mod -json -output "$BOM_PATH/bom.json" -licenses
 else
-  folder="$(find . -type f -name main.go -not -path '*/.go/*' -exec dirname {} \;)"
-  if [ -z "$folder" ]; then
+  # One line per directory holding a `main.go`. A module may legitimately hold SEVERAL -- a
+  # server plus a scheduled worker, a CLI plus its daemon -- and `-main` accepts exactly one
+  # path, so handing it the raw multi-line result made cyclonedx-gomod refuse the whole run with
+  # `invalid options: - main: "..." does not exist`. No BOM was written, the SBOM upload that
+  # consumes it had nothing to send, and the job failed on every single build.
+  folders="$(find . -type f -name main.go -not -path '*/.go/*' -exec dirname {} \;)"
+  if [ -z "$folders" ]; then
     echo "Could not find a directory containing Go files"
     exit 1
   fi
-  echo "Using 'cyclonedx-gomod app' command..."
-  "$(go env GOPATH)/bin/cyclonedx-gomod" app -json -output "$BOM_PATH/bom.json" -packages -files -licenses -main "$folder"
+
+  mainCount="$(printf '%s\n' "$folders" | grep -c '^')"
+
+  if [ "$mainCount" -gt 1 ]; then
+    # `app` describes ONE binary's reachable dependencies; with several binaries in the module no
+    # single one represents the repository, and picking one arbitrarily would silently drop the
+    # dependencies only the others pull in. `mod` describes the module -- a superset of every
+    # binary's dependencies -- which is the safe direction for vulnerability tracking: it can
+    # over-report a component, never miss one.
+    echo "Found $mainCount main packages, using 'cyclonedx-gomod mod' command..."
+    "$(go env GOPATH)/bin/cyclonedx-gomod" mod -json -output "$BOM_PATH/bom.json" -licenses
+  else
+    echo "Using 'cyclonedx-gomod app' command..."
+    "$(go env GOPATH)/bin/cyclonedx-gomod" app -json -output "$BOM_PATH/bom.json" -packages -files -licenses -main "$folders"
+  fi
 fi

--- a/global/scripts/languages/golang/cyclonedx/run.sh
+++ b/global/scripts/languages/golang/cyclonedx/run.sh
@@ -34,15 +34,15 @@ else
     exit 1
   fi
 
-  mainCount="$(printf '%s\n' "$folders" | grep -c '^')"
+  main_count="$(printf '%s\n' "$folders" | grep -c '^')"
 
-  if [ "$mainCount" -gt 1 ]; then
+  if [ "$main_count" -gt 1 ]; then
     # `app` describes ONE binary's reachable dependencies; with several binaries in the module no
     # single one represents the repository, and picking one arbitrarily would silently drop the
     # dependencies only the others pull in. `mod` describes the module -- a superset of every
     # binary's dependencies -- which is the safe direction for vulnerability tracking: it can
     # over-report a component, never miss one.
-    echo "Found $mainCount main packages, using 'cyclonedx-gomod mod' command..."
+    echo "Found $main_count main packages, using 'cyclonedx-gomod mod' command..."
     "$(go env GOPATH)/bin/cyclonedx-gomod" mod -json -output "$BOM_PATH/bom.json" -licenses
   else
     echo "Using 'cyclonedx-gomod app' command..."


### PR DESCRIPTION
## Problem

`global/scripts/languages/golang/cyclonedx/run.sh` picks the entry point for
`cyclonedx-gomod app` like this:

```sh
folder="$(find . -type f -name main.go -not -path '*/.go/*' -exec dirname {} \;)"
"$(go env GOPATH)/bin/cyclonedx-gomod" app ... -main "$folder"
```

`find` prints **one line per match**, and `-main` accepts exactly one path. A Go
module with two entry points — a server plus a scheduled worker, a CLI plus its
daemon — therefore hands `-main` a newline-separated list and the tool refuses
the whole run:

```
invalid options:
 - main: "..." does not exist
```

No `bom.json` is written, so the SBOM upload step that consumes it has nothing
to send, and the job fails on **every** build. A single-entry-point module is
unaffected, which is why this went unnoticed.

## Fix

Count the `main` packages before choosing the mode:

- **exactly one** → `cyclonedx-gomod app -main <dir>`, unchanged
- **more than one** → `cyclonedx-gomod mod`, which describes the *module*
- **none** → the existing explicit failure, unchanged
- a `pkg/` directory still short-circuits to `mod` first, unchanged

`mod` rather than picking one `main`: `app` reports the dependencies reachable
from a single binary, so choosing one arbitrarily would silently drop whatever
only the other entry points import. A module BOM is a superset of every
binary's dependency set — it can over-report a component, never miss one, which
is the safe direction for vulnerability tracking.

## Tests

New `.github/tests/test-cyclonedx-main-detection.sh`, wired into `make test`
and therefore into the CI `Run all validation tests` step. It stubs
`cyclonedx-gomod` and `go` on `PATH` and asserts the *decision*, not the tool:

| # | Case | Expected |
|---|---|---|
| 1 | one `main` package | `app -main ./cmd` |
| 2 | two `main` packages | `mod`, no `-main`, single-line invocation |
| 3 | two `main` packages | a `bom.json` is still written |
| 4 | a `pkg/` directory | `mod` (precedence unchanged) |
| 5 | no `main` package | non-zero exit with the existing message |

8 assertions, all passing. Reverting `run.sh` to its previous form fails 3 of
them — including the multi-line `-main` value that is the regression itself.

`shellcheck --severity=warning` is clean on both the changed script and the new
test.