### PR TITLE
feat(dart): added a complete Dart and Flutter pipeline for all three platforms

### DIFF
--- a/.docs/examples/github-flutter-artifacts/.github/workflows/ci.yaml
+++ b/.docs/examples/github-flutter-artifacts/.github/workflows/ci.yaml
@@ -1,0 +1,26 @@
+name: 'CI/CD Pipeline'
+
+on:
+  push:
+    branches: [ 'main' ]
+    tags: [ '*' ]
+  pull_request:
+    branches: [ 'main' ]
+  workflow_dispatch:
+
+permissions:
+  contents: 'write' # required for releases
+  checks: 'write' # required for test results
+  # NOTE: no `security-events: write` here, unlike the Go/Python/Java examples.
+  # That permission exists for CodeQL, which has no Dart extractor and is
+  # therefore not part of the Dart pipeline. See the workflow's own header.
+
+jobs:
+  pipeline:
+    uses: 'rios0rios0/pipelines/.github/workflows/flutter-artifacts.yaml@main'
+    with:
+      # Omit to track the current stable release; pin for reproducible builds.
+      flutter_version: '3.47.0'
+      build_web: true
+      build_android: true
+      android_targets: 'apk appbundle'

--- a/.docs/examples/github-flutter-artifacts/Makefile
+++ b/.docs/examples/github-flutter-artifacts/Makefile
@@ -1,0 +1,17 @@
+SCRIPTS_DIR ?= $(HOME)/Development/github.com/rios0rios0/pipelines
+
+# -- Project-specific targets --------------------------------------------------
+
+run:
+	flutter run
+
+devices:
+	flutter devices
+
+# -- Pipeline targets (lint, test, sast, sca, cyclonedx, build, setup) ---------
+#
+# Order matters: `common.mk` first so `dart.mk` can append the Dart-native SCA to
+# its `sast` target.
+
+-include $(SCRIPTS_DIR)/makefiles/common.mk
+-include $(SCRIPTS_DIR)/makefiles/dart.mk

--- a/.docs/examples/github-flutter-artifacts/README.md
+++ b/.docs/examples/github-flutter-artifacts/README.md
@@ -1,0 +1,77 @@
+# GitHub Actions -- Flutter with Artifact Delivery Example
+
+Minimal example showing how to use the reusable Flutter workflow from `rios0rios0/pipelines`.
+
+## Files
+
+| File                        | Purpose                                                    |
+|-----------------------------|------------------------------------------------------------|
+| `.github/workflows/ci.yaml` | Calls the reusable `flutter-artifacts.yaml` workflow       |
+| `Makefile`                  | Local development with pipeline tools via `makefiles/`     |
+
+## Setup
+
+1. Copy `.github/workflows/ci.yaml` into your repository.
+2. Push to `main` or open a pull request to trigger the pipeline.
+
+No SDK setup step is needed. The pipeline detects Dart vs Flutter from your
+`pubspec.yaml` and installs the matching SDK from Google's release archive.
+
+## Local Development
+
+```bash
+# First-time setup -- clone the pipelines repository
+curl -sSL https://raw.githubusercontent.com/rios0rios0/pipelines/main/clone.sh | bash
+
+# Then use the Makefile targets
+make lint       # dart format --fix, dart analyze, unused-code scan
+make test       # flutter test with coverage -> JUnit + Cobertura + LCOV
+make sast       # Semgrep, Trivy, Hadolint, ShellCheck, Gitleaks, OSV-Scanner
+make sca        # OSV-Scanner over pubspec.lock only
+make build      # flutter build apk (override with DART_BUILD_TARGETS)
+```
+
+## What the Pipeline Does
+
+1. **Code Check** -- `dart format`, `dart analyze`, unused-code/files scan
+2. **Security** -- Semgrep, Gitleaks, Hadolint, Trivy (IaC + SCA), OSV-Scanner
+3. **Tests** -- `flutter test` with coverage, published as JUnit + Cobertura
+4. **Management** -- CycloneDX SBOM published as a job artifact
+5. **Delivery** -- web bundle and Android APK/AAB as downloadable artifacts
+
+## Two Tools Are Missing, On Purpose
+
+| Tool        | Why it is absent                                                                                                                                             |
+|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **CodeQL**  | Has no Dart extractor ([dart-lang/sdk#52953](https://github.com/dart-lang/sdk/issues/52953)). A CodeQL job on a Dart repository can only fail.                |
+| **`p/dart` Semgrep pack** | The Semgrep Registry publishes no Dart rules. The pipeline ships [its own Dart ruleset](../../../global/scripts/tools/semgrep/rules/dart.yaml) instead. |
+
+`dart analyze` and the shipped Semgrep rules together cover what those two would
+have. See the repository README's *Dart & Flutter Tool Coverage* section for the
+full matrix.
+
+## Useful Inputs
+
+| Input              | Default | Purpose                                                    |
+|--------------------|---------|------------------------------------------------------------|
+| `flutter_version`  | current stable | Pin an exact SDK version for reproducible builds    |
+| `build_web`        | `true`  | Build the web bundle                                       |
+| `build_android`    | `true`  | Build Android artifacts                                    |
+| `android_targets`  | `apk appbundle` | APK for QA sideloading, AAB for Google Play         |
+
+## Building an iOS Archive
+
+`ipa` is not part of this workflow: it needs a `macos-latest` runner and a
+signing identity that belongs to your project, not to a shared template. Add:
+
+```yaml
+  delivery-ios:
+    runs-on: 'macos-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/dart/stages/40-delivery/build@main'
+        with:
+          toolchain: 'flutter'
+          targets: 'ipa'
+```
+
+The runner builds it with `--no-codesign`; add your own signing step afterwards.

--- a/.docs/examples/gitlab-dart-library/.gitlab-ci.yml
+++ b/.docs/examples/gitlab-dart-library/.gitlab-ci.yml
@@ -1,0 +1,21 @@
+# GitLab CI -- Dart package published to pub.dev.
+#
+# Validation (`dart pub publish --dry-run`) runs on every merge request and
+# default-branch build; the real publication runs only on a tag. Publishing to
+# pub.dev is irreversible, so the checks pub.dev performs at upload time have to
+# fail the merge rather than the release.
+include:
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/dart-library.yaml'
+
+variables:
+  # Pin the SDK for reproducible builds; omit to track the current stable.
+  DART_SDK_VERSION: 'latest'
+  # Fail the analyze job on lints too, not only on errors and warnings.
+  DART_FATAL_INFOS: 'true'
+  # Fail the test job below this line-coverage percentage.
+  DART_COVERAGE_MINIMUM: '80'
+
+# Required CI/CD variables (Settings > CI/CD > Variables):
+#   PUB_TOKEN                   masked + protected -- pub.dev credential
+#   SONAR_HOST_URL, SONAR_TOKEN masked             -- report:sonarqube
+#   DEPENDENCY_TRACK_HOST_URL, DEPENDENCY_TRACK_TOKEN masked -- report:dependency-track

--- a/.docs/examples/gitlab-dart-library/Makefile
+++ b/.docs/examples/gitlab-dart-library/Makefile
@@ -1,0 +1,17 @@
+SCRIPTS_DIR ?= $(HOME)/Development/github.com/rios0rios0/pipelines
+
+# -- Project-specific targets --------------------------------------------------
+
+run:
+	dart run
+
+docs:
+	dart doc
+
+# -- Pipeline targets (lint, test, sast, sca, cyclonedx, build, setup) ---------
+#
+# Order matters: `common.mk` first so `dart.mk` can append the Dart-native SCA to
+# its `sast` target.
+
+-include $(SCRIPTS_DIR)/makefiles/common.mk
+-include $(SCRIPTS_DIR)/makefiles/dart.mk

--- a/.docs/examples/gitlab-dart-library/README.md
+++ b/.docs/examples/gitlab-dart-library/README.md
@@ -1,0 +1,51 @@
+# GitLab CI -- Dart Package (pub.dev) Example
+
+Minimal example showing how to use the Dart library template from
+`rios0rios0/pipelines` on GitLab CI.
+
+## Files
+
+| File            | Purpose                                                  |
+|-----------------|----------------------------------------------------------|
+| `.gitlab-ci.yml`| Includes the remote `gitlab/dart/dart-library.yaml`      |
+| `Makefile`      | Local development with pipeline tools via `makefiles/`   |
+
+## Setup
+
+1. Copy `.gitlab-ci.yml` into your repository root.
+2. Add the CI/CD variables listed at the bottom of that file.
+3. Push to your default branch or open a merge request.
+
+The SDK is installed by the pipeline from Google's release archive and cached in
+`$CI_PROJECT_DIR/.sdk`, so no runner image with Dart preinstalled is needed.
+
+## Local Development
+
+```bash
+curl -sSL https://raw.githubusercontent.com/rios0rios0/pipelines/main/clone.sh | bash
+
+make lint       # dart format --fix, dart analyze, unused-code scan
+make test       # dart test with coverage -> JUnit + Cobertura + LCOV
+make sast       # Semgrep, Trivy, Hadolint, ShellCheck, Gitleaks, OSV-Scanner
+make cyclonedx  # CycloneDX SBOM at build/reports/bom.json
+```
+
+## Publishing
+
+`publish:validate` runs on every merge request and default-branch build and does
+**not** upload anything -- it runs the same validation pub.dev performs at upload
+time. `publish:prod` runs only on a tag and needs `PUB_TOKEN` as a **masked and
+protected** variable.
+
+The token is never passed on the command line: the runner hands
+`dart pub token add` the variable's *name* (`--env-var PUB_TOKEN`) and pub reads
+the value from the environment.
+
+For a self-hosted pub server, set `PUB_HOSTED_URL`.
+
+## Coverage in the Merge Request Widget
+
+Dart emits coverage as LCOV only. The test runner converts it to Cobertura (with
+a dependency-free converter shipped in this repository) so GitLab renders
+per-line coverage in the MR diff, and prints `COVERAGE_PERCENT=NN.NN%` for the
+job's `coverage:` regex.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -164,6 +164,30 @@ This repository provides comprehensive SDLC pipeline templates for GitHub Action
 |-----------------|------------------------------|-----------------------------------------------|
 | **Checkstyle**  | Java code style enforcement  | `global/scripts/languages/java/checkstyle/`   |
 
+#### Dart / Flutter Tools
+
+One set of scripts serves both toolchains: `dart_detect_toolchain` reads the project's `pubspec.yaml` and picks `flutter` when it finds a `flutter:\n    sdk: flutter` dependency, `dart` otherwise (`DART_TOOLCHAIN` overrides). The SDK is installed from Google's release archive rather than pulled as a Docker image, so no anonymous Docker Hub rate limit can fail the job. Every runner honours `DART_DRY_RUN=true`, which resolves and records commands without installing or executing anything — that is what makes the family testable offline.
+
+| Tool             | Purpose                                                     | Script Location                                |
+|------------------|-------------------------------------------------------------|------------------------------------------------|
+| **setup**        | Installs the Dart or Flutter SDK                            | `global/scripts/languages/dart/setup/run.sh`     |
+| **format**       | `dart format` gate (`--fix` rewrites in place)              | `global/scripts/languages/dart/format/run.sh`    |
+| **analyze**      | `dart analyze` → JUnit + JSON, configurable severity gate    | `global/scripts/languages/dart/analyze/run.sh`   |
+| **test**         | Tests + coverage → JUnit, Cobertura, LCOV                   | `global/scripts/languages/dart/test/run.sh`      |
+| **unused**       | Unused code and unused file detection                        | `global/scripts/languages/dart/unused/run.sh`    |
+| **sca**          | OSV-Scanner over `pubspec.lock`                              | `global/scripts/languages/dart/sca/run.sh`       |
+| **cyclonedx**    | SBOM generation for pub projects                             | `global/scripts/languages/dart/cyclonedx/run.sh` |
+| **build**        | Release artifacts (APK, AAB, web, exe, …)                    | `global/scripts/languages/dart/build/run.sh`     |
+| **publish**      | pub.dev publication with a validation gate                   | `global/scripts/languages/dart/publish/run.sh`   |
+
+**Two tools in the standard stack do not support Dart, and both gaps are handled deliberately — do not "restore consistency" with the other languages:**
+
+- **CodeQL is omitted from every Dart template.** It ships no Dart extractor ([dart-lang/sdk#52953](https://github.com/dart-lang/sdk/issues/52953)); a `sast:codeql` job could only fail. `makefiles/dart.mk` leaves `CODEQL_LANGUAGE` unset and `common.mk` skips the target with an explanation.
+- **The Semgrep Registry publishes no Dart rules** (`p/dart` is HTTP 404, `r/dart` returns an empty `rules: []`). `semgrep/run.sh` probes the registry and skips a missing pack — passing one is fatal to the whole invocation — then loads this repository's own ruleset from `global/scripts/tools/semgrep/rules/dart.yaml`.
+- **OWASP Dependency-Check has no pub analyzer**, so OSV-Scanner covers Dart SCA alongside `sca:trivy` (Trivy reads `pubspec.lock` but records SDK-provided dependencies at version `0.0.0`, leaving them unmatched).
+
+`.github/tests/test-dart-pipeline.sh` fails if any of these decisions is reverted.
+
 #### Terraform / Terra Tools
 
 The Terra CLI pipeline test stage exposes parallel jobs on every platform (Azure DevOps, GitLab CI, GitHub Actions) — two always on, one opt-in. `test:all` delegates to `test-all/run.sh`, which auto-detects which of the two heavier tiers the consumer has, runs only those, merges the JUnit outputs into `build/reports/junit-terra-all.xml`, and exits `0` when neither has tests so stack-only repos pass without a bespoke opt-out. `test:structural` and the opt-in `test:validate` each run on their own parallel job with their own JUnit. Only `validate` **resolves** references (`terraform validate`) — the other three tiers parse, so a root module referencing an undeclared module/variable/resource/output stays green everywhere else while failing every plan. `test:validate` is off by default (`ENABLE_VALIDATE` / `enable_validate`) because it needs the network for provider downloads and, for private module sources, credentials; each platform reuses its existing pre-script hook (`PRE_STEPS` / `VALIDATE_PRE_SCRIPT` / `pre_script`) and `VALIDATE_ROOTS` (default `stacks`) overrides the search.
@@ -346,14 +370,16 @@ Two rules govern this family and must not be relaxed:
 | **PHP**                | ✅              | ❌         | ❌            | Composer, Docker                          |
 | **Ruby**               | ✅              | ❌         | ❌            | Bundler, Docker                           |
 | **.NET/C#**            | ✅              | ✅         | ✅            | Framework, Core, Docker, PowerShell       |
+| **Dart**               | ✅              | ✅         | ✅            | pub.dev publishing, Docker, native binary |
+| **Flutter**            | ✅              | ✅         | ✅            | Web bundle, Android APK/AAB, Docker       |
 | **Logstash**           | ❌              | ✅         | ❌            | Docker delivery                           |
 | **Terraform**          | ❌              | ✅         | ✅            | Infrastructure as Code                    |
 | **Terra CLI**          | ✅              | ✅         | ✅            | Terraform/Terragrunt wrapper              |
 
 **Pipeline Templates Available:**
-- **GitHub Actions:** `go.yaml`, `go-docker.yaml`, `go-binary.yaml`, `go-library.yaml`, `pdm.yaml`, `pdm-docker.yaml`, `pdm-library.yaml`, `gradle.yaml`, `gradle-docker.yaml`, `gradle-library.yaml`, `maven.yaml`, `maven-docker.yaml`, `maven-library.yaml`, `yarn.yaml`, `yarn-docker.yaml`, `yarn-library.yaml`, `npm.yaml`, `npm-docker.yaml`, `npm-library.yaml`, `composer.yaml`, `composer-docker.yaml`, `composer-library.yaml`, `bundler.yaml`, `bundler-docker.yaml`, `bundler-library.yaml`, `dotnet.yaml`, `dotnet-docker.yaml`, `dotnet-library.yaml`, `terra.yaml`
-- **GitLab CI:** `go-docker.yaml`, `go-binary.yaml`, `go-docker-k8s-deployment.yaml`, `go-sam.yaml`, `gradle-docker.yaml`, `gradle-docker-k8s-deployment.yaml`, `gradle-library.yaml`, `maven-docker.yaml`, `pdm-docker.yaml`, `pdm-docker-k8s-deployment.yaml`, `pdm-library.yaml`, `yarn-docker.yaml`, `yarn-docker-k8s-deployment.yaml`, `framework.yaml`, `powershell.yaml`, `logstash-docker.yaml`, `terraform/terra.yaml`, `terra/terra.yaml`
-- **Azure DevOps:** `go-docker.yaml`, `go-arm.yaml`, `go-docker-arm.yaml`, `go-docker-k8s.yaml`, `go-docker-with-registry.yaml`, `go-function-arm.yaml`, `go-lambda-sam.yaml`, `go-lambda.yaml`, `go-library.yaml`, `kotlin-gradle.yaml`, `pdm-docker.yaml`, `yarn-docker.yaml`, `core.yaml`, `terraform/terra.yaml`, `terra/terra.yaml`
+- **GitHub Actions:** `go.yaml`, `go-docker.yaml`, `go-binary.yaml`, `go-library.yaml`, `pdm.yaml`, `pdm-docker.yaml`, `pdm-library.yaml`, `gradle.yaml`, `gradle-docker.yaml`, `gradle-library.yaml`, `maven.yaml`, `maven-docker.yaml`, `maven-library.yaml`, `yarn.yaml`, `yarn-docker.yaml`, `yarn-library.yaml`, `npm.yaml`, `npm-docker.yaml`, `npm-library.yaml`, `composer.yaml`, `composer-docker.yaml`, `composer-library.yaml`, `bundler.yaml`, `bundler-docker.yaml`, `bundler-library.yaml`, `dotnet.yaml`, `dotnet-docker.yaml`, `dotnet-library.yaml`, `dart.yaml`, `dart-docker.yaml`, `dart-library.yaml`, `flutter-artifacts.yaml`, `terra.yaml`
+- **GitLab CI:** `go-docker.yaml`, `go-binary.yaml`, `go-docker-k8s-deployment.yaml`, `go-sam.yaml`, `gradle-docker.yaml`, `gradle-docker-k8s-deployment.yaml`, `gradle-library.yaml`, `maven-docker.yaml`, `pdm-docker.yaml`, `pdm-docker-k8s-deployment.yaml`, `pdm-library.yaml`, `yarn-docker.yaml`, `yarn-docker-k8s-deployment.yaml`, `framework.yaml`, `powershell.yaml`, `logstash-docker.yaml`, `dart/dart-docker.yaml`, `dart/dart-library.yaml`, `dart/flutter-docker.yaml`, `dart/flutter-artifacts.yaml`, `terraform/terra.yaml`, `terra/terra.yaml`
+- **Azure DevOps:** `go-docker.yaml`, `go-arm.yaml`, `go-docker-arm.yaml`, `go-docker-k8s.yaml`, `go-docker-with-registry.yaml`, `go-function-arm.yaml`, `go-lambda-sam.yaml`, `go-lambda.yaml`, `go-library.yaml`, `kotlin-gradle.yaml`, `pdm-docker.yaml`, `yarn-docker.yaml`, `core.yaml`, `dart/dart-docker.yaml`, `dart/dart-library.yaml`, `dart/flutter-docker.yaml`, `dart/flutter-artifacts.yaml`, `terraform/terra.yaml`, `terra/terra.yaml`
 
 ## Common Tasks
 

--- a/.github/tests/test-dart-pipeline.sh
+++ b/.github/tests/test-dart-pipeline.sh
@@ -1,0 +1,767 @@
+#!/usr/bin/env bash
+# The assertion helpers take their condition as a STRING and `eval` it, so
+# ShellCheck cannot see that CMD / COV_OUT / MK_OUT / PY_OUT are read, and reports
+# them as unused. They are not. A file-wide directive is only honoured before the
+# first command, which is why it sits here rather than beside each assignment.
+# shellcheck disable=SC2034
+set -e
+
+# Validation for the Dart / Flutter pipeline: the scripts under
+# `global/scripts/languages/dart/`, the Dart Semgrep ruleset, and the templates
+# on all three platforms.
+#
+# Five classes of assertion, each pinning something that would otherwise fail
+# silently or late:
+#
+#   1. STRUCTURAL -- every stage is wired on GitHub Actions, GitLab CI and Azure
+#      DevOps, and every template points at a script that exists. A stage added
+#      to one platform and forgotten on the other two is the most likely
+#      regression in this repository, and nothing else in CI would catch it:
+#      each file is valid YAML on its own.
+#
+#   2. TOOLCHAIN DISPATCH -- the same script must drive `flutter` on a Flutter
+#      project and `dart` on a pure Dart one, chosen from `pubspec.yaml`. Getting
+#      this backwards produces failures deep inside the widget-test bindings that
+#      name nothing useful, so it is asserted on the argv each script builds.
+#
+#   3. TOOL-GAP -- CodeQL has no Dart extractor and the Semgrep Registry
+#      publishes no Dart rules. Both gaps are handled by deliberate ABSENCES and
+#      SUBSTITUTIONS, which are exactly the kind of decision a later "let's make
+#      this consistent with the other languages" edit silently undoes. These
+#      cases fail if a `codeql` job reappears in a Dart template, or if the
+#      shipped Dart Semgrep ruleset goes missing.
+#
+#   4. REPORT CONVERSION -- Dart emits coverage as LCOV and its analyzer output
+#      as a pipe-delimited line format; two of the three platforms can read
+#      neither. The converters are exercised against fixtures covering the cases
+#      a naive implementation gets wrong (escaped pipes, repeated `SF:` records).
+#
+#   5. SECURITY -- no credential may reach a recorded command line. Every report
+#      directory here is published as a job artifact on all three platforms, so a
+#      token on argv would be both visible in `ps` on a self-hosted runner AND
+#      persisted into a downloadable artifact. Each case feeds a distinctive
+#      sentinel and greps the whole report tree for it. This assertion must never
+#      be relaxed.
+#
+# The whole suite runs OFFLINE with no Dart SDK, no Flutter SDK and no network:
+# the run scripts are driven under `DART_DRY_RUN=true`, which resolves and
+# records every command without installing or executing anything. Semgrep
+# assertions that need the binary are skipped when it is absent (the repository's
+# CI job does not install it), but the ruleset's presence and YAML validity are
+# always checked.
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export SCRIPTS_DIR
+
+DART_DIR="$SCRIPTS_DIR/global/scripts/languages/dart"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_SKIPPED=0
+
+assert_true() {
+  local description="$1"
+  local condition="$2"
+  if eval "$condition"; then
+    echo -e "${GREEN}  PASS: $description${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}  FAIL: $description${NC}"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+assert_equals() {
+  local description="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "${GREEN}  PASS: $description${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}  FAIL: $description${NC}"
+    echo -e "${RED}        expected: $expected${NC}"
+    echo -e "${RED}        actual:   $actual${NC}"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+skip() {
+  echo -e "${YELLOW}  SKIP: $1${NC}"
+  TESTS_SKIPPED=$((TESTS_SKIPPED + 1))
+}
+
+WORK_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$WORK_DIR"; }
+trap cleanup EXIT
+
+# make_project <dir> <flutter|dart>
+#
+# Build a minimal but realistic package. The Flutter variant declares
+# `flutter:\n    sdk: flutter` under `dependencies`, which is the marker the
+# toolchain detection actually keys on.
+make_project() {
+  local dir="$WORK_DIR/$1"
+  local kind="$2"
+  rm -rf "${dir:?}"
+  mkdir -p "$dir/lib" "$dir/test" "$dir/bin"
+
+  if [[ "$kind" == "flutter" ]]; then
+    cat > "$dir/pubspec.yaml" <<'EOF'
+name: sample_app
+description: A sample Flutter application.
+version: 1.4.2+7
+environment:
+  sdk: '>=3.5.0 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^1.2.0
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+EOF
+  else
+    cat > "$dir/pubspec.yaml" <<'EOF'
+name: sample_cli
+description: A sample Dart command-line application.
+version: 2.0.1
+environment:
+  sdk: '>=3.5.0 <4.0.0'
+dependencies:
+  args: ^2.4.0
+dev_dependencies:
+  test: ^1.24.0
+EOF
+  fi
+
+  printf 'void main() {}\n' > "$dir/lib/${1}.dart"
+  printf 'void main() {}\n' > "$dir/test/sample_test.dart"
+  printf 'void main() {}\n' > "$dir/bin/sample_cli.dart"
+  : > "$dir/pubspec.lock"
+  : > "$dir/analysis_options.yaml"
+  printf '%s' "$dir"
+}
+
+# run_dart <project-dir> <script> [env assignments...]
+#
+# Drive one runner in dry-run mode and expose:
+#   STATUS -- the exit code
+#   CMD    -- the recorded command journal, newline-joined
+run_dart() {
+  local project="$1"
+  local script="$2"
+  shift 2
+
+  STATUS=0
+  (
+    cd "$project"
+    env DART_DRY_RUN=true SCRIPTS_DIR="$SCRIPTS_DIR" "$@" \
+      sh "$DART_DIR/$script/run.sh" > "$WORK_DIR/last.log" 2>&1
+  ) || STATUS=$?
+
+  CMD="$(cat "$project"/build/reports/*/command.txt 2>/dev/null || true)"
+}
+
+assert_no_leak() {
+  local description="$1"
+  local project="$2"
+  local sentinel="$3"
+  if grep -rqF "$sentinel" "$project/build/reports" 2>/dev/null; then
+    echo -e "${RED}  FAIL: $description (sentinel found in the published report tree)${NC}"
+    grep -rlF "$sentinel" "$project/build/reports" 2>/dev/null | sed 's/^/        /'
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  else
+    echo -e "${GREEN}  PASS: $description${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  fi
+}
+
+echo "=========================================="
+echo "Dart / Flutter pipeline validation"
+echo "=========================================="
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 1. Scripts exist, are executable, and declare POSIX sh ---"
+# ---------------------------------------------------------------------------
+
+for script in setup format analyze test unused sca cyclonedx build publish; do
+  assert_true "$script/run.sh exists" "[[ -f '$DART_DIR/$script/run.sh' ]]"
+  assert_true "$script/run.sh is executable" "[[ -x '$DART_DIR/$script/run.sh' ]]"
+  assert_true "$script/run.sh declares '#!/usr/bin/env sh'" \
+    "head -1 '$DART_DIR/$script/run.sh' | grep -q '^#!/usr/bin/env sh$'"
+done
+
+# `common.sh` is sourced, never executed -- the same contract the deploy family
+# follows. An executable bit on it invites someone to run it, which does nothing.
+assert_true "common.sh exists" "[[ -f '$DART_DIR/common.sh' ]]"
+assert_true "common.sh is NOT executable (it is sourced, never run)" \
+  "[[ ! -x '$DART_DIR/common.sh' ]]"
+assert_true "common.sh is not named run.sh (so the CI permission check skips it)" \
+  "[[ ! -f '$DART_DIR/common.sh/run.sh' ]]"
+
+for helper in analyze/dart_analyze_report.py test/lcov_to_cobertura.py; do
+  assert_true "$helper exists" "[[ -f '$DART_DIR/$helper' ]]"
+  assert_true "$helper is valid Python" \
+    "python3 -m py_compile '$DART_DIR/$helper'"
+done
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 2. Toolchain dispatch: Flutter project ---"
+# ---------------------------------------------------------------------------
+
+FLUTTER_PROJECT="$(make_project flutterapp flutter)"
+
+run_dart "$FLUTTER_PROJECT" analyze
+assert_true "flutter: dependencies are resolved with 'flutter pub get'" \
+  "grep -qx 'flutter pub get' <<< \"\$CMD\""
+# `flutter analyze` has no `--format` option (flutter/flutter#95090), so the
+# machine-readable path must go through the SDK's bundled `dart`.
+assert_true "flutter: analysis runs 'dart analyze --format=machine', not 'flutter analyze'" \
+  "grep -qx 'dart analyze --format=machine .' <<< \"\$CMD\""
+assert_true "flutter: 'flutter analyze' is never invoked" \
+  "! grep -q 'flutter analyze' <<< \"\$CMD\""
+
+run_dart "$FLUTTER_PROJECT" test
+assert_true "flutter: tests run 'flutter test --machine --coverage'" \
+  "grep -qx 'flutter test --machine --coverage' <<< \"\$CMD\""
+assert_true "flutter: the JUnit converter is installed" \
+  "grep -qx 'dart pub global activate junitreport' <<< \"\$CMD\""
+# `flutter test --coverage` writes `coverage/lcov.info` itself; running
+# format_coverage over it would be a no-op at best.
+assert_true "flutter: format_coverage is NOT run (flutter emits LCOV directly)" \
+  "! grep -q 'format_coverage' <<< \"\$CMD\""
+
+run_dart "$FLUTTER_PROJECT" build
+assert_true "flutter: the default build target is an APK" \
+  "grep -q 'flutter build apk --release' <<< \"\$CMD\""
+assert_true "flutter: --build-name is derived from pubspec.yaml, without the build metadata" \
+  "grep -q 'build-name=1.4.2' <<< \"\$CMD\""
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 3. Toolchain dispatch: pure Dart project ---"
+# ---------------------------------------------------------------------------
+
+DART_PROJECT="$(make_project dartcli dart)"
+
+run_dart "$DART_PROJECT" analyze
+assert_true "dart: dependencies are resolved with 'dart pub get'" \
+  "grep -qx 'dart pub get' <<< \"\$CMD\""
+assert_true "dart: 'flutter' is never invoked on a non-Flutter package" \
+  "! grep -q '^flutter ' <<< \"\$CMD\""
+
+run_dart "$DART_PROJECT" test
+# `dart test` spells the reporter flag differently from `flutter test`, and
+# rejects the other one outright.
+assert_true "dart: tests run 'dart test --reporter json'" \
+  "grep -q 'dart test --reporter json --coverage=coverage' <<< \"\$CMD\""
+assert_true "dart: raw VM coverage is converted to LCOV with format_coverage" \
+  "grep -q 'format_coverage --lcov' <<< \"\$CMD\""
+# A CLI package keeps its sources in bin/, so reporting only on lib/ would show
+# it as 0% covered.
+assert_true "dart: coverage reports on both lib/ and bin/ when both exist" \
+  "grep -q -- '--report-on=lib' <<< \"\$CMD\" && grep -q -- '--report-on=bin' <<< \"\$CMD\""
+
+run_dart "$DART_PROJECT" build
+assert_true "dart: the default build target is a native executable" \
+  "grep -q 'dart compile exe' <<< \"\$CMD\""
+assert_true "dart: the entry point is the bin/ file named after the package" \
+  "grep -q 'bin/sample_cli.dart' <<< \"\$CMD\""
+
+# A library with no bin/ has nothing to build and must not fail for it.
+LIB_PROJECT="$(make_project dartlib dart)"
+rm -rf "${LIB_PROJECT:?}/bin"
+run_dart "$LIB_PROJECT" build
+assert_true "dart: a package with no bin/ exits cleanly instead of failing" "[[ $STATUS -eq 0 ]]"
+assert_true "dart: a package with no bin/ builds nothing" \
+  "! grep -q 'dart compile' <<< \"\$CMD\""
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 4. Explicit toolchain override ---"
+# ---------------------------------------------------------------------------
+
+run_dart "$DART_PROJECT" analyze DART_TOOLCHAIN=flutter
+assert_true "DART_TOOLCHAIN=flutter overrides the pubspec detection" \
+  "grep -qx 'flutter pub get' <<< \"\$CMD\""
+
+run_dart "$FLUTTER_PROJECT" analyze DART_TOOLCHAIN=dart
+assert_true "DART_TOOLCHAIN=dart overrides the pubspec detection" \
+  "grep -qx 'dart pub get' <<< \"\$CMD\""
+
+run_dart "$FLUTTER_PROJECT" analyze DART_TOOLCHAIN=auto
+assert_true "DART_TOOLCHAIN=auto falls back to detection rather than being taken literally" \
+  "grep -qx 'flutter pub get' <<< \"\$CMD\""
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 5. Missing test directory is a skip, not a crash ---"
+# ---------------------------------------------------------------------------
+
+NOTESTS="$(make_project notests dart)"
+rm -rf "${NOTESTS:?}/test"
+STATUS=0
+(cd "$NOTESTS" && env SCRIPTS_DIR="$SCRIPTS_DIR" sh "$DART_DIR/test/run.sh" > "$WORK_DIR/notests.log" 2>&1) || STATUS=$?
+assert_true "a package with no test/ directory passes rather than failing" "[[ $STATUS -eq 0 ]]"
+assert_true "a package with no test/ directory still gets a valid JUnit report" \
+  "python3 -c \"import xml.dom.minidom as m; m.parse('$NOTESTS/build/reports/junit.xml')\""
+assert_true "the skip is reported loudly rather than silently" \
+  "grep -q 'no .* directory found' '$WORK_DIR/notests.log'"
+
+STATUS=0
+(cd "$NOTESTS" && env SCRIPTS_DIR="$SCRIPTS_DIR" DART_REQUIRE_TESTS=true sh "$DART_DIR/test/run.sh" > /dev/null 2>&1) || STATUS=$?
+assert_true "DART_REQUIRE_TESTS=true turns the skip into a failure" "[[ $STATUS -eq 1 ]]"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 6. Credentials never reach a recorded command line ---"
+# ---------------------------------------------------------------------------
+
+PUB_PROJECT="$(make_project pubpkg dart)"
+SENTINEL='fixture-pub-credential-placeholder'
+
+STATUS=0
+(cd "$PUB_PROJECT" && env DART_DRY_RUN=true SCRIPTS_DIR="$SCRIPTS_DIR" \
+  PUB_TOKEN="$SENTINEL" sh "$DART_DIR/publish/run.sh" > /dev/null 2>&1) || STATUS=$?
+CMD="$(cat "$PUB_PROJECT"/build/reports/*/command.txt 2>/dev/null || true)"
+assert_true "publish: the dry run validates the package" \
+  "grep -q 'dart pub publish --dry-run' <<< \"\$CMD\""
+assert_no_leak "publish: the pub token is never recorded" "$PUB_PROJECT" "$SENTINEL"
+
+# The real publish path is the one that must pass the token's NAME, never its
+# value. `--env-var PUB_TOKEN` is what makes that possible; a `--token` style
+# flag would put the credential on argv and into the published artifact.
+PUB2="$(make_project pubpkg2 dart)"
+STATUS=0
+(cd "$PUB2" && env SCRIPTS_DIR="$SCRIPTS_DIR" PUB_TOKEN="$SENTINEL" DART_TOOLCHAIN=dart \
+  sh -c 'set -e
+    . "$SCRIPTS_DIR/global/scripts/languages/dart/common.sh"
+    dart_prepare_reports "dart-publish"
+    DART_DRY_RUN=true dart_run dart pub token add https://pub.dev --env-var PUB_TOKEN' \
+  > /dev/null 2>&1) || STATUS=$?
+CMD="$(cat "$PUB2"/build/reports/*/command.txt 2>/dev/null || true)"
+assert_true "publish: authentication passes the variable NAME, not its value" \
+  "grep -q -- '--env-var PUB_TOKEN' <<< \"\$CMD\""
+assert_no_leak "publish: the token value never appears in the report tree" "$PUB2" "$SENTINEL"
+
+# `publish_to: none` marks a package that must never be uploaded anywhere.
+NOPUB="$(make_project nopub dart)"
+printf 'publish_to: none\n' >> "$NOPUB/pubspec.yaml"
+STATUS=0
+(cd "$NOPUB" && env SCRIPTS_DIR="$SCRIPTS_DIR" PUB_TOKEN="$SENTINEL" \
+  sh "$DART_DIR/publish/run.sh" > "$WORK_DIR/nopub.log" 2>&1) || STATUS=$?
+assert_true "publish: 'publish_to: none' short-circuits before any pub command" "[[ $STATUS -eq 0 ]]"
+assert_true "publish: 'publish_to: none' is reported as a deliberate skip" \
+  "grep -q 'not meant to be published' '$WORK_DIR/nopub.log'"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 7. LCOV to Cobertura conversion ---"
+# ---------------------------------------------------------------------------
+
+cat > "$WORK_DIR/lcov.info" <<'EOF'
+SF:lib/main.dart
+DA:1,1
+DA:2,0
+DA:3,5
+BRDA:3,0,0,1
+BRDA:3,0,1,-
+end_of_record
+SF:lib/src/util.dart
+DA:10,2
+DA:11,2
+end_of_record
+SF:lib/main.dart
+DA:2,3
+DA:4,0
+end_of_record
+EOF
+
+COV_OUT="$(python3 "$DART_DIR/test/lcov_to_cobertura.py" "$WORK_DIR/lcov.info" "$WORK_DIR/cobertura.xml" . 2>&1)"
+assert_true "the Cobertura report is well-formed XML" \
+  "python3 -c \"import xml.dom.minidom as m; m.parse('$WORK_DIR/cobertura.xml')\""
+# A repeated `SF:` record for the same file is what a multi-entry-point suite
+# produces. Replacing rather than merging would report only the last suite's
+# hits -- here that would turn 5/6 into 1/2.
+assert_true "repeated SF: records for one file are merged, not replaced" \
+  "grep -q 'COVERAGE_PERCENT=83.33%' <<< \"\$COV_OUT\""
+assert_true "the merged file has all four of its lines" \
+  "grep -c '<line number=' '$WORK_DIR/cobertura.xml' | grep -qx '6'"
+assert_true "a line covered by only the second record counts as covered" \
+  "grep -q '<line number=\"2\" hits=\"3\"/>' '$WORK_DIR/cobertura.xml'"
+assert_true "branch coverage is recomputed from the BRDA rows" \
+  "grep -q 'branches-covered=\"1\" branches-valid=\"2\"' '$WORK_DIR/cobertura.xml'"
+# The GitLab templates scrape this exact spelling with a `coverage:` regex.
+assert_true "the coverage line matches the GitLab 'coverage:' regex" \
+  "grep -qE 'COVERAGE_PERCENT=[0-9.]+%' <<< \"\$COV_OUT\""
+
+STATUS=0
+DART_COVERAGE_MINIMUM=90 python3 "$DART_DIR/test/lcov_to_cobertura.py" \
+  "$WORK_DIR/lcov.info" "$WORK_DIR/c2.xml" . > /dev/null 2>&1 || STATUS=$?
+assert_true "DART_COVERAGE_MINIMUM fails the job below the threshold" "[[ $STATUS -eq 1 ]]"
+
+STATUS=0
+DART_COVERAGE_MINIMUM=80 python3 "$DART_DIR/test/lcov_to_cobertura.py" \
+  "$WORK_DIR/lcov.info" "$WORK_DIR/c3.xml" . > /dev/null 2>&1 || STATUS=$?
+assert_true "DART_COVERAGE_MINIMUM passes at or above the threshold" "[[ $STATUS -eq 0 ]]"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 8. dart analyze machine-format parsing and severity gate ---"
+# ---------------------------------------------------------------------------
+
+# The fourth row carries an ESCAPED PIPE inside its message. A naive split on
+# `|` yields nine fields, shifts every column, and files the finding against the
+# wrong source location -- which is why this row exists.
+cat > "$WORK_DIR/machine.txt" <<'EOF'
+INFO|LINT|AVOID_PRINT|lib/main.dart|28|3|5|Don't invoke 'print' in production code.
+WARNING|STATIC_WARNING|UNUSED_LOCAL_VARIABLE|lib/src/util.dart|12|9|3|The value of the local variable 'foo' isn't used.
+ERROR|COMPILE_TIME_ERROR|UNDEFINED_METHOD|lib/src/api.dart|44|10|7|The method 'fetchz' isn't defined for the type 'Api'.
+INFO|LINT|PREFER_CONST|lib/widgets/card.dart|7|5|9|Use 'a \| b' instead of a pipe here.
+Analyzing project...
+EOF
+
+STATUS=0
+python3 "$DART_DIR/analyze/dart_analyze_report.py" "$WORK_DIR/an" < "$WORK_DIR/machine.txt" > /dev/null 2>&1 || STATUS=$?
+assert_true "the default gate fails on an ERROR" "[[ $STATUS -eq 1 ]]"
+assert_true "the JUnit report is well-formed XML" \
+  "python3 -c \"import xml.dom.minidom as m; m.parse('$WORK_DIR/an/junit-analyze.xml')\""
+assert_true "the JSON report is valid JSON" \
+  "python3 -c \"import json; json.load(open('$WORK_DIR/an/analyze.json'))\""
+assert_equals "all four diagnostics are parsed (the progress line is ignored)" \
+  "4" "$(python3 -c "import json;print(json.load(open('$WORK_DIR/an/analyze.json'))['summary']['total'])")"
+assert_equals "an escaped pipe inside a message is unescaped, not treated as a separator" \
+  "Use 'a | b' instead of a pipe here." \
+  "$(python3 -c "import json;print(json.load(open('$WORK_DIR/an/analyze.json'))['diagnostics'][3]['message'])")"
+assert_equals "the row with the escaped pipe keeps its correct file" \
+  "lib/widgets/card.dart" \
+  "$(python3 -c "import json;print(json.load(open('$WORK_DIR/an/analyze.json'))['diagnostics'][3]['file'])")"
+# Fatal findings become failures; non-fatal ones stay visible as skipped rather
+# than being dropped from the report entirely.
+assert_true "fatal findings are recorded as JUnit failures" \
+  "grep -c '<failure' '$WORK_DIR/an/junit-analyze.xml' | grep -qx '2'"
+assert_true "non-fatal findings stay visible as JUnit skips" \
+  "grep -c '<skipped' '$WORK_DIR/an/junit-analyze.xml' | grep -qx '2'"
+
+head -1 "$WORK_DIR/machine.txt" > "$WORK_DIR/infos.txt"
+STATUS=0
+python3 "$DART_DIR/analyze/dart_analyze_report.py" "$WORK_DIR/an2" < "$WORK_DIR/infos.txt" > /dev/null 2>&1 || STATUS=$?
+assert_true "INFO findings alone do not fail by default" "[[ $STATUS -eq 0 ]]"
+
+STATUS=0
+DART_FATAL_INFOS=true python3 "$DART_DIR/analyze/dart_analyze_report.py" "$WORK_DIR/an3" \
+  < "$WORK_DIR/infos.txt" > /dev/null 2>&1 || STATUS=$?
+assert_true "DART_FATAL_INFOS=true makes INFO findings fatal" "[[ $STATUS -eq 1 ]]"
+
+STATUS=0
+python3 "$DART_DIR/analyze/dart_analyze_report.py" "$WORK_DIR/an4" < /dev/null > /dev/null 2>&1 || STATUS=$?
+assert_true "a clean analysis passes and still writes a valid JUnit report" \
+  "[[ $STATUS -eq 0 ]] && python3 -c \"import xml.dom.minidom as m; m.parse('$WORK_DIR/an4/junit-analyze.xml')\""
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 9. Tool gap: CodeQL is absent, Semgrep is substituted ---"
+# ---------------------------------------------------------------------------
+
+DART_RULES="$SCRIPTS_DIR/global/scripts/tools/semgrep/rules/dart.yaml"
+
+# CodeQL has NO Dart extractor. A `codeql` job in a Dart template could only
+# fail, so its absence is the correct state and this case defends it against a
+# future "make the languages consistent" edit.
+for template in \
+  "$SCRIPTS_DIR/gitlab/dart/stages/20-security/dart.yaml" \
+  "$SCRIPTS_DIR/azure-devops/dart/stages/20-security/dart.yaml"; do
+  assert_true "$(basename "$(dirname "$(dirname "$(dirname "$template")")")"): no CodeQL job is wired for Dart" \
+    "! grep -E '^[^#]*codeql' '$template'"
+done
+assert_true "GitHub: no CodeQL job is wired in the Dart workflow" \
+  "! grep -E '^[^#]*20-security/codeql' '$SCRIPTS_DIR/.github/workflows/dart.yaml'"
+assert_true "dart.mk leaves CODEQL_LANGUAGE unset so 'make sast' skips CodeQL" \
+  "! grep -qE '^CODEQL_LANGUAGE' '$SCRIPTS_DIR/makefiles/dart.mk'"
+# The skip has to be a real skip. Before the guard in common.mk, an unset
+# language reached the run script and produced a bare usage error on every
+# `make sast`.
+assert_true "common.mk skips CodeQL cleanly when no language is configured" \
+  "grep -q 'skipping CodeQL' '$SCRIPTS_DIR/makefiles/common.mk'"
+# The guard must be a RECIPE-level test. A make-level `ifeq` is evaluated while
+# common.mk is parsed -- before any language fragment has set the variable -- so
+# it would disable CodeQL for every language, not just Dart.
+assert_true "the CodeQL guard is evaluated at recipe time, not at parse time" \
+  "! grep -qE '^ifeq.*CODEQL_LANGUAGE' '$SCRIPTS_DIR/makefiles/common.mk'"
+
+# The Semgrep Registry publishes no Dart rules at all (`p/dart` is a 404 and
+# `r/dart` returns an empty `rules: []`), so this repository ships its own. If
+# the file disappears, a Dart scan silently degrades to language-agnostic packs
+# while still reporting success.
+assert_true "a first-party Dart Semgrep ruleset is shipped" "[[ -f '$DART_RULES' ]]"
+assert_true "the Dart ruleset is valid YAML" \
+  "python3 -c \"import yaml,sys; yaml.safe_load(open('$DART_RULES'))\""
+assert_true "the Dart ruleset declares rules for the 'dart' language" \
+  "python3 -c \"
+import yaml
+rules = yaml.safe_load(open('$DART_RULES'))['rules']
+assert rules, 'no rules'
+assert all('dart' in r['languages'] for r in rules), 'a rule does not target dart'
+\""
+# The TLS-bypass rule is the one that must never be dropped: an unconditional
+# `badCertificateCallback` returning true is the single most common critical
+# defect in Flutter networking code.
+assert_true "the ruleset covers the TLS-verification bypass" \
+  "grep -q 'dart-tls-verification-disabled' '$DART_RULES'"
+assert_true "the shared Semgrep runner loads a repo-shipped ruleset by language" \
+  "grep -q 'tools/semgrep/rules/\$SEMGREP_LANGUAGE.yaml' '$SCRIPTS_DIR/global/scripts/tools/semgrep/run.sh'"
+# Passing an unpublished pack is FATAL to semgrep, taking the language-agnostic
+# packs down with it -- so the runner has to probe rather than assume.
+assert_true "the shared Semgrep runner skips an unpublished registry pack" \
+  "grep -q 'semgrep_registry_pack_exists' '$SCRIPTS_DIR/global/scripts/tools/semgrep/run.sh'"
+# The language pack must be added CONDITIONALLY (via the positional-parameter
+# list, after the registry probe) and never as a fixed line of the `semgrep`
+# invocation. An unconditional `--config p/<lang>` is what made an unpublished
+# pack fatal to the whole scan in the first place, so this checks placement
+# rather than mere presence.
+assert_true "the language pack is added conditionally, not hardcoded into the semgrep invocation" \
+  "! grep -qE '^[[:space:]]+--config \"p/\\\$SEMGREP_LANGUAGE\" \\\\\\\\\$' '$SCRIPTS_DIR/global/scripts/tools/semgrep/run.sh'"
+assert_equals "the language pack is referenced exactly once, on the conditional 'set --' line" \
+  "1" \
+  "$(grep -c 'set -- "\$@" --config "p/\$SEMGREP_LANGUAGE"' "$SCRIPTS_DIR/global/scripts/tools/semgrep/run.sh")"
+
+if command -v semgrep > /dev/null 2>&1; then
+  assert_true "the Dart ruleset passes 'semgrep --validate'" \
+    "semgrep --metrics=off --disable-version-check --validate --config '$DART_RULES' 2>&1 | grep -q 'Configuration is valid'"
+
+  # Matching is asserted against real Dart, not against the rule text: Semgrep's
+  # Dart support is experimental, and several intuitive pattern spellings load
+  # cleanly and then match nothing (the `"...$..."` string-ellipsis idiom in
+  # particular). A rule that silently matches nothing is worse than no rule.
+  mkdir -p "$WORK_DIR/dartsrc"
+  cat > "$WORK_DIR/dartsrc/vuln.dart" <<'EOF'
+import 'dart:io';
+import 'dart:math';
+
+void insecure(HttpClient client) {
+  client.badCertificateCallback = (X509Certificate cert, String host, int port) => true;
+}
+
+Future<void> net() async {
+  await Uri.parse("http://api.example.com/v1/items");
+  await Uri.parse("http://localhost:8080/health");
+  await Uri.parse("https://api.example.com/v1/items");
+}
+
+void weak() {
+  var sessionToken = Random();
+  var particleOffset = Random();
+  print(sessionToken.hashCode + particleOffset.hashCode);
+}
+
+Future<void> shell(String name) async {
+  await Process.run("ls $name", [], runInShell: true);
+  await Process.run("ls", [name]);
+}
+
+Future<void> query(dynamic db, String user) async {
+  await db.rawQuery("SELECT * FROM users WHERE name = '$user'");
+  await db.rawQuery("SELECT * FROM users WHERE name = ?", [user]);
+}
+
+Future<void> store(dynamic prefs, String v) async {
+  await prefs.setString("auth_token", v);
+  await prefs.setString("theme_mode", v);
+}
+
+void web(dynamic controller) {
+  controller.javascriptMode = JavascriptMode.unrestricted;
+  controller.settings.allowFileAccessFromFileURLs = true;
+}
+EOF
+  SEMGREP_JSON="$(semgrep --metrics=off --disable-version-check --no-git-ignore \
+    --config "$DART_RULES" --json "$WORK_DIR/dartsrc" 2>/dev/null)"
+  FIRED="$(python3 -c "
+import json,sys
+d = json.loads(sys.stdin.read())
+print(len({r['check_id'].split('.')[-1] for r in d['results']}))
+" <<< "$SEMGREP_JSON")"
+  TOTAL_RULES="$(python3 -c "import yaml;print(len(yaml.safe_load(open('$DART_RULES'))['rules']))")"
+  assert_equals "every shipped Dart rule matches its vulnerable sample" "$TOTAL_RULES" "$FIRED"
+
+  # The safe counterparts sit on known lines; a rule firing on them would make
+  # the ruleset noise a team disables rather than a gate it trusts.
+  HITS="$(python3 -c "
+import json,sys
+d = json.loads(sys.stdin.read())
+print(' '.join(sorted(str(r['start']['line']) for r in d['results'])))
+" <<< "$SEMGREP_JSON")"
+  assert_true "the parameterised SQL query is not flagged" "! grep -qw '27' <<< '$HITS'"
+  assert_true "the non-shell Process.run is not flagged" "! grep -qw '22' <<< '$HITS'"
+  assert_true "the https:// URL is not flagged" "! grep -qw '11' <<< '$HITS'"
+  assert_true "the loopback http:// URL is not flagged" "! grep -qw '10' <<< '$HITS'"
+  assert_true "a non-security-named Random() is not flagged" "! grep -qw '16' <<< '$HITS'"
+  assert_true "a non-sensitive SharedPreferences key is not flagged" "! grep -qw '33' <<< '$HITS'"
+else
+  skip "semgrep is not installed; rule validation and matching assertions skipped"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 10. Cross-platform wiring ---"
+# ---------------------------------------------------------------------------
+
+# A stage added to one platform and forgotten on the other two leaves three
+# files that are each valid YAML on their own, so nothing else in CI catches it.
+for stage in 10-code-check 20-security 30-tests 35-management; do
+  assert_true "GitLab: the $stage stage exists" \
+    "[[ -f '$SCRIPTS_DIR/gitlab/dart/stages/$stage/dart.yaml' ]]"
+  assert_true "Azure DevOps: the $stage stage exists" \
+    "[[ -f '$SCRIPTS_DIR/azure-devops/dart/stages/$stage/dart.yaml' ]]"
+done
+
+for entry in dart-docker dart-library flutter-docker flutter-artifacts; do
+  assert_true "GitLab: the $entry entry template exists" \
+    "[[ -f '$SCRIPTS_DIR/gitlab/dart/$entry.yaml' ]]"
+  assert_true "Azure DevOps: the $entry entry template exists" \
+    "[[ -f '$SCRIPTS_DIR/azure-devops/dart/$entry.yaml' ]]"
+done
+
+for workflow in dart dart-docker dart-library flutter-artifacts; do
+  assert_true "GitHub: the $workflow workflow exists" \
+    "[[ -f '$SCRIPTS_DIR/.github/workflows/$workflow.yaml' ]]"
+done
+
+for action in 10-code-check/format 10-code-check/analyze 10-code-check/unused \
+              20-security/osv-scanner 30-tests/all 35-management/cyclonedx \
+              40-delivery/build 40-delivery/publish; do
+  assert_true "GitHub: the $action composite action exists" \
+    "[[ -f '$SCRIPTS_DIR/github/dart/stages/$action/action.yaml' ]]"
+done
+
+# Every `run.sh` path referenced by any Dart template must exist. A renamed
+# script is otherwise discovered only when the job runs.
+MISSING=""
+while IFS= read -r referenced; do
+  [[ -f "$SCRIPTS_DIR/$referenced" ]] || MISSING="$MISSING $referenced"
+done < <(grep -rhoE 'global/scripts/languages/dart/[a-z-]+/run\.sh' \
+  "$SCRIPTS_DIR/gitlab/dart" "$SCRIPTS_DIR/azure-devops/dart" \
+  "$SCRIPTS_DIR/github/dart" "$SCRIPTS_DIR/makefiles/dart.mk" 2>/dev/null | sort -u)
+assert_equals "every dart run.sh referenced by a template exists" "" "$MISSING"
+
+# Each platform must reach every runner, or a stage silently does less there.
+for runner in format analyze unused test sca build publish; do
+  for platform in gitlab/dart azure-devops/dart github/dart; do
+    assert_true "$platform references the $runner runner" \
+      "grep -rq 'languages/dart/$runner/run.sh' '$SCRIPTS_DIR/$platform'"
+  done
+done
+
+# The SBOM generator is reached on all three, though GitHub publishes the BOM as
+# an artifact rather than pushing it to a Dependency-Track it has no credentials
+# for.
+for platform in gitlab/dart azure-devops/dart github/dart; do
+  assert_true "$platform references the cyclonedx runner" \
+    "grep -rq 'languages/dart/cyclonedx/run.sh' '$SCRIPTS_DIR/$platform'"
+done
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 11. Makefile fragment ---"
+# ---------------------------------------------------------------------------
+
+assert_true "makefiles/dart.mk exists" "[[ -f '$SCRIPTS_DIR/makefiles/dart.mk' ]]"
+assert_true "dart.mk sets SEMGREP_LANGUAGE=dart" \
+  "grep -qE '^SEMGREP_LANGUAGE \?= dart' '$SCRIPTS_DIR/makefiles/dart.mk'"
+
+if command -v make > /dev/null 2>&1; then
+  MK_PROJECT="$(make_project mkproj dart)"
+  cat > "$MK_PROJECT/Makefile" <<EOF
+SCRIPTS_DIR ?= $SCRIPTS_DIR
+-include \$(SCRIPTS_DIR)/makefiles/common.mk
+-include \$(SCRIPTS_DIR)/makefiles/dart.mk
+EOF
+  MK_OUT="$( (cd "$MK_PROJECT" && make -n sast 2>&1) || true )"
+  assert_true "make sast skips CodeQL on a Dart project" \
+    "grep -q 'skipping CodeQL' <<< \"\$MK_OUT\""
+  assert_true "make sast runs Semgrep with the dart language" \
+    "grep -q 'semgrep/run.sh \"dart\"' <<< \"\$MK_OUT\""
+  assert_true "make sast includes the Dart-native SCA" \
+    "grep -q 'languages/dart/sca/run.sh' <<< \"\$MK_OUT\""
+  # Redefining a target that already has a recipe emits "overriding recipe for
+  # target"; appending to a prerequisite-only rule (which is what `sast` is)
+  # does not. This case keeps the fragment on the quiet side of that line.
+  assert_true "including dart.mk after common.mk emits no make warning" \
+    "! grep -qi 'overriding recipe' <<< \"\$MK_OUT\""
+
+  # The same guard must NOT disable CodeQL for languages that do support it.
+  cat > "$MK_PROJECT/Makefile.py" <<EOF
+SCRIPTS_DIR ?= $SCRIPTS_DIR
+-include \$(SCRIPTS_DIR)/makefiles/common.mk
+-include \$(SCRIPTS_DIR)/makefiles/python.mk
+EOF
+  PY_OUT="$( (cd "$MK_PROJECT" && make -f Makefile.py -n codeql 2>&1) || true )"
+  assert_true "a Python project still runs CodeQL (the guard is language-scoped)" \
+    "grep -q 'codeql/run.sh \"python\"' <<< \"\$PY_OUT\""
+else
+  skip "make is not installed; Makefile fragment assertions skipped"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 12. YAML validity of every Dart template ---"
+# ---------------------------------------------------------------------------
+
+YAML_ERRORS="$(python3 - <<PY
+import glob, yaml
+
+class L(yaml.SafeLoader):
+    pass
+
+def ctor(loader, suffix, node):
+    if isinstance(node, yaml.ScalarNode):
+        return loader.construct_scalar(node)
+    if isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node)
+    return loader.construct_mapping(node)
+
+L.add_multi_constructor('!', ctor)
+
+paths = sorted(set(
+    glob.glob('$SCRIPTS_DIR/gitlab/dart/**/*.yaml', recursive=True)
+    + glob.glob('$SCRIPTS_DIR/azure-devops/dart/**/*.yaml', recursive=True)
+    + glob.glob('$SCRIPTS_DIR/github/dart/**/*.yaml', recursive=True)
+    + glob.glob('$SCRIPTS_DIR/.github/workflows/dart*.yaml')
+    + glob.glob('$SCRIPTS_DIR/.github/workflows/flutter*.yaml')
+    + glob.glob('$SCRIPTS_DIR/global/scripts/tools/semgrep/rules/*.yaml')
+    + glob.glob('$SCRIPTS_DIR/.docs/examples/github-flutter-artifacts/**/*.yaml', recursive=True)
+    + glob.glob('$SCRIPTS_DIR/.docs/examples/gitlab-dart-library/*.yml')
+))
+bad = []
+for p in paths:
+    try:
+        yaml.load(open(p), Loader=L)
+    except Exception as exc:
+        bad.append(p)
+print(' '.join(bad))
+PY
+)"
+assert_equals "every Dart template and example is valid YAML" "" "$YAML_ERRORS"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=========================================="
+echo -e "Passed:  ${GREEN}$TESTS_PASSED${NC}"
+echo -e "Failed:  ${RED}$TESTS_FAILED${NC}"
+[[ $TESTS_SKIPPED -gt 0 ]] && echo -e "Skipped: ${YELLOW}$TESTS_SKIPPED${NC}"
+echo "=========================================="
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+  echo -e "${RED}Dart pipeline validation FAILED${NC}"
+  exit 1
+fi
+echo -e "${GREEN}Dart pipeline validation passed${NC}"
+exit 0

--- a/.github/tests/test-dart-pipeline.sh
+++ b/.github/tests/test-dart-pipeline.sh
@@ -284,6 +284,21 @@ assert_true "dart: a package with no bin/ exits cleanly instead of failing" "[[ 
 assert_true "dart: a package with no bin/ builds nothing" \
   "! grep -q 'dart compile' <<< \"\$CMD\""
 
+# EVERY `dart compile` target needs an entry point, and none of them fails
+# usefully without one: an empty path makes the compiler complain about a file it
+# was never given, and the snapshot targets derive their OUTPUT name from it too,
+# so an empty value silently produces `build/.aot`. The guard originally lived in
+# `exe` alone; these cases keep `js` and `aot-snapshot` from drifting back.
+for target in exe js aot-snapshot; do
+  STATUS=0
+  (cd "$LIB_PROJECT" && env DART_DRY_RUN=true SCRIPTS_DIR="$SCRIPTS_DIR" \
+    sh "$DART_DIR/build/run.sh" "$target" > "$WORK_DIR/entry.$target.log" 2>&1) || STATUS=$?
+  assert_true "build: the '$target' target fails when no entry point can be resolved" \
+    "[[ $STATUS -eq 1 ]]"
+  assert_true "build: the '$target' failure names the target it was building" \
+    "grep -q \"no entry point found for the '$target' target\" '$WORK_DIR/entry.$target.log'"
+done
+
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- 4. Explicit toolchain override ---"
@@ -399,6 +414,14 @@ assert_true "a line covered by only the second record counts as covered" \
   "grep -q '<line number=\"2\" hits=\"3\"/>' '$WORK_DIR/cobertura.xml'"
 assert_true "branch coverage is recomputed from the BRDA rows" \
   "grep -q 'branches-covered=\"1\" branches-valid=\"2\"' '$WORK_DIR/cobertura.xml'"
+# The `<package>` branch rate must be AGGREGATED, not hard-coded. A fixed `0.0`
+# disagrees with the `<class>` rates inside that same package and with the
+# document totals, so a consumer that aggregates per package reads fully
+# branch-covered code as having none.
+assert_true "the package-level branch rate is aggregated, not hard-coded to zero" \
+  "! grep -q '<package [^>]*branch-rate=\"0\.0\"' '$WORK_DIR/cobertura.xml'"
+assert_true "the package holding the branch data reports its real branch rate" \
+  "grep -q '<package name=\"lib\" line-rate=\"0.7500\" branch-rate=\"0.5000\"' '$WORK_DIR/cobertura.xml'"
 # The GitLab templates scrape this exact spelling with a `coverage:` regex.
 assert_true "the coverage line matches the GitLab 'coverage:' regex" \
   "grep -qE 'COVERAGE_PERCENT=[0-9.]+%' <<< \"\$COV_OUT\""
@@ -641,6 +664,20 @@ for action in 10-code-check/format 10-code-check/analyze 10-code-check/unused \
   assert_true "GitHub: the $action composite action exists" \
     "[[ -f '$SCRIPTS_DIR/github/dart/stages/$action/action.yaml' ]]"
 done
+
+# `upload-artifact` splits its `path` input on NEWLINES. A quoted multi-line YAML
+# scalar folds into one space-separated line, so several patterns written that way
+# arrive as a single glob containing spaces and match nothing -- and with
+# `if-no-files-found: warn` the job still goes green, publishing an empty artifact.
+# Assert on the PARSED value, since both spellings look identical in the source.
+assert_equals "the build action's artifact path stays newline-separated (not YAML-folded)" \
+  "4" \
+  "$(python3 -c "
+import yaml
+d = yaml.safe_load(open('$SCRIPTS_DIR/github/dart/stages/40-delivery/build/action.yaml'))
+path = [s for s in d['runs']['steps'] if s.get('uses', '').startswith('actions/upload-artifact')][0]['with']['path']
+print(len([l for l in path.strip().splitlines() if l.strip()]))
+")"
 
 # Every `run.sh` path referenced by any Dart template must exist. A renamed
 # script is otherwise discovered only when the job runs.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
           for f in CONTRIBUTING.md CHANGELOG.md README.md Makefile clone.sh; do
             test -f "$f" && echo "  ✓ $f" || { echo "  ✗ $f is missing"; exit 1; }
           done
-          for f in .github/tests/test-go-validation.sh .github/tests/test-lambda-templates.sh .github/tests/test-sonarqube-auto-derive.sh .github/tests/test-release-tag-idempotency.sh .github/tests/test-docker-multi-arch.sh; do
+          for f in .github/tests/test-go-validation.sh .github/tests/test-lambda-templates.sh .github/tests/test-sonarqube-auto-derive.sh .github/tests/test-release-tag-idempotency.sh .github/tests/test-docker-multi-arch.sh .github/tests/test-dart-pipeline.sh; do
             test -f "$f" && echo "  ✓ $f" || { echo "  ✗ $f is missing"; exit 1; }
           done
 

--- a/.github/workflows/dart-docker.yaml
+++ b/.github/workflows/dart-docker.yaml
@@ -1,0 +1,49 @@
+# Dart or Flutter project delivered as a container image.
+#
+# Suits a server-side Dart application (shelf, dart_frog, a compiled CLI in a
+# container) and equally a Flutter web app whose Dockerfile serves `build/web`.
+on:
+  workflow_call:
+    inputs:
+      flutter_version:
+        required: false
+        type: 'string'
+        default: ''
+      dart_sdk_version:
+        required: false
+        type: 'string'
+        default: 'latest'
+      toolchain:
+        required: false
+        type: 'string'
+        default: 'auto'
+
+jobs:
+  dart:
+    uses: 'rios0rios0/pipelines/.github/workflows/dart.yaml@main'
+    with:
+      flutter_version: ${{ inputs.flutter_version }}
+      dart_sdk_version: ${{ inputs.dart_sdk_version }}
+      toolchain: ${{ inputs.toolchain }}
+
+  # fourth stage
+  delivery-release:
+    name: 'delivery > release'
+    runs-on: 'ubuntu-latest'
+    outputs:
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - id: 'release'
+        uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/release@main'
+    needs: [ 'dart' ]
+    if: "github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(github.event.head_commit.message, 'chore/bump-') || contains(github.event.head_commit.message, 'chore(bump)'))"
+
+  delivery-docker:
+    name: 'delivery > docker'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker@main'
+        with:
+          tag_name: "${{ needs.delivery-release.outputs.tag_name }}"
+    needs: [ 'dart', 'delivery-release' ]
+    if: "!failure() && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/'))"

--- a/.github/workflows/dart-library.yaml
+++ b/.github/workflows/dart-library.yaml
@@ -1,0 +1,87 @@
+# Dart package published to pub.dev (or a self-hosted pub server).
+#
+# Validation runs on every default-branch build; publication runs only on a tag.
+# The split is not ceremony: publishing to pub.dev is IRREVERSIBLE -- a version
+# can be retracted but never replaced or re-uploaded -- so the checks pub.dev
+# performs at upload time have to run long before the upload.
+#
+# The caller must forward the credential explicitly, because a reusable workflow
+# does not inherit the caller's secrets:
+#
+#   jobs:
+#     pipeline:
+#       uses: 'rios0rios0/pipelines/.github/workflows/dart-library.yaml@main'
+#       secrets:
+#         PUB_TOKEN: ${{ secrets.PUB_TOKEN }}
+on:
+  workflow_call:
+    inputs:
+      flutter_version:
+        required: false
+        type: 'string'
+        default: ''
+      dart_sdk_version:
+        required: false
+        type: 'string'
+        default: 'latest'
+      toolchain:
+        required: false
+        type: 'string'
+        default: 'auto'
+      pub_hosted_url:
+        required: false
+        type: 'string'
+        default: ''
+        description: 'Self-hosted pub server URL. Defaults to https://pub.dev.'
+    secrets:
+      PUB_TOKEN:
+        required: false
+        description: 'pub.dev credential. Required for the publish job; the validation job runs without it.'
+
+jobs:
+  dart:
+    uses: 'rios0rios0/pipelines/.github/workflows/dart.yaml@main'
+    with:
+      flutter_version: ${{ inputs.flutter_version }}
+      dart_sdk_version: ${{ inputs.dart_sdk_version }}
+      toolchain: ${{ inputs.toolchain }}
+
+  # fourth stage
+  delivery-publish_validate:
+    name: 'delivery > publish:validate'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/dart/stages/40-delivery/publish@main'
+        with:
+          flutter_version: ${{ inputs.flutter_version }}
+          dart_sdk_version: ${{ inputs.dart_sdk_version }}
+          toolchain: ${{ inputs.toolchain }}
+          dry_run: 'true'
+    needs: [ 'dart' ]
+    if: "!startsWith(github.ref, 'refs/tags/')"
+
+  delivery-release:
+    name: 'delivery > release'
+    runs-on: 'ubuntu-latest'
+    outputs:
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - id: 'release'
+        uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/release@main'
+    needs: [ 'dart' ]
+    if: "github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(github.event.head_commit.message, 'chore/bump-') || contains(github.event.head_commit.message, 'chore(bump)'))"
+
+  delivery-publish_prod:
+    name: 'delivery > publish:prod'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/dart/stages/40-delivery/publish@main'
+        with:
+          flutter_version: ${{ inputs.flutter_version }}
+          dart_sdk_version: ${{ inputs.dart_sdk_version }}
+          toolchain: ${{ inputs.toolchain }}
+          dry_run: 'false'
+          pub_token: ${{ secrets.PUB_TOKEN }}
+          pub_hosted_url: ${{ inputs.pub_hosted_url }}
+    needs: [ 'dart' ]
+    if: "startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -1,0 +1,212 @@
+# Quality, security and test stages for a Dart or Flutter project.
+#
+# The toolchain is detected from the project's own `pubspec.yaml`, so this one
+# workflow serves both a pure Dart package and a Flutter app; force it with the
+# `toolchain` input when the detection is wrong for your layout.
+#
+# NOTE ON THE SECURITY STAGE -- there is no `security-sast_codeql` job here, and
+# its absence is deliberate. CodeQL has no Dart extractor (dart-lang/sdk#52953,
+# open since 2023), so a CodeQL job could only fail. Semgrep IS present and does
+# run, because the shared runner skips the unpublished `p/dart` registry pack
+# instead of failing on it and picks up the Dart ruleset this repository ships at
+# `global/scripts/tools/semgrep/rules/dart.yaml`. Without that ruleset the scan
+# would be language-agnostic packs only -- the registry publishes no Dart rules
+# at all.
+#
+# see the bottom of the file for more information¹
+# the parent workflow is responsible for setting up the call events²
+on:
+  workflow_call:
+    inputs:
+      flutter_version:
+        required: false
+        type: 'string'
+        default: ''
+        description: 'Pin an exact Flutter version (e.g. 3.47.0). Defaults to the current stable release.'
+      dart_sdk_version:
+        required: false
+        type: 'string'
+        default: 'latest'
+        description: 'Pin an exact Dart SDK version. Only used for pure Dart projects.'
+      toolchain:
+        required: false
+        type: 'string'
+        default: 'auto'
+        description: "Force the toolchain: 'dart', 'flutter', or 'auto'."
+      fatal_infos:
+        required: false
+        type: 'boolean'
+        default: false
+        description: 'Fail the analyze job on INFO-level diagnostics (this is where lints land).'
+      coverage_minimum:
+        required: false
+        type: 'string'
+        default: ''
+        description: 'Fail the test job when line coverage falls below this percentage.'
+      enable_sbom:
+        required: false
+        type: 'boolean'
+        default: true
+        description: 'Generate a CycloneDX SBOM and publish it as a job artifact.'
+
+jobs:
+  # first stage
+  code_check-basic_checks:
+    name: 'code-check > quality:basic-checks'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/global/stages/10-code-check/basic-checks@main'
+        with:
+          target_branch: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch || 'main' }}
+    if: "github.event_name == 'pull_request'"
+
+  code_check-style_format:
+    name: 'code-check > style:format'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/dart/stages/10-code-check/format@main'
+        with:
+          flutter_version: ${{ inputs.flutter_version }}
+          dart_sdk_version: ${{ inputs.dart_sdk_version }}
+          toolchain: ${{ inputs.toolchain }}
+    if: "!startsWith(github.ref, 'refs/tags/')"
+
+  code_check-quality_analyze:
+    name: 'code-check > quality:analyze'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/dart/stages/10-code-check/analyze@main'
+        with:
+          flutter_version: ${{ inputs.flutter_version }}
+          dart_sdk_version: ${{ inputs.dart_sdk_version }}
+          toolchain: ${{ inputs.toolchain }}
+          fatal_infos: ${{ inputs.fatal_infos }}
+    if: "!startsWith(github.ref, 'refs/tags/')"
+
+  code_check-quality_unused_code:
+    name: 'code-check > quality:unused-code'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/dart/stages/10-code-check/unused@main'
+        with:
+          flutter_version: ${{ inputs.flutter_version }}
+          dart_sdk_version: ${{ inputs.dart_sdk_version }}
+          toolchain: ${{ inputs.toolchain }}
+    continue-on-error: true
+    if: "!startsWith(github.ref, 'refs/tags/')"
+
+
+  # second stage
+  security-sast_semgrep:
+    name: 'security > sast:semgrep'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/global/stages/20-security/semgrep@main'
+        with:
+          semgrep_lang: 'dart'
+    needs: [ 'code_check-style_format', 'code_check-quality_analyze', 'code_check-quality_unused_code' ]
+    if: "!startsWith(github.ref, 'refs/tags/')"
+
+  security-sast_gitleaks:
+    name: 'security > sast:gitleaks'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/global/stages/20-security/gitleaks@main'
+    needs: [ 'code_check-style_format', 'code_check-quality_analyze', 'code_check-quality_unused_code' ]
+    if: "!startsWith(github.ref, 'refs/tags/')"
+
+  security-sast_hadolint:
+    name: 'security > sast:hadolint'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/global/stages/20-security/hadolint@main'
+    needs: [ 'code_check-style_format', 'code_check-quality_analyze', 'code_check-quality_unused_code' ]
+    continue-on-error: true
+    if: "!startsWith(github.ref, 'refs/tags/')"
+
+  security-sast_trivy:
+    name: 'security > sast:trivy'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/global/stages/20-security/trivy@main'
+    needs: [ 'code_check-style_format', 'code_check-quality_analyze', 'code_check-quality_unused_code' ]
+    continue-on-error: true
+    if: "!startsWith(github.ref, 'refs/tags/')"
+
+  security-sca_trivy:
+    name: 'security > sca:trivy'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/global/stages/20-security/trivy-sca@main'
+    needs: [ 'code_check-style_format', 'code_check-quality_analyze', 'code_check-quality_unused_code' ]
+    continue-on-error: true
+    if: "!startsWith(github.ref, 'refs/tags/')"
+
+  security-sca_osv_scanner:
+    name: 'security > sca:osv-scanner'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/dart/stages/20-security/osv-scanner@main'
+        with:
+          flutter_version: ${{ inputs.flutter_version }}
+          dart_sdk_version: ${{ inputs.dart_sdk_version }}
+          toolchain: ${{ inputs.toolchain }}
+    needs: [ 'code_check-style_format', 'code_check-quality_analyze', 'code_check-quality_unused_code' ]
+    continue-on-error: true
+    if: "!startsWith(github.ref, 'refs/tags/')"
+
+
+  # third stage
+  tests-test_all:
+    name: 'tests > test:all'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/dart/stages/30-tests/all@main'
+        with:
+          flutter_version: ${{ inputs.flutter_version }}
+          dart_sdk_version: ${{ inputs.dart_sdk_version }}
+          toolchain: ${{ inputs.toolchain }}
+          coverage_minimum: ${{ inputs.coverage_minimum }}
+    needs: [ 'security-sast_semgrep', 'security-sast_gitleaks', 'security-sast_hadolint', 'security-sast_trivy', 'security-sca_trivy', 'security-sca_osv_scanner' ]
+    if: "!startsWith(github.ref, 'refs/tags/')"
+
+
+  # fourth stage
+  # The BOM is published as a job artifact rather than pushed to a server: unlike
+  # the GitLab and Azure DevOps templates, this workflow has no Dependency-Track
+  # credentials to assume. A consumer that runs Dependency-Track can download
+  # `bom.json` and upload it, or call the composite action directly with its own
+  # credentials.
+  management-report_sbom:
+    name: 'management > report:sbom'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/dart/stages/35-management/cyclonedx@main'
+        with:
+          flutter_version: ${{ inputs.flutter_version }}
+          dart_sdk_version: ${{ inputs.dart_sdk_version }}
+          toolchain: ${{ inputs.toolchain }}
+    needs: [ 'tests-test_all' ]
+    continue-on-error: true
+    if: "inputs.enable_sbom && !startsWith(github.ref, 'refs/tags/')"
+
+
+# 1 - this file MUST be inside ".github/workflows" because of GitHub Actions limitations
+# 2 - the recommended events to trigger this workflow and permissions are:
+#   on:
+#     push:
+#       branches:
+#         - 'main'
+#       tags:
+#         - '*'
+#     pull_request:
+#       branches:
+#         - 'main'
+#     workflow_dispatch:
+#
+# permissions:
+#   contents: 'read'
+#
+# There is no `security-events: write` requirement here, unlike the other
+# language workflows: that permission exists for CodeQL, which does not support
+# Dart and is therefore not part of this pipeline.

--- a/.github/workflows/flutter-artifacts.yaml
+++ b/.github/workflows/flutter-artifacts.yaml
@@ -1,0 +1,74 @@
+# Flutter application delivered as downloadable artifacts: a web bundle and
+# Android APK/AAB.
+#
+# GitHub's `ubuntu-latest` runners already ship the Android SDK and a JDK, so the
+# Android target works out of the box -- unlike the GitLab equivalent, where the
+# runner image is the consumer's choice and cannot be assumed to carry them.
+#
+# `ipa` is not built here: it needs a `macos-latest` runner and, to be
+# installable, a signing identity and provisioning profile that belong to the
+# consuming project rather than to a shared template. Add a job with
+# `runs-on: macos-latest` and `targets: ipa` when you have them.
+on:
+  workflow_call:
+    inputs:
+      flutter_version:
+        required: false
+        type: 'string'
+        default: ''
+      build_web:
+        required: false
+        type: 'boolean'
+        default: true
+      build_android:
+        required: false
+        type: 'boolean'
+        default: true
+      android_targets:
+        required: false
+        type: 'string'
+        default: 'apk appbundle'
+        description: "APK is sideloadable for QA; App Bundle is the only format Google Play accepts for new releases."
+
+jobs:
+  dart:
+    uses: 'rios0rios0/pipelines/.github/workflows/dart.yaml@main'
+    with:
+      flutter_version: ${{ inputs.flutter_version }}
+      toolchain: 'flutter'
+
+  # fourth stage
+  delivery-release:
+    name: 'delivery > release'
+    runs-on: 'ubuntu-latest'
+    outputs:
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - id: 'release'
+        uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/release@main'
+    needs: [ 'dart' ]
+    if: "github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(github.event.head_commit.message, 'chore/bump-') || contains(github.event.head_commit.message, 'chore(bump)'))"
+
+  delivery-web:
+    name: 'delivery > delivery:web'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/dart/stages/40-delivery/build@main'
+        with:
+          flutter_version: ${{ inputs.flutter_version }}
+          toolchain: 'flutter'
+          targets: 'web'
+    needs: [ 'dart' ]
+    if: "inputs.build_web && !failure() && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/'))"
+
+  delivery-android:
+    name: 'delivery > delivery:android'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'rios0rios0/pipelines/github/dart/stages/40-delivery/build@main'
+        with:
+          flutter_version: ${{ inputs.flutter_version }}
+          toolchain: 'flutter'
+          targets: ${{ inputs.android_targets }}
+    needs: [ 'dart' ]
+    if: "inputs.build_android && !failure() && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/'))"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,27 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added a complete Dart and Flutter pipeline for all three platforms (GitHub Actions, GitLab CI, Azure DevOps), covering every stage of the 5-stage model: code check, security, tests, management and delivery. The toolchain is detected from the project's own `pubspec.yaml` (a `flutter: sdk: flutter` dependency selects Flutter, anything else selects Dart), so one set of templates and scripts serves a Flutter application and a pure Dart package alike; `DART_TOOLCHAIN` overrides the detection
+- added nine Dart runners under `global/scripts/languages/dart/`: `setup` (SDK install), `format`, `analyze`, `test`, `unused`, `sca`, `cyclonedx`, `build` and `publish`, plus a sourced `common.sh` of shared helpers. All support `DART_DRY_RUN=true`, which resolves and records every command without installing or executing anything — the mechanism that lets the validation suite exercise the whole family offline with no SDK and no network
+- added a first-party Semgrep ruleset for Dart at `global/scripts/tools/semgrep/rules/dart.yaml`. **The Semgrep Registry publishes no Dart rules at all** — `p/dart` returns HTTP 404 and the language-scoped `r/dart` returns a literal `rules: []` — so without it a Dart scan would run only the language-agnostic packs while still reporting success. The eight shipped rules cover TLS verification bypass via `badCertificateCallback`, WebView JavaScript and file-URL access, shell and SQL injection through string interpolation, weak randomness for security-sensitive values, cleartext `http://` requests, and secrets written to `SharedPreferences`
+- added OSV-Scanner as the Dart dependency scanner (`sca:osv-scanner`), the counterpart of `govulncheck` for Go and `safety` for Python. It runs alongside `sca:trivy` rather than replacing it: Trivy reads `pubspec.lock` but records SDK-provided dependencies at version `0.0.0`, leaving them unmatched against any advisory, while OSV queries the Pub advisory database directly
+- added a dependency-free LCOV-to-Cobertura converter (`lcov_to_cobertura.py`, standard library only). Dart emits coverage as LCOV and nothing else, which neither Azure DevOps' `PublishCodeCoverageResults@2` nor GitLab's coverage visualisation can read
+- added a `dart analyze` machine-format report generator emitting JUnit XML and JSON with a configurable severity gate (`DART_FATAL_WARNINGS`, `DART_FATAL_INFOS`). The gate is configurable because CodeQL cannot cover Dart, which leaves the analyzer as the primary source of language-level correctness findings
+- added `makefiles/dart.mk` with `lint`, `format`, `analyze`, `test`, `unused`, `sca`, `cyclonedx`, `build` and `setup-dart` targets
+- added `.github/tests/test-dart-pipeline.sh` (166 assertions) and a `test-dart-pipeline` make target wired into the aggregate `test` target CI runs. The cases pin the four things that would otherwise fail silently: cross-platform wiring (a stage added to one platform and forgotten on the other two leaves three files that are each valid YAML on their own), toolchain dispatch (asserted on the argv each script builds, not on what the source looks like it says), the two deliberate tool-gap decisions, and that no credential ever reaches a recorded command line
+- added `.docs/examples/github-flutter-artifacts/` and `.docs/examples/gitlab-dart-library/` complete usage examples
+
+### Changed
+
+- changed `global/scripts/tools/semgrep/run.sh` to probe the Semgrep Registry before passing a language rule pack, and to load a repository-shipped ruleset from `global/scripts/tools/semgrep/rules/<language>.yaml` when one exists. Passing an unpublished pack is fatal to the whole invocation, so `--config p/dart` would have taken the language-agnostic packs (secrets, Dockerfile, OWASP) down with it. Only an explicit HTTP 404 skips the pack — a timeout or proxy error keeps it, so a transient network problem can never quietly downgrade a scan while the job still reports success. An empty or `none` language is now also accepted, where it previously composed the meaningless config `p/`
+- changed `makefiles/common.mk` so the `codeql` target skips with an explanation when `CODEQL_LANGUAGE` is unset, instead of passing an empty argument that the run script rejects with a bare usage message. The test lives in the recipe rather than in a make-level `ifeq`, because a conditional is evaluated while `common.mk` is parsed — before the language fragment that sets the variable has been included — which would have disabled CodeQL for every language
+
+### Notes
+
+- **CodeQL is deliberately absent from every Dart template.** It ships no Dart extractor ([dart-lang/sdk#52953](https://github.com/dart-lang/sdk/issues/52953), open since 2023), so a `sast:codeql` job on a Dart repository could only fail. `make sast` skips it with an explanation, and the validation suite fails if the job reappears
+
 ## [4.21.0] - 2026-08-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-A CI/CD pipeline templates library providing reusable workflows for **GitHub Actions**, **GitLab CI**, and **Azure DevOps** across Go, Python, Java, JavaScript, PHP, Ruby, .NET, Terraform, and Terra CLI. This is **not a runnable application** — it provides templates and scripts consumed by other projects.
+A CI/CD pipeline templates library providing reusable workflows for **GitHub Actions**, **GitLab CI**, and **Azure DevOps** across Go, Python, Java, JavaScript, PHP, Ruby, .NET, Dart/Flutter, Terraform, and Terra CLI. This is **not a runnable application** — it provides templates and scripts consumed by other projects.
 
 ## Commands
 
 ```bash
-make test              # Run all validation tests (Go, CycloneDX main detection, Go cache trim, Lambda, YAML merge, Trivy merge, SonarQube, release tag, tftest-gen, order-check, var-catalog, terraform-validate, docker-multi-arch, basic-checks, dependency-check, goreleaser-prepare, release-version-extraction, release-reconcile, deploy-providers)
+make test              # Run all validation tests (Go, CycloneDX main detection, Go cache trim, Lambda, YAML merge, Trivy merge, SonarQube, release tag, tftest-gen, order-check, var-catalog, terraform-validate, docker-multi-arch, basic-checks, dependency-check, goreleaser-prepare, release-version-extraction, release-reconcile, deploy-providers, dart-pipeline)
 make test-go-script    # Test Go validation script only
 make test-go-integration-scope  # Test which packages the Go runner's integration phase selects only
 make test-lambda       # Test Lambda template validation only
@@ -30,6 +30,7 @@ make test-release-version-extraction  # Test release version extraction (tag ref
 make test-release-reconcile  # Test release reconciliation gap detection only
 make test-deploy-providers   # Test the MVP hosting deployment providers (Cloudflare, Vercel, Render, Netlify, Fly.io) only
 make test-memory-detection  # Test the cgroup-aware memory ceiling detection only
+make test-dart-pipeline # Test the Dart/Flutter pipeline (scripts, Semgrep rules, cross-platform wiring) only
 make build-and-push NAME=<image> TAG=<tag>  # Build and push a container image
 ```
 
@@ -53,7 +54,8 @@ All platforms follow consistent numbered stages:
 - `gitlab/<language>/` — GitLab CI templates with `stages/`, `scripts/`, `abstracts/` subdirs
 - `azure-devops/<language>/` — Azure DevOps templates, same structure as GitLab
 - `global/scripts/tools/` — Platform-agnostic security tools (codeql, gitleaks, semgrep, hadolint, shellcheck, trivy, sonarqube, dependency-track)
-- `global/scripts/languages/` — Language-specific scripts (golang, java, javascript, php, python, ruby, terraform). Most `run.sh` scripts follow shared conventions, but the Terraform helpers below are documented exceptions: they write reports directly under `build/reports/` and do not rely on the common `cleanup.sh` report-directory pattern.
+- `global/scripts/languages/` — Language-specific scripts (golang, java, javascript, php, python, ruby, dart, terraform). Most `run.sh` scripts follow shared conventions, but the Terraform helpers below are documented exceptions: they write reports directly under `build/reports/` and do not rely on the common `cleanup.sh` report-directory pattern.
+  - `dart/` — Dart and Flutter runners: `setup`, `format`, `analyze`, `test`, `unused`, `sca`, `cyclonedx`, `build`, `publish`, plus a sourced `common.sh` (not executable — it is sourced, never run). All honour `DART_DRY_RUN=true`, which resolves and records commands without installing or executing anything; that is what makes the whole family testable offline. See Dart & Flutter Support below
   - `terraform/terra-test/` — `terraform test` runner over `modules/*/tests/*.tftest.hcl` (emits JUnit + Markdown/JSON/Cobertura coverage under `build/reports/`)
   - `terraform/terratest/` — Go Terratest runner over `tests/terratest/*.go` (emits JUnit under `build/reports/`)
   - `terraform/test-all/` — unified orchestrator for the first two tiers; runs both when present, merges JUnits into `build/reports/junit-terra-all.xml`, exits `0` when neither tier has tests (stack-only repos)
@@ -84,6 +86,12 @@ GitHub Actions workflow files (`.github/workflows/`) are named by **package mana
 | PHP        | Composer      | `composer-docker.yaml` | ~~php-docker.yaml~~          |
 | Ruby       | Bundler       | `bundler-docker.yaml`  | ~~ruby-docker.yaml~~         |
 | C#         | dotnet        | `dotnet-docker.yaml` | —              |
+| Dart       | dart          | `dart-docker.yaml`   | ~~pub-docker.yaml~~ |
+| Flutter    | flutter       | `flutter-artifacts.yaml` | ~~dart-flutter.yaml~~ |
+
+Dart is the one language here with TWO toolchains sharing ONE package manager
+(`pub`), so the workflow name follows the toolchain (`dart` / `flutter`) rather
+than the package manager — the same precedent Go sets with `go.yaml`.
 
 When adding a new language or toolchain, always use the toolchain name in the workflow file.
 
@@ -129,6 +137,50 @@ Because the tools run directly on the host, the consuming CI job only needs the 
 | `cache/save` is gated on a `.owasp/.odc-complete` marker, not on `always()` alone | Saving unconditionally made one cancelled run permanent: the half-written database was published, restored, rejected by Dependency-Check, and rebuilt from zero until the timeout killed it and it saved another partial. `run.sh` clears the marker before running and writes it only after the analysis returns, so it is the one trustworthy "this database is whole" signal — a partial `odc.mv.db` is indistinguishable from a good one on disk |
 
 With no API key the runner uses NIST's gzipped JSON data feeds (`nvdDatafeedUrl`), which are not rate limited, so a keyless project still gets a usable scan; a **cold** run uses them even when a key *is* present, for the reason in the table above. `NVD_DATAFEED_URL` overrides this with a self-hosted [`vulnz`](https://github.com/jeremylong/open-vulnerability-cli) mirror. The database is pinned to `.owasp/` (both plugins require an absolute path and otherwise default it into `~/.m2` / `$GRADLE_USER_HOME`, where the pipelines were not caching it) and reused for 24h via `nvdValidForHours`. The job is capped at 45 minutes on every platform so a pathological download is bounded rather than trusted — a safety net, not the fix; the datafeed bootstrap is what keeps a cold build under it. Covered by `.github/tests/test-dependency-check.sh`, which runs the script against a stub build tool and asserts on the argv it actually produces, including both the cold (datafeed) and warm (API delta) paths.
+
+### Dart & Flutter Support
+
+One set of templates and scripts serves both toolchains. `dart_detect_toolchain`
+(in `global/scripts/languages/dart/common.sh`) reads the project's `pubspec.yaml`
+and picks `flutter` when it finds a `flutter:\n    sdk: flutter` dependency,
+`dart` otherwise; `DART_TOOLCHAIN` overrides it. The detection deliberately keys
+on that dependency rather than on a top-level `flutter:` key — a pure Dart
+package can carry the latter to declare assets without depending on Flutter at
+all, and picking the wrong CLI fails deep inside the widget-test bindings.
+
+Entry templates: `dart-docker`, `dart-library`, `flutter-docker`,
+`flutter-artifacts` on GitLab CI and Azure DevOps; `dart.yaml`,
+`dart-docker.yaml`, `dart-library.yaml`, `flutter-artifacts.yaml` on GitHub
+Actions.
+
+**Two tools in the standard stack do not support Dart.** Both gaps are handled
+by a deliberate absence or substitution rather than by a job that silently checks
+nothing; `.github/tests/test-dart-pipeline.sh` fails if either decision is
+reverted. Do not "restore consistency" with the other languages here:
+
+| Constraint | Why |
+|------------|-----|
+| **No `sast:codeql` job in any Dart template** | CodeQL ships no Dart extractor ([dart-lang/sdk#52953](https://github.com/dart-lang/sdk/issues/52953), open since 2023). `codeql database create --language=dart` is not a supported invocation, so the job could only fail. `makefiles/dart.mk` leaves `CODEQL_LANGUAGE` unset and `common.mk`'s `codeql` target skips with an explanation |
+| **Semgrep runs, but the registry contributes nothing** | The engine parses Dart (experimental, actively maintained), but the registry publishes **zero** Dart rules: `p/dart` is HTTP 404 and `r/dart` returns a literal `rules: []`. Passing an unpublished pack is FATAL to the whole invocation, so `semgrep/run.sh` now probes the registry and skips a missing pack — only an explicit 404 skips it, so a network blip cannot quietly downgrade a scan. It then loads `global/scripts/tools/semgrep/rules/<language>.yaml` if this repository ships one, which for Dart it does |
+| **OSV-Scanner replaces OWASP Dependency-Check** | Dependency-Check has no pub analyzer. OSV-Scanner queries the Pub advisory database directly and runs **alongside** `sca:trivy`, not instead of it: Trivy reads `pubspec.lock` but records SDK-provided dependencies (Flutter itself and anything resolved through it) at version `0.0.0`, leaving them unmatched against any advisory. Exit code 128 ("no packages found") is mapped to success — a lockfile with only SDK dependencies produces it, and the safest possible dependency set must not be a red job |
+| **`dart analyze`, not `flutter analyze`** | `flutter analyze` has no `--format` option at all ([flutter/flutter#95090](https://github.com/flutter/flutter/issues/95090)), so it can only be scraped. The Flutter SDK's bundled `dart` runs the same analyzer over the same `analysis_options.yaml`, which is why `common.sh` symlinks it. The analyzer's own exit code is ignored and the verdict recomputed from the parsed diagnostics, because this pipeline's gate is configurable (`DART_FATAL_WARNINGS`, `DART_FATAL_INFOS`) and the tool's all-or-nothing verdict is the wrong one to propagate |
+| **The SDK comes from `storage.googleapis.com`, never a Docker image** | Same reason every other tool here is installed natively: Docker Hub rate-limits anonymous pulls, and a large, frequently-pulled SDK image is exactly what trips it. `DART_SDK_INSTALL_DIR` relocates the unpack target because GitLab CI can only cache paths inside `$CI_PROJECT_DIR` |
+| **Coverage is converted, not consumed raw** | Dart emits LCOV and nothing else. Azure DevOps' `PublishCodeCoverageResults@2` and GitLab's coverage visualisation both need Cobertura, so `test/lcov_to_cobertura.py` converts it — standard library only, so an offline `make test` can exercise it and a Dart job needs no Python toolchain. Repeated `SF:` records for one file are MERGED, not replaced: a multi-entry-point suite emits several, and taking the last would report only that suite's hits |
+| **`dart_run` prints to stderr, never stdout** | Several callers capture the wrapped command's stdout because that stdout IS the payload (`dart test --reporter json`, `flutter test --machine`, `osv-scanner --format json`). A progress line on stdout would be interleaved into it and `tojunit`/`jq` would reject the whole document |
+| **The pub token is never on argv** | `dart pub token add --env-var PUB_TOKEN` passes the variable's NAME; pub reads the value from the environment. Argv is world-readable via `ps`, and the recorded `command.txt` is published as a job artifact. Same reasoning as `-DnvdApiKeyEnvironmentVariable` above |
+
+The shipped Semgrep ruleset (`global/scripts/tools/semgrep/rules/dart.yaml`)
+holds eight rules covering TLS verification bypass, WebView JavaScript and
+file-URL access, shell and SQL injection through interpolation, weak randomness
+for security-sensitive values, cleartext HTTP, and secrets in
+`SharedPreferences`. Two Dart-specific Semgrep mechanics are load-bearing and
+were verified against the engine rather than assumed: patterns containing
+`runInShell: true` must be QUOTED (YAML reads them as a nested mapping
+otherwise), and interpolation must be detected with `metavariable-regex` — the
+`"...$..."` string-ellipsis idiom is **not implemented for Dart**, so a rule
+written with it loads cleanly and then matches nothing. When editing that file,
+re-run `make test-dart-pipeline` with Semgrep installed; the suite asserts every
+rule still matches its vulnerable sample and none matches the safe counterpart.
 
 ### Terra Test Tiers
 
@@ -204,6 +256,10 @@ SCRIPTS_DIR ?= $(HOME)/Development/github.com/rios0rios0/pipelines
 -include $(SCRIPTS_DIR)/makefiles/common.mk    # setup, sast
 -include $(SCRIPTS_DIR)/makefiles/golang.mk     # lint, test
 ```
+
+Order matters for `dart.mk`: it APPENDS its `sca` target to `common.mk`'s `sast`
+(a prerequisite-only rule, so appending emits no "overriding recipe" warning),
+so `common.mk` must be included first.
 
 The `-include` prefix makes includes optional (no error if pipelines not cloned).
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TAG := latest
 ROOT := global/containers
 CONTAINER_REGISTRY = ghcr.io/rios0rios0/pipelines
 
-.PHONY: login setup-buildx build-and-push test-go-script test-cyclonedx-main test-go-cache-trim test-go-tmpdir-modcache test-go-integration-scope test-lambda test-yaml-merge test-trivy-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-var-catalog test-terraform-validate test-terraform-provider-mirror test-docker-multi-arch test-basic-checks test-dependency-check test-goreleaser-prepare test-release-version-extraction test-release-reconcile test-deploy-providers test-memory-detection test
+.PHONY: login setup-buildx build-and-push test-go-script test-cyclonedx-main test-go-cache-trim test-go-tmpdir-modcache test-go-integration-scope test-lambda test-yaml-merge test-trivy-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-var-catalog test-terraform-validate test-terraform-provider-mirror test-docker-multi-arch test-basic-checks test-dependency-check test-goreleaser-prepare test-release-version-extraction test-release-reconcile test-deploy-providers test-memory-detection test-dart-pipeline test
 
 login:
 	docker login $(CONTAINER_REGISTRY)
@@ -110,5 +110,9 @@ test-memory-detection:
 	@echo "Running memory ceiling detection validation..."
 	@./.github/tests/test-memory-detection.sh
 
-test: test-go-script test-cyclonedx-main test-go-cache-trim test-go-tmpdir-modcache test-go-integration-scope test-lambda test-yaml-merge test-trivy-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-var-catalog test-terraform-validate test-terraform-provider-mirror test-docker-multi-arch test-basic-checks test-dependency-check test-goreleaser-prepare test-release-version-extraction test-release-reconcile test-deploy-providers test-memory-detection
+test-dart-pipeline:
+	@echo "Running Dart/Flutter pipeline validation..."
+	@./.github/tests/test-dart-pipeline.sh
+
+test: test-go-script test-cyclonedx-main test-go-cache-trim test-go-tmpdir-modcache test-go-integration-scope test-lambda test-yaml-merge test-trivy-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-var-catalog test-terraform-validate test-terraform-provider-mirror test-docker-multi-arch test-basic-checks test-dependency-check test-goreleaser-prepare test-release-version-extraction test-release-reconcile test-deploy-providers test-memory-detection test-dart-pipeline
 	@echo "All tests completed successfully!"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Comprehensive, enterprise-grade SDLC pipeline templates for **GitHub Actions**, 
 | **PHP**                | yes            | no        | no           | Composer, Docker                  |
 | **Ruby**               | yes            | no        | no           | Bundler, Docker                   |
 | **.NET/C#**            | yes            | yes       | yes          | Framework, Core, Docker           |
+| **Dart**               | yes            | yes       | yes          | pub.dev, Docker, native binary    |
+| **Flutter**            | yes            | yes       | yes          | Web, Android APK/AAB, Docker      |
 | **Terraform**          | no             | yes       | yes          | Infrastructure as Code            |
 | **Terra CLI**          | yes            | yes       | yes          | Terraform/Terragrunt wrapper      |
 
@@ -55,6 +57,9 @@ pipelines/
 │   ├── composer-docker.yaml   # PHP/Composer with Docker delivery
 │   ├── bundler-docker.yaml    # Ruby/Bundler with Docker delivery
 │   ├── dotnet-docker.yaml     # .NET with Docker delivery
+│   ├── dart-docker.yaml       # Dart with Docker delivery
+│   ├── dart-library.yaml      # Dart package published to pub.dev
+│   ├── flutter-artifacts.yaml # Flutter web bundle + Android APK/AAB
 │   └── ...
 ├── gitlab/                     # GitLab CI pipeline templates
 │   ├── golang/                # Go language pipelines
@@ -62,6 +67,7 @@ pipelines/
 │   ├── python/                # Python language pipelines
 │   ├── javascript/            # JavaScript/Node.js pipelines
 │   ├── dotnet/                # .NET language pipelines
+│   ├── dart/                  # Dart and Flutter pipelines
 │   ├── terraform/             # Terraform pipelines (raw terraform/terragrunt)
 │   ├── terra/                 # Terra CLI pipelines (terraform/terragrunt wrapper)
 │   └── global/                # Shared GitLab configurations
@@ -71,6 +77,7 @@ pipelines/
 │   ├── python/                # Python language pipelines
 │   ├── javascript/            # JavaScript/Node.js pipelines
 │   ├── dotnet/                # .NET language pipelines
+│   ├── dart/                  # Dart and Flutter pipelines
 │   ├── terraform/             # Terraform pipelines (raw terraform/terragrunt)
 │   ├── terra/                 # Terra CLI pipelines (terraform/terragrunt wrapper)
 │   └── global/                # Shared Azure DevOps templates
@@ -86,6 +93,8 @@ pipelines/
 │   │   │   └── dependency-track/ # SCA analysis
 │   │   ├── languages/         # Language-specific scripts
 │   │   │   ├── golang/        # Go scripts (test, cyclonedx, golangci-lint, init)
+│   │   │   ├── dart/          # Dart/Flutter scripts (setup, format, analyze,
+│   │   │   │                  #   test, unused, sca, cyclonedx, build, publish)
 │   │   │   └── python/        # Python scripts (cyclonedx)
 │   │   ├── deploy/            # MVP hosting providers (50-deployment stage)
 │   │   │   ├── cloudflare/    # Cloudflare Pages + Workers
@@ -107,6 +116,7 @@ pipelines/
 │   ├── java.mk                # Java/Gradle targets (lint, test)
 │   ├── javascript.mk          # JavaScript/Yarn targets (lint, test)
 │   ├── dotnet.mk              # .NET/C# targets (lint, test)
+│   ├── dart.mk                # Dart/Flutter targets (lint, test, sca, build)
 │   ├── terraform.mk           # Terraform targets (lint, test)
 │   └── terra.mk               # Terra CLI targets (lint, test)
 ├── .docs/                      # Documentation and examples
@@ -175,6 +185,10 @@ GitHub Actions workflows are located in `.github/workflows/` and can be used as 
 | `composer-docker.yaml`       | PHP/Composer with Docker image delivery    | PHP           |
 | `bundler.yaml`               | Ruby/Bundler testing and quality checks    | Ruby          |
 | `bundler-docker.yaml`        | Ruby/Bundler with Docker image delivery    | Ruby          |
+| `dart.yaml`                  | Dart/Flutter quality, security, and tests  | Dart/Flutter  |
+| `dart-docker.yaml`           | Dart/Flutter with Docker image delivery    | Dart/Flutter  |
+| `dart-library.yaml`          | Dart package published to pub.dev          | Dart          |
+| `flutter-artifacts.yaml`     | Flutter web bundle and Android APK/AAB     | Flutter       |
 | `terra.yaml`                 | Terra CLI quality, security, and tests     | Terraform/HCL |
 
 #### Usage Example (Go with Docker)
@@ -313,6 +327,46 @@ jobs:
     uses: 'rios0rios0/pipelines/.github/workflows/npm-docker.yaml@main'
 ```
 
+#### Usage Example (Flutter with Artifact Delivery)
+
+```yaml
+name: 'CI/CD Pipeline'
+
+on:
+  push:
+    branches: [ 'main' ]
+    tags: [ '*' ]
+  pull_request:
+    branches: [ 'main' ]
+
+permissions:
+  contents: 'write'
+  checks: 'write'
+  # No `security-events: write` is needed: that permission exists for CodeQL,
+  # which has no Dart extractor and is not part of the Dart pipeline.
+
+jobs:
+  pipeline:
+    uses: 'rios0rios0/pipelines/.github/workflows/flutter-artifacts.yaml@main'
+    with:
+      flutter_version: '3.47.0'   # omit to track the current stable release
+```
+
+#### Usage Example (Dart Package to pub.dev)
+
+```yaml
+jobs:
+  pipeline:
+    uses: 'rios0rios0/pipelines/.github/workflows/dart-library.yaml@main'
+    secrets:
+      PUB_TOKEN: ${{ secrets.PUB_TOKEN }}   # only used by the tag-triggered publish job
+```
+
+The toolchain is detected from `pubspec.yaml`, so the same workflows serve a
+Flutter app and a pure Dart package. See
+[.docs/examples/github-flutter-artifacts](.docs/examples/github-flutter-artifacts)
+for a complete project.
+
 #### Usage Example (Java/Maven with Docker)
 
 ```yaml
@@ -396,6 +450,10 @@ GitLab CI templates use remote includes and are organized by language in the `gi
 | **Python**      | `pdm-docker.yaml`    | Python PDM with Docker     |
 | **JavaScript**  | `yarn-docker.yaml`   | Node.js Yarn with Docker   |
 | **.NET**        | `framework.yaml`     | .NET Framework pipeline    |
+| **Dart**        | `dart-docker.yaml`   | Dart with Docker delivery  |
+| **Dart**        | `dart-library.yaml`  | Dart package to pub.dev    |
+| **Flutter**     | `flutter-docker.yaml`| Flutter web in a container |
+| **Flutter**     | `flutter-artifacts.yaml` | Flutter web + Android  |
 | **Terraform**   | `terra.yaml`         | Terraform IaC pipeline     |
 
 #### Usage Example (Go with Docker)
@@ -423,6 +481,23 @@ include:
 variables:
   PYTHON_VERSION: "3.11"  # Optional: specify a Python version
 ```
+
+#### Usage Example (Dart / Flutter)
+
+```yaml
+include:
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/flutter-artifacts.yaml'
+
+variables:
+  DART_FATAL_INFOS: 'true'        # fail on lints, not only errors and warnings
+  DART_COVERAGE_MINIMUM: '80'     # fail below this line coverage
+  ENABLE_ANDROID_DELIVERY: 'true' # needs an Android-SDK-capable runner
+```
+
+No runner image with Dart preinstalled is required: the SDK is downloaded from
+Google's archive and cached in `$CI_PROJECT_DIR/.sdk`. See
+[.docs/examples/gitlab-dart-library](.docs/examples/gitlab-dart-library) for a
+complete package pipeline.
 
 #### Usage Example (Terraform -- raw terraform/terragrunt)
 
@@ -526,6 +601,10 @@ Azure DevOps templates are located in the `azure-devops/` directory and use temp
 | **Python**      | `pdm-docker.yaml`      | Python PDM with Docker            |
 | **JavaScript**  | `yarn-docker.yaml`     | Node.js Yarn with Docker          |
 | **.NET**        | `core.yaml`            | .NET Core pipeline                |
+| **Dart**        | `dart/dart-docker.yaml`  | Dart with Docker delivery       |
+| **Dart**        | `dart/dart-library.yaml` | Dart package to pub.dev         |
+| **Flutter**     | `dart/flutter-docker.yaml` | Flutter web in a container    |
+| **Flutter**     | `dart/flutter-artifacts.yaml` | Flutter web + Android      |
 | **Terraform**   | `terra.yaml`           | Infrastructure as Code pipeline   |
 | **Terra CLI**   | `terra/terra.yaml`     | Terra CLI wrapper pipeline        |
 
@@ -557,6 +636,27 @@ resources:
 stages:
   - template: 'azure-devops/golang/go-docker.yaml@pipelines'
 ```
+
+#### Usage Example (Dart / Flutter)
+
+```yaml
+resources:
+  repositories:
+    - repository: 'pipelines'
+      type: 'github'
+      name: 'rios0rios0/pipelines'
+      ref: 'refs/heads/main'
+      endpoint: 'github-service-connection'
+
+extends:
+  template: 'azure-devops/dart/flutter-artifacts.yaml@pipelines'
+  parameters:
+    ENABLE_WEB_DELIVERY: true
+    ENABLE_ANDROID_DELIVERY: true
+```
+
+Microsoft-hosted `ubuntu-latest` agents already carry the Android SDK and a JDK,
+so the Android target works without extra setup.
 
 #### Usage Example (Go with ARM Deployment)
 
@@ -730,6 +830,60 @@ Optional environment variables:
 | **golangci-lint**  | Go linting suite      | `global/scripts/languages/golang/golangci-lint/` |
 | **Go Test Runner** | Comprehensive testing | `global/scripts/languages/golang/test/`          |
 | **CycloneDX**      | SBOM generation       | `global/scripts/languages/golang/cyclonedx/`     |
+
+#### Dart / Flutter Tools
+
+| Tool             | Purpose                                                    | Script Location                              |
+|------------------|------------------------------------------------------------|----------------------------------------------|
+| **setup**        | Installs the Dart or Flutter SDK from Google's archive      | `global/scripts/languages/dart/setup/`       |
+| **format**       | `dart format` gate (`--fix` rewrites in place)             | `global/scripts/languages/dart/format/`      |
+| **analyze**      | `dart analyze` with JUnit/JSON reports and a severity gate  | `global/scripts/languages/dart/analyze/`     |
+| **test**         | Tests + coverage → JUnit, Cobertura and LCOV               | `global/scripts/languages/dart/test/`        |
+| **unused**       | Unused code and unused file detection (`dart_code_linter`)  | `global/scripts/languages/dart/unused/`      |
+| **sca**          | OSV-Scanner over `pubspec.lock` (Pub advisory database)     | `global/scripts/languages/dart/sca/`         |
+| **cyclonedx**    | SBOM generation for pub projects                            | `global/scripts/languages/dart/cyclonedx/`   |
+| **build**        | Release artifacts (APK, AAB, web, exe, …)                   | `global/scripts/languages/dart/build/`       |
+| **publish**      | pub.dev publication with validation gate                    | `global/scripts/languages/dart/publish/`     |
+
+The toolchain is detected from the project's own `pubspec.yaml` — a `flutter:
+sdk: flutter` dependency selects `flutter`, anything else selects `dart` — so
+the same nine scripts serve a Flutter app and a pure Dart package. Override with
+`DART_TOOLCHAIN=dart|flutter`.
+
+The SDK is downloaded from `storage.googleapis.com` rather than pulled as a
+Docker image, for the same reason every other tool here is installed natively:
+Docker Hub rate-limits anonymous pulls, and a large SDK image is exactly what
+trips that limit.
+
+##### Dart & Flutter Tool Coverage
+
+**Two tools in this repository's standard stack do not support Dart.** Both gaps
+are handled by a deliberate absence or substitution, not by a job that silently
+checks nothing:
+
+| Tool                       | Dart support                                                                 | What the pipeline does                                                                                  |
+|----------------------------|------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
+| **CodeQL**                 | ❌ No extractor ([dart-lang/sdk#52953](https://github.com/dart-lang/sdk/issues/52953)) | The `sast:codeql` job is **omitted** from every Dart template. `make sast` skips it with an explanation.  |
+| **Semgrep** (registry)     | ⚠️ Engine parses Dart (experimental); registry publishes **zero** Dart rules — `p/dart` is a 404 and `r/dart` returns an empty `rules: []` | The job runs. The shared runner skips the unpublished pack instead of failing, and loads the **first-party Dart ruleset** shipped at `global/scripts/tools/semgrep/rules/dart.yaml`. |
+| **OWASP Dependency-Check** | ❌ No pub analyzer                                                            | Replaced by **OSV-Scanner**, which queries the Pub advisory database directly.                            |
+| **Semgrep** (engine)       | ✅ Experimental                                                               | Runs the language-agnostic packs plus the shipped Dart rules.                                             |
+| **Trivy** (IaC + SCA)      | ✅ Parses `pubspec.lock`                                                      | Runs unchanged. Note it records SDK-provided dependencies as version `0.0.0`, which is why OSV-Scanner runs alongside it. |
+| **Gitleaks / Hadolint / ShellCheck** | ✅ Language-agnostic                                               | Run unchanged.                                                                                            |
+| **SonarQube**              | ✅ First-party Dart analyzer (Server 10.7+/Cloud); community `sonar-flutter` on older servers | Both `sonar.dart.lcov.reportPaths` and `sonar.flutter.coverage.reportPath` are written, so either implementation finds the coverage. |
+| **Dependency-Track**       | ✅ via CycloneDX                                                              | BOM generated with Trivy (`package:sbom` emits SPDX only; `cdxgen` would need a Node.js toolchain).        |
+
+The shipped Semgrep ruleset covers the Dart and Flutter issues that are both
+high-consequence and reliably expressible as a pattern — TLS verification
+bypass via `badCertificateCallback`, WebView JavaScript and file-URL access,
+shell and SQL injection through string interpolation, weak randomness for
+security-sensitive values, and secrets written to `SharedPreferences`. Style and
+correctness lints are deliberately left to `dart analyze`, which does them
+better with the project's own `analysis_options.yaml` deciding what counts.
+
+Because CodeQL is absent, `dart analyze` carries more weight here than the
+equivalent job does in other pipelines. Its gate is therefore configurable:
+`DART_FATAL_WARNINGS` (default `true`) and `DART_FATAL_INFOS` (default `false`,
+since that is where every lint lands).
 
 #### Terraform / Terra Tools
 
@@ -1001,8 +1155,13 @@ Available language files:
 | `java.mk`       | Java (Gradle)     | `./gradlew check`                     | `./gradlew test`                |
 | `javascript.mk` | JavaScript (Yarn) | `yarn lint`                           | `yarn test`                     |
 | `dotnet.mk`     | .NET/C#           | `dotnet format`                       | `dotnet test`                   |
+| `dart.mk`       | Dart / Flutter    | `dart format --fix` + `dart analyze` + unused-code scan | `dart`/`flutter test` + coverage → JUnit, Cobertura, LCOV |
 | `terraform.mk`  | Terraform         | `terraform fmt` + `validate`          | `terraform plan`                |
 | `terra.mk`      | Terra CLI         | `terra format` + git diff check       | unified `test-all` runner (`terraform test` on all modules + Terratest suite when present) |
+
+`dart.mk` adds `make sca` (OSV-Scanner over `pubspec.lock`) to `make sast`, and leaves
+`CODEQL_LANGUAGE` unset so `make sast` skips CodeQL with an explanation rather than failing —
+CodeQL has no Dart extractor. Include `common.mk` **before** `dart.mk` so that append works.
 
 The `-include` prefix means Make silently skips the includes if the repository is not cloned yet. Run `make setup` (or `curl ... | bash`) to bootstrap.
 
@@ -1014,6 +1173,12 @@ If you prefer calling scripts directly without Makefile includes:
 
 ```bash
 export SCRIPTS_DIR=$HOME/Development/github.com/rios0rios0/pipelines
+
+# Dart/Flutter: format, analyze, test with coverage, dependency scan
+$SCRIPTS_DIR/global/scripts/languages/dart/format/run.sh --fix
+$SCRIPTS_DIR/global/scripts/languages/dart/analyze/run.sh
+$SCRIPTS_DIR/global/scripts/languages/dart/test/run.sh
+$SCRIPTS_DIR/global/scripts/languages/dart/sca/run.sh
 
 # Go linting
 $SCRIPTS_DIR/global/scripts/languages/golang/golangci-lint/run.sh --fix

--- a/azure-devops/dart/abstracts/dart.yaml
+++ b/azure-devops/dart/abstracts/dart.yaml
@@ -1,0 +1,47 @@
+# Shared setup steps for every Dart / Flutter job.
+#
+# Unlike the GitLab abstract, this one runs directly on the agent rather than in
+# a container, so there is no base image to choose: the SDK is installed by
+# `global/scripts/languages/dart/setup/run.sh` from Google's release archive,
+# and the toolchain (Dart or Flutter) is derived from the project's own
+# `pubspec.yaml`. Microsoft-hosted `ubuntu-latest` agents already carry curl,
+# git, jq, unzip, xz and python3, which is everything that install needs.
+#
+# `Agent.ToolsDirectory` persists across jobs on a self-hosted agent and is
+# wiped between jobs on a hosted one, which is exactly the caching behaviour
+# wanted here: a self-hosted pool downloads the SDK once, a hosted pool restores
+# it from the pipeline cache below.
+steps:
+  - task: 'Cache@2'
+    inputs:
+      # `pubspec.lock` keys the cache because it changes exactly when the
+      # resolved dependency set does. The SDK itself is keyed by the pinned
+      # version variables so bumping FLUTTER_VERSION invalidates it.
+      key: "dart | $(Agent.OS) | $(FLUTTER_VERSION) | $(DART_SDK_VERSION) | pubspec.lock"
+      path: "$(Pipeline.Workspace)/.dart-sdk"
+    displayName: 'Cache the Dart/Flutter SDK'
+    continueOnError: true
+
+  - task: 'Cache@2'
+    inputs:
+      key: "pub | $(Agent.OS) | pubspec.lock"
+      path: "$(Pipeline.Workspace)/.pub-cache"
+    displayName: 'Cache pub packages'
+    continueOnError: true
+
+  - template: '../../global/abstracts/scripts-repo.yaml'
+
+  - script: |
+      set -e
+      export DART_SDK_INSTALL_DIR="$(Pipeline.Workspace)/.dart-sdk"
+      export PUB_CACHE="$(Pipeline.Workspace)/.pub-cache"
+      $(Scripts.Directory)/global/scripts/languages/dart/setup/run.sh
+      # Azure Pipelines starts every `script` step in a fresh shell, so an
+      # exported PATH does not survive to the next one. `task.prependpath` and
+      # `task.setvariable` are the only channels that do, so the SDK location and
+      # the pub cache are re-published through them for every subsequent step.
+      echo "##vso[task.prependpath]$HOME/.local/bin"
+      echo "##vso[task.prependpath]$(Pipeline.Workspace)/.pub-cache/bin"
+      echo "##vso[task.setvariable variable=DART_SDK_INSTALL_DIR]$(Pipeline.Workspace)/.dart-sdk"
+      echo "##vso[task.setvariable variable=PUB_CACHE]$(Pipeline.Workspace)/.pub-cache"
+    displayName: 'Install the Dart/Flutter SDK'

--- a/azure-devops/dart/dart-docker.yaml
+++ b/azure-devops/dart/dart-docker.yaml
@@ -1,0 +1,20 @@
+# Full pipeline for a pure Dart application delivered as a container image.
+# Suits a server-side Dart application (shelf, dart_frog, a compiled CLI in a
+# container): the delivery stage builds from the project's own Dockerfile.
+parameters:
+  - name: 'DOCKER_BUILD_ARGS'
+    type: 'string'
+    default: ''
+  - name: 'RUN_BEFORE_BUILD'
+    type: 'string'
+    default: ''
+
+stages:
+  - template: 'stages/10-code-check/dart.yaml'
+  - template: 'stages/20-security/dart.yaml'
+  - template: 'stages/30-tests/dart.yaml'
+  - template: 'stages/35-management/dart.yaml'
+  - template: 'stages/40-delivery/docker.yaml'
+    parameters:
+      DOCKER_BUILD_ARGS: ${{ parameters.DOCKER_BUILD_ARGS }}
+      RUN_BEFORE_BUILD: ${{ parameters.RUN_BEFORE_BUILD }}

--- a/azure-devops/dart/dart-library.yaml
+++ b/azure-devops/dart/dart-library.yaml
@@ -1,0 +1,11 @@
+# Full pipeline for a Dart package published to pub.dev (or a self-hosted pub
+# server via the PUB_HOSTED_URL variable). Validation runs on every main build;
+# publication runs only on a tag -- see the delivery template for why.
+#
+# Required variable group entries: PUB_TOKEN (secret).
+stages:
+  - template: 'stages/10-code-check/dart.yaml'
+  - template: 'stages/20-security/dart.yaml'
+  - template: 'stages/30-tests/dart.yaml'
+  - template: 'stages/35-management/dart.yaml'
+  - template: 'stages/40-delivery/dart-library.yaml'

--- a/azure-devops/dart/flutter-artifacts.yaml
+++ b/azure-devops/dart/flutter-artifacts.yaml
@@ -1,0 +1,25 @@
+# Full pipeline for a Flutter application delivered as downloadable artifacts:
+# a web bundle and Android APK/AAB. Both targets are on by default because
+# Microsoft-hosted `ubuntu-latest` agents already carry the Android SDK and a
+# JDK; turn either off with the parameters below.
+parameters:
+  - name: 'ENABLE_WEB_DELIVERY'
+    type: 'boolean'
+    default: true
+  - name: 'ENABLE_ANDROID_DELIVERY'
+    type: 'boolean'
+    default: true
+  - name: 'ANDROID_BUILD_TARGETS'
+    type: 'string'
+    default: 'apk appbundle'
+
+stages:
+  - template: 'stages/10-code-check/dart.yaml'
+  - template: 'stages/20-security/dart.yaml'
+  - template: 'stages/30-tests/dart.yaml'
+  - template: 'stages/35-management/dart.yaml'
+  - template: 'stages/40-delivery/flutter-artifacts.yaml'
+    parameters:
+      ENABLE_WEB_DELIVERY: ${{ parameters.ENABLE_WEB_DELIVERY }}
+      ENABLE_ANDROID_DELIVERY: ${{ parameters.ENABLE_ANDROID_DELIVERY }}
+      ANDROID_BUILD_TARGETS: ${{ parameters.ANDROID_BUILD_TARGETS }}

--- a/azure-devops/dart/flutter-docker.yaml
+++ b/azure-devops/dart/flutter-docker.yaml
@@ -1,0 +1,20 @@
+# Full pipeline for a Flutter application delivered as a container image serving
+# the web build. Set the pipeline variable DART_TEST_BUILD_TARGETS to 'web' so
+# the tests stage compiles the same target the delivery stage ships.
+parameters:
+  - name: 'DOCKER_BUILD_ARGS'
+    type: 'string'
+    default: ''
+  - name: 'RUN_BEFORE_BUILD'
+    type: 'string'
+    default: ''
+
+stages:
+  - template: 'stages/10-code-check/dart.yaml'
+  - template: 'stages/20-security/dart.yaml'
+  - template: 'stages/30-tests/dart.yaml'
+  - template: 'stages/35-management/dart.yaml'
+  - template: 'stages/40-delivery/docker.yaml'
+    parameters:
+      DOCKER_BUILD_ARGS: ${{ parameters.DOCKER_BUILD_ARGS }}
+      RUN_BEFORE_BUILD: ${{ parameters.RUN_BEFORE_BUILD }}

--- a/azure-devops/dart/stages/10-code-check/dart.yaml
+++ b/azure-devops/dart/stages/10-code-check/dart.yaml
@@ -1,0 +1,56 @@
+stages:
+  - stage: 'code_check'
+    displayName: 'code check (style/quality)'
+    condition: not(startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
+    jobs:
+      - template: '../../../global/stages/10-code-check/basic-checks.yaml'
+
+      - job: 'style_format'
+        displayName: 'style:format'
+        steps:
+          - template: '../../abstracts/dart.yaml'
+          - script: $(Scripts.Directory)/global/scripts/languages/dart/format/run.sh
+            displayName: 'Run "dart format" check'
+
+      # `dart analyze` carries more weight in a Dart pipeline than the
+      # equivalent job does elsewhere: CodeQL has no Dart extractor, so this is
+      # the primary source of language-level correctness findings. Gate tuning:
+      # DART_FATAL_WARNINGS (default true) and DART_FATAL_INFOS (default false).
+      - job: 'quality_analyze'
+        displayName: 'quality:analyze'
+        steps:
+          - template: '../../abstracts/dart.yaml'
+          - script: $(Scripts.Directory)/global/scripts/languages/dart/analyze/run.sh
+            displayName: 'Run "dart analyze"'
+
+          - task: 'PublishTestResults@2'
+            inputs:
+              testResultsFormat: 'JUnit'
+              testResultsFiles: 'build/reports/dart-analyze/junit-analyze.xml'
+              testRunTitle: 'dart analyze'
+              failTaskOnFailedTests: false
+            displayName: 'Publish analyzer findings'
+            condition: always()
+
+          - task: 'PublishPipelineArtifact@1'
+            inputs:
+              artifactName: 'dart-analyze'
+              targetPath: 'build/reports/dart-analyze'
+            condition: always()
+
+      # Advisory, like `quality:vulture` and `quality:knip` on the other
+      # pipelines: whole-package reachability analysis has a false-positive tail
+      # that a per-library analyzer does not.
+      - job: 'quality_unused_code'
+        displayName: 'quality:unused-code'
+        steps:
+          - template: '../../abstracts/dart.yaml'
+          - script: $(Scripts.Directory)/global/scripts/languages/dart/unused/run.sh
+            displayName: 'Detect unused Dart code and files'
+
+          - task: 'PublishPipelineArtifact@1'
+            inputs:
+              artifactName: 'dart-unused'
+              targetPath: 'build/reports/dart-unused'
+            condition: always()
+        continueOnError: true

--- a/azure-devops/dart/stages/20-security/dart.yaml
+++ b/azure-devops/dart/stages/20-security/dart.yaml
@@ -1,0 +1,54 @@
+# TOOL COVERAGE FOR DART -- read before adding or removing a job here.
+#
+# Two of the security tools this repository runs for every other language have
+# nothing to offer Dart, and both gaps are handled deliberately rather than by
+# leaving a job that silently checks nothing:
+#
+#   CodeQL   -- has NO Dart extractor (dart-lang/sdk#52953, open since 2023), so
+#               `sast:codeql` is ABSENT from this template rather than included
+#               and failing. Do not add it back "for consistency" with the Go,
+#               Python and .NET security stages.
+#
+#   Semgrep  -- the ENGINE parses Dart, but the REGISTRY publishes no Dart rules
+#               (`p/dart` is a 404, `r/dart` returns an empty `rules: []`). The
+#               job below still runs: the shared runner skips an unpublished
+#               language pack instead of failing on it, and picks up the Dart
+#               ruleset this repository ships at
+#               `global/scripts/tools/semgrep/rules/dart.yaml`.
+#
+# Gitleaks and Hadolint are language-agnostic, and Trivy parses `pubspec.lock`
+# natively, so those apply to Dart unchanged.
+stages:
+  - stage: 'security'
+    displayName: 'security (sca/sast)'
+    condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')))
+    jobs:
+      - template: '../../../global/stages/20-security/semgrep.yaml'
+        parameters:
+          SEMGREP_LANGUAGE: 'dart'
+
+      - template: '../../../global/stages/20-security/gitleaks.yaml'
+
+      - template: '../../../global/stages/20-security/hadolint.yaml'
+
+      - template: '../../../global/stages/20-security/trivy.yaml'
+
+      - template: '../../../global/stages/20-security/trivy-sca.yaml'
+
+      # The Dart member of the `sca:govulncheck` / `sca:safety` family, running
+      # ALONGSIDE `sca:trivy` rather than instead of it: Trivy records SDK
+      # provided dependencies at version `0.0.0`, leaving them unmatched against
+      # any advisory, while OSV queries the Pub advisory database directly.
+      - job: 'sca_osv_scanner'
+        displayName: 'sca:osv-scanner'
+        steps:
+          - template: '../../abstracts/dart.yaml'
+          - script: $(Scripts.Directory)/global/scripts/languages/dart/sca/run.sh
+            displayName: 'Run OSV-Scanner over pubspec.lock'
+
+          - task: 'PublishPipelineArtifact@1'
+            inputs:
+              artifactName: 'osv-scanner'
+              targetPath: 'build/reports/osv-scanner'
+            condition: always()
+        continueOnError: true

--- a/azure-devops/dart/stages/30-tests/dart.yaml
+++ b/azure-devops/dart/stages/30-tests/dart.yaml
@@ -1,0 +1,48 @@
+stages:
+  - stage: 'tests'
+    displayName: 'tests'
+    condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')))
+    jobs:
+      - job: 'test_all'
+        displayName: 'test:all'
+        steps:
+          - template: '../../abstracts/dart.yaml'
+          - script: $(Scripts.Directory)/global/scripts/languages/dart/test/run.sh
+            displayName: 'Run tests with coverage'
+
+          - task: 'PublishTestResults@2'
+            inputs:
+              testResultsFormat: 'JUnit'
+              testResultsFiles: 'build/reports/junit.xml'
+            displayName: 'Publish JUnit XML Results'
+            condition: always()
+
+          # Dart emits coverage as LCOV and nothing else, which
+          # `PublishCodeCoverageResults@2` cannot read -- the runner's own
+          # converter produces this Cobertura report from it.
+          - task: 'PublishCodeCoverageResults@2'
+            inputs:
+              summaryFileLocation: 'build/reports/cobertura.xml'
+            displayName: 'Publish Cobertura XML Results'
+            condition: always()
+
+          - task: 'PublishPipelineArtifact@1'
+            inputs:
+              artifactName: 'coverage'
+              targetPath: 'build/reports'
+            displayName: 'Publish Coverage Files'
+            condition: always()
+        continueOnError: false
+
+      # Compiling is a check in its own right: `dart analyze` resolves and type
+      # checks but never runs a compiler back end, so a defect only the AOT or
+      # web compiler rejects passes analysis and fails at release time. Mirrors
+      # `test:build` in the Go and Python templates.
+      - job: 'test_build'
+        displayName: 'test:build'
+        variables:
+          DART_BUILD_MODE: '--debug'
+        steps:
+          - template: '../../abstracts/dart.yaml'
+          - script: $(Scripts.Directory)/global/scripts/languages/dart/build/run.sh $(DART_TEST_BUILD_TARGETS)
+            displayName: 'Compile the project'

--- a/azure-devops/dart/stages/35-management/dart.yaml
+++ b/azure-devops/dart/stages/35-management/dart.yaml
@@ -1,0 +1,31 @@
+stages:
+  - stage: 'management'
+    displayName: 'management'
+    condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')))
+    jobs:
+      - template: '../../../global/stages/35-management/sonarqube.yaml'
+        parameters:
+          COVERAGE_ARTIFACT_TARGET_PATH: "$(Build.SourcesDirectory)/build/reports"
+
+      - job: 'report_dependency_track'
+        displayName: 'report:dependency-track'
+        variables:
+          REPORT_PATH: 'build/reports'
+        steps:
+          # $(Scripts.Directory) is defined by the template below.
+          - template: '../../abstracts/dart.yaml'
+
+          - script: $(Scripts.Directory)/global/scripts/languages/dart/cyclonedx/run.sh
+            displayName: 'Generate the CycloneDX BOM'
+
+          - script: $(Scripts.Directory)/global/scripts/tools/dependency-track/run.sh
+            displayName: 'Upload the BOM to Dependency-Track'
+            # Explicit mapping so the secret `$(DEPENDENCY_TRACK_TOKEN)` reaches
+            # the shell as `$DEPENDENCY_TRACK_TOKEN`. Azure Pipelines gates
+            # secret variables from the process environment; without this block
+            # the script sends an empty `X-Api-Key` header and DT returns
+            # `HTTP 401`.
+            env:
+              DEPENDENCY_TRACK_TOKEN: $(DEPENDENCY_TRACK_TOKEN)
+              DEPENDENCY_TRACK_HOST_URL: $(DEPENDENCY_TRACK_HOST_URL)
+        continueOnError: true

--- a/azure-devops/dart/stages/40-delivery/dart-library.yaml
+++ b/azure-devops/dart/stages/40-delivery/dart-library.yaml
@@ -1,0 +1,42 @@
+stages:
+  - stage: 'delivery'
+    displayName: 'delivery'
+    condition: and(not(failed()), or(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/main')))
+    jobs:
+      # Validation on every main build, publication only on a tag.
+      #
+      # The split is not ceremony. Publishing to pub.dev is IRREVERSIBLE -- a
+      # version can be retracted but never replaced or re-uploaded -- so the
+      # checks pub.dev performs at upload time (missing description, missing
+      # licence, unresolvable constraints, files that would ship by mistake)
+      # have to run long before the upload. `dart pub publish --dry-run` runs
+      # exactly those, so a package that would be rejected fails on the merge
+      # rather than on the release.
+      - job: 'publish_validate'
+        displayName: 'publish:validate'
+        condition: not(startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
+        variables:
+          DART_PUBLISH_DRY_RUN: 'true'
+        steps:
+          - template: '../../abstracts/dart.yaml'
+          - script: $(Scripts.Directory)/global/scripts/languages/dart/publish/run.sh
+            displayName: 'Validate the package (dry run)'
+
+      - job: 'publish_prod'
+        displayName: 'publish:prod'
+        condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+        steps:
+          - template: '../../abstracts/dart.yaml'
+          - script: $(Scripts.Directory)/global/scripts/languages/dart/publish/run.sh
+            displayName: 'Publish to pub.dev'
+            # Explicit mapping so the secret `$(PUB_TOKEN)` reaches the shell as
+            # `$PUB_TOKEN`. Azure Pipelines withholds secret variables from the
+            # process environment; without this block the runner would report a
+            # missing token on a correctly configured pipeline. The runner then
+            # passes only the variable's NAME to `dart pub token add --env-var`,
+            # so the value never reaches argv.
+            env:
+              PUB_TOKEN: $(PUB_TOKEN)
+              PUB_HOSTED_URL: $(PUB_HOSTED_URL)
+
+      - template: '../../../global/stages/40-delivery/release.yaml'

--- a/azure-devops/dart/stages/40-delivery/docker.yaml
+++ b/azure-devops/dart/stages/40-delivery/docker.yaml
@@ -1,0 +1,32 @@
+parameters:
+  - name: 'DOCKER_BUILD_ARGS'
+    type: 'string'
+    default: ''
+  - name: 'RUN_BEFORE_BUILD'
+    type: 'string'
+    default: ''
+  - name: 'IMAGE_NAME'
+    type: 'string'
+    default: ''
+
+stages:
+  - stage: 'delivery'
+    displayName: 'delivery'
+    condition: and(not(failed()), or(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/main')))
+    jobs:
+      - job: 'delivery'
+        displayName: 'delivery'
+        variables:
+          DOCKER_CACHE_DIR: "$(Agent.TempDirectory)/docker-cache"
+        steps:
+          - template: '../../../global/stages/40-delivery/docker.yaml'
+            parameters:
+              DOCKER_FILE: '.ci/stages/40-delivery/app.Dockerfile'
+              DOCKER_CACHE_DIR: "$(DOCKER_CACHE_DIR)"
+              CONTAINER_REGISTRY_SERVER: "$(CONTAINER_REGISTRY_SERVER)"
+              CONTAINER_REGISTRY_SERVICE_CONNECTION: "$(CONTAINER_REGISTRY_SERVICE_CONNECTION)"
+              DOCKER_BUILD_ARGS: "${{ parameters.DOCKER_BUILD_ARGS }}"
+              RUN_BEFORE_BUILD: "${{ parameters.RUN_BEFORE_BUILD }}"
+              IMAGE_NAME: "${{ parameters.IMAGE_NAME }}"
+
+      - template: '../../../global/stages/40-delivery/release.yaml'

--- a/azure-devops/dart/stages/40-delivery/flutter-artifacts.yaml
+++ b/azure-devops/dart/stages/40-delivery/flutter-artifacts.yaml
@@ -1,0 +1,64 @@
+parameters:
+  # Android artifacts need the Android SDK and a JDK. Microsoft-hosted
+  # `ubuntu-latest` agents already ship both, so this defaults to on here --
+  # unlike the GitLab template, where the runner image is the consumer's choice
+  # and cannot be assumed to carry them.
+  - name: 'ENABLE_ANDROID_DELIVERY'
+    type: 'boolean'
+    default: true
+  - name: 'ENABLE_WEB_DELIVERY'
+    type: 'boolean'
+    default: true
+  # An APK is sideloadable and useful for QA distribution; an App Bundle is the
+  # only format Google Play accepts for new releases. Both are built by default.
+  - name: 'ANDROID_BUILD_TARGETS'
+    type: 'string'
+    default: 'apk appbundle'
+
+stages:
+  - stage: 'delivery'
+    displayName: 'delivery'
+    condition: and(not(failed()), or(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/main')))
+    jobs:
+      - ${{ if eq(parameters.ENABLE_WEB_DELIVERY, true) }}:
+          - job: 'delivery_web'
+            displayName: 'delivery:web'
+            variables:
+              DART_BUILD_TARGETS: 'web'
+            steps:
+              - template: '../../abstracts/dart.yaml'
+              - script: $(Scripts.Directory)/global/scripts/languages/dart/build/run.sh
+                displayName: 'Build the Flutter web bundle'
+
+              - task: 'PublishPipelineArtifact@1'
+                inputs:
+                  artifactName: 'flutter-web'
+                  targetPath: 'build/web'
+                displayName: 'Publish the web bundle'
+
+      - ${{ if eq(parameters.ENABLE_ANDROID_DELIVERY, true) }}:
+          - job: 'delivery_android'
+            displayName: 'delivery:android'
+            variables:
+              DART_BUILD_TARGETS: '${{ parameters.ANDROID_BUILD_TARGETS }}'
+            steps:
+              - template: '../../abstracts/dart.yaml'
+
+              - task: 'JavaToolInstaller@0'
+                inputs:
+                  versionSpec: '17'
+                  jdkArchitectureOption: 'x64'
+                  jdkSourceOption: 'PreInstalled'
+                displayName: 'Use JDK 17 for the Android Gradle plugin'
+                continueOnError: true
+
+              - script: $(Scripts.Directory)/global/scripts/languages/dart/build/run.sh
+                displayName: 'Build the Android artifacts'
+
+              - task: 'PublishPipelineArtifact@1'
+                inputs:
+                  artifactName: 'flutter-android'
+                  targetPath: 'build/app/outputs'
+                displayName: 'Publish the Android artifacts'
+
+      - template: '../../../global/stages/40-delivery/release.yaml'

--- a/github/dart/stages/10-code-check/analyze/action.yaml
+++ b/github/dart/stages/10-code-check/analyze/action.yaml
@@ -1,0 +1,66 @@
+# `dart analyze` gate, with JUnit + JSON reports.
+#
+# This job carries more weight in a Dart pipeline than the equivalent does
+# elsewhere: CodeQL has no Dart extractor (dart-lang/sdk#52953), so the analyzer
+# is the primary source of language-level correctness findings. The severity gate
+# is configurable for that reason -- a project adopting a stricter lint set can
+# see INFO findings before it has to fix them all.
+inputs:
+  flutter_version:
+    required: false
+    default: ''
+    description: 'Pin an exact Flutter version (e.g. 3.47.0). Defaults to the current stable release.'
+  dart_sdk_version:
+    required: false
+    default: 'latest'
+    description: 'Pin an exact Dart SDK version. Only used for pure Dart projects.'
+  toolchain:
+    required: false
+    default: 'auto'
+    description: "Force the toolchain: 'dart', 'flutter', or 'auto' to detect it from pubspec.yaml."
+  fatal_warnings:
+    required: false
+    default: 'true'
+    description: 'Fail the job on WARNING-level diagnostics.'
+  fatal_infos:
+    required: false
+    default: 'false'
+    description: 'Fail the job on INFO-level diagnostics (this is where lints land).'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Checkout code'
+      uses: 'actions/checkout@v6'
+
+    - uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
+
+    - name: 'Cache the Dart/Flutter SDK and pub packages'
+      uses: 'actions/cache@v4'
+      with:
+        path: |
+          ~/.local/share/flutter
+          ~/.local/share/dart-sdk
+          ~/.pub-cache
+        key: "dart-${{ runner.os }}-${{ inputs.flutter_version }}-${{ inputs.dart_sdk_version }}-${{ hashFiles('**/pubspec.lock') }}"
+        restore-keys: "dart-${{ runner.os }}-${{ inputs.flutter_version }}-${{ inputs.dart_sdk_version }}-"
+
+    - name: 'Run "dart analyze"'
+      run: $SCRIPTS_DIR/global/scripts/languages/dart/analyze/run.sh
+      shell: 'bash'
+      env:
+        FLUTTER_VERSION: '${{ inputs.flutter_version }}'
+        DART_SDK_VERSION: '${{ inputs.dart_sdk_version }}'
+        DART_TOOLCHAIN: '${{ inputs.toolchain }}'
+        DART_FATAL_WARNINGS: '${{ inputs.fatal_warnings }}'
+        DART_FATAL_INFOS: '${{ inputs.fatal_infos }}'
+
+    - name: 'Upload Report'
+      uses: 'actions/upload-artifact@v7'
+      with:
+        name: 'dart-analyze'
+        path: 'build/reports/dart-analyze/'
+        if-no-files-found: 'warn'
+        overwrite: 'true'
+        retention-days: 10
+      if: always()

--- a/github/dart/stages/10-code-check/format/action.yaml
+++ b/github/dart/stages/10-code-check/format/action.yaml
@@ -1,0 +1,49 @@
+# `dart format` gate.
+#
+# The SDK is installed by this repository's own setup script rather than by
+# `subosito/flutter-action`, for the same reason the rest of the Dart family
+# avoids prebuilt images: ONE code path installs Dart OR Flutter (chosen from the
+# project's `pubspec.yaml`) from Google's release archive, and it is identical on
+# GitHub Actions, GitLab CI and Azure DevOps -- so a Dart pipeline behaves the
+# same whichever platform runs it, and there is one place to fix when it does
+# not. A third-party action would also be a supply-chain dependency in the
+# critical path of every Dart job here.
+inputs:
+  flutter_version:
+    required: false
+    default: ''
+    description: 'Pin an exact Flutter version (e.g. 3.47.0). Defaults to the current stable release.'
+  dart_sdk_version:
+    required: false
+    default: 'latest'
+    description: 'Pin an exact Dart SDK version. Only used for pure Dart projects.'
+  toolchain:
+    required: false
+    default: 'auto'
+    description: "Force the toolchain: 'dart', 'flutter', or 'auto' to detect it from pubspec.yaml."
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Checkout code'
+      uses: 'actions/checkout@v6'
+
+    - uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
+
+    - name: 'Cache the Dart/Flutter SDK and pub packages'
+      uses: 'actions/cache@v4'
+      with:
+        path: |
+          ~/.local/share/flutter
+          ~/.local/share/dart-sdk
+          ~/.pub-cache
+        key: "dart-${{ runner.os }}-${{ inputs.flutter_version }}-${{ inputs.dart_sdk_version }}-${{ hashFiles('**/pubspec.lock') }}"
+        restore-keys: "dart-${{ runner.os }}-${{ inputs.flutter_version }}-${{ inputs.dart_sdk_version }}-"
+
+    - name: 'Run "dart format" check'
+      run: $SCRIPTS_DIR/global/scripts/languages/dart/format/run.sh
+      shell: 'bash'
+      env:
+        FLUTTER_VERSION: '${{ inputs.flutter_version }}'
+        DART_SDK_VERSION: '${{ inputs.dart_sdk_version }}'
+        DART_TOOLCHAIN: '${{ inputs.toolchain }}'

--- a/github/dart/stages/10-code-check/unused/action.yaml
+++ b/github/dart/stages/10-code-check/unused/action.yaml
@@ -1,0 +1,70 @@
+# Dead-code detection for Dart -- the counterpart of `vulture` (Python), `knip`
+# (JavaScript) and golangci-lint's `unused` (Go).
+#
+# It exists for the two things `dart analyze` structurally cannot see: a PUBLIC
+# declaration nothing references, and a `.dart` file nothing imports. Both need a
+# whole-package pass; a per-library analyzer must assume a public API has callers
+# it cannot see.
+#
+# Advisory by default (`continue-on-error` in the calling workflow) because
+# reachability analysis has a false-positive tail -- framework entry points,
+# generated code, `@visibleForTesting` members.
+inputs:
+  flutter_version:
+    required: false
+    default: ''
+    description: 'Pin an exact Flutter version (e.g. 3.47.0). Defaults to the current stable release.'
+  dart_sdk_version:
+    required: false
+    default: 'latest'
+    description: 'Pin an exact Dart SDK version. Only used for pure Dart projects.'
+  toolchain:
+    required: false
+    default: 'auto'
+    description: "Force the toolchain: 'dart', 'flutter', or 'auto' to detect it from pubspec.yaml."
+  targets:
+    required: false
+    default: 'lib'
+    description: 'Directories to scan for unused code.'
+  fatal:
+    required: false
+    default: 'false'
+    description: 'Fail the job when unused code or files are found.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Checkout code'
+      uses: 'actions/checkout@v6'
+
+    - uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
+
+    - name: 'Cache the Dart/Flutter SDK and pub packages'
+      uses: 'actions/cache@v4'
+      with:
+        path: |
+          ~/.local/share/flutter
+          ~/.local/share/dart-sdk
+          ~/.pub-cache
+        key: "dart-${{ runner.os }}-${{ inputs.flutter_version }}-${{ inputs.dart_sdk_version }}-${{ hashFiles('**/pubspec.lock') }}"
+        restore-keys: "dart-${{ runner.os }}-${{ inputs.flutter_version }}-${{ inputs.dart_sdk_version }}-"
+
+    - name: 'Detect unused Dart code and files'
+      run: $SCRIPTS_DIR/global/scripts/languages/dart/unused/run.sh
+      shell: 'bash'
+      env:
+        FLUTTER_VERSION: '${{ inputs.flutter_version }}'
+        DART_SDK_VERSION: '${{ inputs.dart_sdk_version }}'
+        DART_TOOLCHAIN: '${{ inputs.toolchain }}'
+        DART_UNUSED_TARGETS: '${{ inputs.targets }}'
+        DART_UNUSED_FATAL: '${{ inputs.fatal }}'
+
+    - name: 'Upload Report'
+      uses: 'actions/upload-artifact@v7'
+      with:
+        name: 'dart-unused'
+        path: 'build/reports/dart-unused/'
+        if-no-files-found: 'warn'
+        overwrite: 'true'
+        retention-days: 10
+      if: always()

--- a/github/dart/stages/20-security/osv-scanner/action.yaml
+++ b/github/dart/stages/20-security/osv-scanner/action.yaml
@@ -1,0 +1,62 @@
+# Pub dependency vulnerability scanning via OSV-Scanner.
+#
+# The Dart member of the `govulncheck` / `safety` / Dependency-Check family: a
+# language-native SCA running ALONGSIDE the shared `sca:trivy` job, not instead
+# of it. Trivy does read `pubspec.lock`, but it records SDK-provided dependencies
+# (Flutter itself and anything resolved through it) at version `0.0.0`, leaving
+# those components unmatched against any advisory. OSV queries the Pub advisory
+# database the Dart team publishes into OSV.dev directly.
+inputs:
+  flutter_version:
+    required: false
+    default: ''
+    description: 'Pin an exact Flutter version (e.g. 3.47.0). Defaults to the current stable release.'
+  dart_sdk_version:
+    required: false
+    default: 'latest'
+    description: 'Pin an exact Dart SDK version. Only used for pure Dart projects.'
+  toolchain:
+    required: false
+    default: 'auto'
+    description: "Force the toolchain: 'dart', 'flutter', or 'auto' to detect it from pubspec.yaml."
+  lockfile:
+    required: false
+    default: 'pubspec.lock'
+    description: 'Path to the pub lockfile to scan.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Checkout code'
+      uses: 'actions/checkout@v6'
+
+    - uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
+
+    - name: 'Cache the Dart/Flutter SDK and pub packages'
+      uses: 'actions/cache@v4'
+      with:
+        path: |
+          ~/.local/share/flutter
+          ~/.local/share/dart-sdk
+          ~/.pub-cache
+        key: "dart-${{ runner.os }}-${{ inputs.flutter_version }}-${{ inputs.dart_sdk_version }}-${{ hashFiles('**/pubspec.lock') }}"
+        restore-keys: "dart-${{ runner.os }}-${{ inputs.flutter_version }}-${{ inputs.dart_sdk_version }}-"
+
+    - name: 'Run OSV-Scanner over pubspec.lock'
+      run: $SCRIPTS_DIR/global/scripts/languages/dart/sca/run.sh
+      shell: 'bash'
+      env:
+        FLUTTER_VERSION: '${{ inputs.flutter_version }}'
+        DART_SDK_VERSION: '${{ inputs.dart_sdk_version }}'
+        DART_TOOLCHAIN: '${{ inputs.toolchain }}'
+        DART_LOCKFILE: '${{ inputs.lockfile }}'
+
+    - name: 'Upload Report'
+      uses: 'actions/upload-artifact@v7'
+      with:
+        name: 'osv-scanner'
+        path: 'build/reports/osv-scanner/'
+        if-no-files-found: 'warn'
+        overwrite: 'true'
+        retention-days: 10
+      if: always()

--- a/github/dart/stages/30-tests/all/action.yaml
+++ b/github/dart/stages/30-tests/all/action.yaml
@@ -1,0 +1,71 @@
+# Tests and coverage for both toolchains.
+#
+# Produces `build/reports/junit.xml`, `build/reports/cobertura.xml` and
+# `build/reports/lcov.info`. Dart emits coverage as LCOV and nothing else, so the
+# Cobertura report is produced by the runner's own stdlib-Python converter --
+# see `global/scripts/languages/dart/test/lcov_to_cobertura.py` for why that is
+# a converter here rather than a `pip install`.
+inputs:
+  flutter_version:
+    required: false
+    default: ''
+    description: 'Pin an exact Flutter version (e.g. 3.47.0). Defaults to the current stable release.'
+  dart_sdk_version:
+    required: false
+    default: 'latest'
+    description: 'Pin an exact Dart SDK version. Only used for pure Dart projects.'
+  toolchain:
+    required: false
+    default: 'auto'
+    description: "Force the toolchain: 'dart', 'flutter', or 'auto' to detect it from pubspec.yaml."
+  coverage_minimum:
+    required: false
+    default: ''
+    description: 'Fail the job when line coverage falls below this percentage (e.g. 80).'
+  require_tests:
+    required: false
+    default: 'false'
+    description: 'Fail rather than skip when the project has no test/ directory.'
+  test_args:
+    required: false
+    default: ''
+    description: 'Extra arguments appended to `dart test` / `flutter test`.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Checkout code'
+      uses: 'actions/checkout@v6'
+
+    - uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
+
+    - name: 'Cache the Dart/Flutter SDK and pub packages'
+      uses: 'actions/cache@v4'
+      with:
+        path: |
+          ~/.local/share/flutter
+          ~/.local/share/dart-sdk
+          ~/.pub-cache
+        key: "dart-${{ runner.os }}-${{ inputs.flutter_version }}-${{ inputs.dart_sdk_version }}-${{ hashFiles('**/pubspec.lock') }}"
+        restore-keys: "dart-${{ runner.os }}-${{ inputs.flutter_version }}-${{ inputs.dart_sdk_version }}-"
+
+    - name: 'Run tests with coverage'
+      run: $SCRIPTS_DIR/global/scripts/languages/dart/test/run.sh
+      shell: 'bash'
+      env:
+        FLUTTER_VERSION: '${{ inputs.flutter_version }}'
+        DART_SDK_VERSION: '${{ inputs.dart_sdk_version }}'
+        DART_TOOLCHAIN: '${{ inputs.toolchain }}'
+        DART_COVERAGE_MINIMUM: '${{ inputs.coverage_minimum }}'
+        DART_REQUIRE_TESTS: '${{ inputs.require_tests }}'
+        DART_TEST_ARGS: '${{ inputs.test_args }}'
+
+    - name: 'Upload Report'
+      uses: 'actions/upload-artifact@v7'
+      with:
+        name: 'test-results'
+        path: 'build/reports/'
+        if-no-files-found: 'warn'
+        overwrite: 'true'
+        retention-days: 10
+      if: always()

--- a/github/dart/stages/35-management/cyclonedx/action.yaml
+++ b/github/dart/stages/35-management/cyclonedx/action.yaml
@@ -1,0 +1,65 @@
+# CycloneDX SBOM generation for a pub project, for the Dependency-Track upload.
+#
+# Trivy generates the BOM because there is no Dart-native alternative that emits
+# CycloneDX: `package:sbom` (the only pub-published generator) emits SPDX, and
+# `cdxgen` would drag a whole Node.js toolchain into a Dart job for one file.
+# Same approach as the Terraform SBOM in this repository.
+inputs:
+  flutter_version:
+    required: false
+    default: ''
+    description: 'Pin an exact Flutter version (e.g. 3.47.0). Defaults to the current stable release.'
+  dart_sdk_version:
+    required: false
+    default: 'latest'
+    description: 'Pin an exact Dart SDK version. Only used for pure Dart projects.'
+  toolchain:
+    required: false
+    default: 'auto'
+    description: "Force the toolchain: 'dart', 'flutter', or 'auto' to detect it from pubspec.yaml."
+  project_name:
+    required: false
+    default: ''
+    description: 'Override the BOM project name (defaults to pubspec.yaml `name`).'
+  project_version:
+    required: false
+    default: ''
+    description: 'Override the BOM project version (defaults to pubspec.yaml `version`).'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Checkout code'
+      uses: 'actions/checkout@v6'
+
+    - uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
+
+    - name: 'Cache the Dart/Flutter SDK and pub packages'
+      uses: 'actions/cache@v4'
+      with:
+        path: |
+          ~/.local/share/flutter
+          ~/.local/share/dart-sdk
+          ~/.pub-cache
+        key: "dart-${{ runner.os }}-${{ inputs.flutter_version }}-${{ inputs.dart_sdk_version }}-${{ hashFiles('**/pubspec.lock') }}"
+        restore-keys: "dart-${{ runner.os }}-${{ inputs.flutter_version }}-${{ inputs.dart_sdk_version }}-"
+
+    - name: 'Generate the CycloneDX BOM'
+      run: $SCRIPTS_DIR/global/scripts/languages/dart/cyclonedx/run.sh
+      shell: 'bash'
+      env:
+        FLUTTER_VERSION: '${{ inputs.flutter_version }}'
+        DART_SDK_VERSION: '${{ inputs.dart_sdk_version }}'
+        DART_TOOLCHAIN: '${{ inputs.toolchain }}'
+        DT_PROJECT_NAME: '${{ inputs.project_name }}'
+        DT_PROJECT_VERSION: '${{ inputs.project_version }}'
+
+    - name: 'Upload Report'
+      uses: 'actions/upload-artifact@v7'
+      with:
+        name: 'bom'
+        path: 'build/reports/bom.json'
+        if-no-files-found: 'warn'
+        overwrite: 'true'
+        retention-days: 10
+      if: always()

--- a/github/dart/stages/40-delivery/build/action.yaml
+++ b/github/dart/stages/40-delivery/build/action.yaml
@@ -1,0 +1,78 @@
+# Builds the release artifacts for the `40-delivery` stage.
+#
+# Targets: apk appbundle web linux macos windows ipa (Flutter);
+#          exe js aot-snapshot (pure Dart).
+# With no target given the runner picks one from the project's own shape -- an
+# APK for a Flutter app, a native executable for a Dart package with a `bin/`,
+# and nothing at all for a library.
+#
+# Android targets need the Android SDK and a JDK; GitHub's `ubuntu-latest`
+# runners already ship both. `ipa` needs a macOS runner and is built unsigned.
+inputs:
+  flutter_version:
+    required: false
+    default: ''
+    description: 'Pin an exact Flutter version (e.g. 3.47.0). Defaults to the current stable release.'
+  dart_sdk_version:
+    required: false
+    default: 'latest'
+    description: 'Pin an exact Dart SDK version. Only used for pure Dart projects.'
+  toolchain:
+    required: false
+    default: 'auto'
+    description: "Force the toolchain: 'dart', 'flutter', or 'auto' to detect it from pubspec.yaml."
+  targets:
+    required: false
+    default: ''
+    description: "Space-separated build targets (e.g. 'web appbundle'). Empty means auto-detect."
+  build_mode:
+    required: false
+    default: '--release'
+    description: 'Flutter build mode flag.'
+  build_args:
+    required: false
+    default: ''
+    description: 'Extra arguments appended to the build command.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Checkout code'
+      uses: 'actions/checkout@v6'
+
+    - uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
+
+    - name: 'Cache the Dart/Flutter SDK and pub packages'
+      uses: 'actions/cache@v4'
+      with:
+        path: |
+          ~/.local/share/flutter
+          ~/.local/share/dart-sdk
+          ~/.pub-cache
+        key: "dart-${{ runner.os }}-${{ inputs.flutter_version }}-${{ inputs.dart_sdk_version }}-${{ hashFiles('**/pubspec.lock') }}"
+        restore-keys: "dart-${{ runner.os }}-${{ inputs.flutter_version }}-${{ inputs.dart_sdk_version }}-"
+
+    - name: 'Build the artifacts'
+      run: $SCRIPTS_DIR/global/scripts/languages/dart/build/run.sh
+      shell: 'bash'
+      env:
+        FLUTTER_VERSION: '${{ inputs.flutter_version }}'
+        DART_SDK_VERSION: '${{ inputs.dart_sdk_version }}'
+        DART_TOOLCHAIN: '${{ inputs.toolchain }}'
+        DART_BUILD_TARGETS: '${{ inputs.targets }}'
+        DART_BUILD_MODE: '${{ inputs.build_mode }}'
+        DART_BUILD_ARGS: '${{ inputs.build_args }}'
+        DART_BUILD_NUMBER: '${{ github.run_number }}'
+
+    - name: 'Upload Report'
+      uses: 'actions/upload-artifact@v7'
+      with:
+        name: 'dart-build'
+        path: 'build/app/outputs/**
+          build/web/**
+          build/*.js
+          build/*.aot'
+        if-no-files-found: 'warn'
+        overwrite: 'true'
+        retention-days: 10
+      if: always()

--- a/github/dart/stages/40-delivery/build/action.yaml
+++ b/github/dart/stages/40-delivery/build/action.yaml
@@ -68,10 +68,17 @@ runs:
       uses: 'actions/upload-artifact@v7'
       with:
         name: 'dart-build'
-        path: 'build/app/outputs/**
+        # A BLOCK SCALAR, not a quoted multi-line string. `upload-artifact`
+        # splits this input on newlines, and a single-quoted scalar spanning
+        # several lines FOLDS them into one space-separated line -- so the four
+        # patterns below would arrive as a single glob containing spaces,
+        # matching nothing. With `if-no-files-found: warn` that failure is
+        # silent: the job stays green and publishes an empty artifact.
+        path: |
+          build/app/outputs/**
           build/web/**
           build/*.js
-          build/*.aot'
+          build/*.aot
         if-no-files-found: 'warn'
         overwrite: 'true'
         retention-days: 10

--- a/github/dart/stages/40-delivery/publish/action.yaml
+++ b/github/dart/stages/40-delivery/publish/action.yaml
@@ -1,0 +1,66 @@
+# Publishes a package to pub.dev (or a self-hosted pub server).
+#
+# THE TOKEN IS NEVER PASSED ON ARGV. The runner calls `dart pub token add
+# --env-var PUB_TOKEN`, which passes the variable's NAME and lets pub read the
+# value from the environment at use time. Argv is world-readable through `ps`,
+# and this repository additionally records resolved command lines into an
+# uploaded artifact -- so a token on argv would be exfiltrated into it and kept
+# for the artifact's retention period.
+#
+# `dry_run: true` runs pub.dev's full validation without uploading. Publishing is
+# IRREVERSIBLE (a version can be retracted, never replaced), so the calling
+# workflows validate on every default-branch build and publish only on a tag.
+inputs:
+  flutter_version:
+    required: false
+    default: ''
+    description: 'Pin an exact Flutter version (e.g. 3.47.0). Defaults to the current stable release.'
+  dart_sdk_version:
+    required: false
+    default: 'latest'
+    description: 'Pin an exact Dart SDK version. Only used for pure Dart projects.'
+  toolchain:
+    required: false
+    default: 'auto'
+    description: "Force the toolchain: 'dart', 'flutter', or 'auto' to detect it from pubspec.yaml."
+  dry_run:
+    required: false
+    default: 'false'
+    description: 'Validate the package without publishing it.'
+  pub_token:
+    required: false
+    default: ''
+    description: 'pub.dev credential. Required unless dry_run is true. Pass a secret, never a literal.'
+  pub_hosted_url:
+    required: false
+    default: ''
+    description: 'Self-hosted pub server URL. Defaults to https://pub.dev.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Checkout code'
+      uses: 'actions/checkout@v6'
+
+    - uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
+
+    - name: 'Cache the Dart/Flutter SDK and pub packages'
+      uses: 'actions/cache@v4'
+      with:
+        path: |
+          ~/.local/share/flutter
+          ~/.local/share/dart-sdk
+          ~/.pub-cache
+        key: "dart-${{ runner.os }}-${{ inputs.flutter_version }}-${{ inputs.dart_sdk_version }}-${{ hashFiles('**/pubspec.lock') }}"
+        restore-keys: "dart-${{ runner.os }}-${{ inputs.flutter_version }}-${{ inputs.dart_sdk_version }}-"
+
+    - name: 'Publish to pub'
+      run: $SCRIPTS_DIR/global/scripts/languages/dart/publish/run.sh
+      shell: 'bash'
+      env:
+        FLUTTER_VERSION: '${{ inputs.flutter_version }}'
+        DART_SDK_VERSION: '${{ inputs.dart_sdk_version }}'
+        DART_TOOLCHAIN: '${{ inputs.toolchain }}'
+        DART_PUBLISH_DRY_RUN: '${{ inputs.dry_run }}'
+        PUB_TOKEN: '${{ inputs.pub_token }}'
+        PUB_HOSTED_URL: '${{ inputs.pub_hosted_url }}'

--- a/gitlab/dart/abstracts/dart.yaml
+++ b/gitlab/dart/abstracts/dart.yaml
@@ -1,0 +1,68 @@
+include:
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/abstracts/default-variables.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/abstracts/scripts-repo.yaml'
+
+# Base job for every Dart and Flutter job.
+#
+# The image is a plain Debian rather than `dart:stable` or a third-party Flutter
+# image, and the SDK is installed by `global/scripts/languages/dart/setup/run.sh`
+# from Google's own release archive. Two reasons:
+#
+#   1. ONE ABSTRACT COVERS BOTH TOOLCHAINS. The setup script reads the project's
+#      `pubspec.yaml` and installs Dart or Flutter accordingly, so a Flutter app
+#      and a pure Dart package share this job definition instead of needing two
+#      near-identical ones that drift.
+#   2. NO DOCKER HUB PULL FOR THE TOOLCHAIN. Docker Hub rate-limits anonymous
+#      pulls; a large, frequently-pulled SDK image is exactly what trips it. The
+#      base image here is small and the SDK comes from `storage.googleapis.com`,
+#      which is not rate limited.
+#
+# `DART_SDK_INSTALL_DIR` and `PUB_CACHE` are relocated INTO `$CI_PROJECT_DIR`
+# because GitLab CI can only cache paths under it. Left at their defaults
+# (`$HOME`), the Flutter SDK -- several hundred megabytes -- would be
+# re-downloaded by every job of every pipeline.
+.dart:
+  image: 'debian:bookworm-slim'
+  variables:
+    DART_SDK_INSTALL_DIR: "$CI_PROJECT_DIR/.sdk"
+    PUB_CACHE: "$CI_PROJECT_DIR/.pub-cache"
+  cache: # relative to the project directory ($CI_PROJECT_DIR)
+    key: "dart-$CI_COMMIT_REF_SLUG"
+    paths:
+      - '.sdk'
+      - '.pub-cache'
+      - '.dart_tool'
+    when: 'always'
+  before_script:
+    # `xz-utils` unpacks the Flutter tarball, `unzip` the Dart SDK zip, `git` is
+    # required by the Flutter SDK itself (it is a git checkout and shells out to
+    # git on almost every invocation), `jq` resolves the current release from the
+    # Flutter manifest, and `python3` runs the report converters.
+    - apt-get update -qq && apt-get install -y -qq --no-install-recommends
+      ca-certificates curl git jq python3 unzip xz-utils zip
+    - !reference [ .scripts-repo, before_script ]
+    - $SCRIPTS_DIR/global/scripts/languages/dart/setup/run.sh
+    - export PATH="$HOME/.local/bin:$PATH:$PUB_CACHE/bin"
+  tags:
+    - 'dev-gitlab-runner-onprem'
+  rules:
+    - if: "$CI_MERGE_REQUEST_IID"
+    - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"
+
+# Variant for jobs that build Android artifacts (`apk`, `appbundle`).
+#
+# Those need the Android SDK and a JDK, which the Debian base image above does
+# not carry and which this repository will not install ad hoc -- an unattended
+# `sdkmanager` licence acceptance inside a CI job is both slow and a supply-chain
+# decision that belongs to the consuming project, not to a shared template.
+# Point `DART_ANDROID_IMAGE` at an image that already has them; the default is
+# Cirrus Labs' Flutter image, published on GHCR (so no Docker Hub rate limit),
+# which bundles the Flutter SDK, the Android SDK and a JDK.
+.dart-android:
+  extends: '.dart'
+  image: "${DART_ANDROID_IMAGE:-ghcr.io/cirruslabs/flutter:stable}"
+  before_script:
+    - !reference [ .scripts-repo, before_script ]
+    # The image already ships the SDK, so `dart_ensure_sdk` finds it on PATH and
+    # downloads nothing; only `apt-get` is skipped relative to `.dart`.
+    - export PATH="$HOME/.local/bin:$PATH:$PUB_CACHE/bin"

--- a/gitlab/dart/dart-docker.yaml
+++ b/gitlab/dart/dart-docker.yaml
@@ -1,0 +1,19 @@
+# Full pipeline for a pure Dart application delivered as a container image.
+# The Docker delivery stage builds from the project's own Dockerfile, so it suits
+# a server-side Dart application (shelf, dart_frog, a compiled CLI in a container).
+include:
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/abstracts/default-image.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/10-code-check/basic-checks.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/stages/10-code-check/dart.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/stages/20-security/dart.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/stages/30-tests/dart.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/stages/35-management/dart.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/40-delivery/docker.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/40-delivery/release.yaml'
+
+stages:
+  - 'code check (style/quality)'
+  - 'security (sca/sast)'
+  - 'tests'
+  - 'management'
+  - 'delivery'

--- a/gitlab/dart/dart-library.yaml
+++ b/gitlab/dart/dart-library.yaml
@@ -1,0 +1,19 @@
+# Full pipeline for a Dart package published to pub.dev (or a self-hosted pub
+# server via PUB_HOSTED_URL). Validation runs on every default-branch build;
+# publication runs only on a tag -- see the delivery template for why.
+include:
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/abstracts/default-image.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/10-code-check/basic-checks.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/stages/10-code-check/dart.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/stages/20-security/dart.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/stages/30-tests/dart.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/stages/35-management/dart.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/stages/40-delivery/dart-library.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/40-delivery/release.yaml'
+
+stages:
+  - 'code check (style/quality)'
+  - 'security (sca/sast)'
+  - 'tests'
+  - 'management'
+  - 'delivery'

--- a/gitlab/dart/flutter-artifacts.yaml
+++ b/gitlab/dart/flutter-artifacts.yaml
@@ -1,0 +1,19 @@
+# Full pipeline for a Flutter application delivered as downloadable artifacts:
+# a web bundle always, plus Android APK/AAB when ENABLE_ANDROID_DELIVERY is 'true'
+# (that target needs an Android-SDK-capable runner -- see the delivery template).
+include:
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/abstracts/default-image.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/10-code-check/basic-checks.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/stages/10-code-check/dart.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/stages/20-security/dart.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/stages/30-tests/dart.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/stages/35-management/dart.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/stages/40-delivery/flutter-artifacts.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/40-delivery/release.yaml'
+
+stages:
+  - 'code check (style/quality)'
+  - 'security (sca/sast)'
+  - 'tests'
+  - 'management'
+  - 'delivery'

--- a/gitlab/dart/flutter-docker.yaml
+++ b/gitlab/dart/flutter-docker.yaml
@@ -1,0 +1,19 @@
+# Full pipeline for a Flutter application delivered as a container image serving
+# the web build. Set DART_TEST_BUILD_TARGETS='web' so the tests stage compiles the
+# same target the delivery stage ships.
+include:
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/abstracts/default-image.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/10-code-check/basic-checks.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/stages/10-code-check/dart.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/stages/20-security/dart.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/stages/30-tests/dart.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/stages/35-management/dart.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/40-delivery/docker.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/40-delivery/release.yaml'
+
+stages:
+  - 'code check (style/quality)'
+  - 'security (sca/sast)'
+  - 'tests'
+  - 'management'
+  - 'delivery'

--- a/gitlab/dart/stages/10-code-check/dart.yaml
+++ b/gitlab/dart/stages/10-code-check/dart.yaml
@@ -1,0 +1,39 @@
+include:
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/abstracts/dart.yaml'
+
+style:format:
+  extends: '.dart'
+  stage: 'code check (style/quality)'
+  script:
+    - $SCRIPTS_DIR/global/scripts/languages/dart/format/run.sh
+
+# `dart analyze` carries more weight in a Dart pipeline than the equivalent job
+# does elsewhere: CodeQL has no Dart extractor at all, so this is the primary
+# source of language-level correctness findings. See the runner's header for the
+# full tool-gap rationale, and `DART_FATAL_WARNINGS` / `DART_FATAL_INFOS` for
+# tuning the gate.
+quality:analyze:
+  extends: '.dart'
+  stage: 'code check (style/quality)'
+  script:
+    - $SCRIPTS_DIR/global/scripts/languages/dart/analyze/run.sh
+  artifacts:
+    when: 'always'
+    paths:
+      - "$REPORT_PATH/dart-analyze"
+    reports:
+      junit: "$REPORT_PATH/dart-analyze/junit-analyze.xml"
+
+# The Dart counterpart of `quality:vulture` (Python) and `quality:knip`
+# (JavaScript), and advisory for the same reason: whole-package reachability
+# analysis has a false-positive tail that a per-library analyzer does not.
+quality:unused-code:
+  extends: '.dart'
+  stage: 'code check (style/quality)'
+  script:
+    - $SCRIPTS_DIR/global/scripts/languages/dart/unused/run.sh
+  artifacts:
+    when: 'always'
+    paths:
+      - "$REPORT_PATH/dart-unused"
+  allow_failure: true

--- a/gitlab/dart/stages/20-security/dart.yaml
+++ b/gitlab/dart/stages/20-security/dart.yaml
@@ -1,0 +1,50 @@
+# TOOL COVERAGE FOR DART -- read before adding or removing a job here.
+#
+# Two of the security tools this repository runs for every other language have
+# nothing to offer Dart, and both gaps are handled deliberately rather than by
+# leaving a job that silently checks nothing:
+#
+#   CodeQL   -- has NO Dart extractor. `codeql database create --language=dart`
+#               is not a supported invocation (dart-lang/sdk#52953 has tracked
+#               the request since 2023 with no extractor shipped). The
+#               `sast:codeql` job is therefore ABSENT from this template rather
+#               than included and failing. Do not add it back "for consistency".
+#
+#   Semgrep  -- the ENGINE parses Dart (experimental support, actively
+#               maintained), but the REGISTRY publishes no Dart rules: `p/dart`
+#               is a 404 and the language-scoped `r/dart` returns an empty
+#               `rules: []`. The job below still runs, because the shared runner
+#               skips an unpublished language pack instead of failing on it, and
+#               because this repository ships its own Dart ruleset at
+#               `global/scripts/tools/semgrep/rules/dart.yaml`, which the runner
+#               picks up automatically. Without that file the scan would be
+#               language-agnostic packs only.
+#
+# Everything else applies to Dart unchanged: Gitleaks and Hadolint are
+# language-agnostic, and Trivy parses `pubspec.lock` natively.
+variables:
+  SEMGREP_LANG: 'dart'
+
+include:
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/20-security/semgrep.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/20-security/gitleaks.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/20-security/hadolint.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/20-security/trivy.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/20-security/trivy-sca.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/abstracts/dart.yaml'
+
+# The Dart member of the `sca:govulncheck` / `sca:safety` family: a language
+# native scanner running ALONGSIDE `sca:trivy`, not instead of it. Trivy does
+# read `pubspec.lock`, but it records SDK-provided dependencies (Flutter itself
+# and anything resolved through it) at version `0.0.0`, so those components go
+# effectively unmatched. OSV queries the Pub advisory database directly.
+sca:osv-scanner:
+  extends: '.dart'
+  stage: 'security (sca/sast)'
+  script:
+    - $SCRIPTS_DIR/global/scripts/languages/dart/sca/run.sh
+  artifacts:
+    when: 'always'
+    paths:
+      - "$REPORT_PATH/osv-scanner"
+  allow_failure: true

--- a/gitlab/dart/stages/30-tests/dart.yaml
+++ b/gitlab/dart/stages/30-tests/dart.yaml
@@ -1,0 +1,41 @@
+include:
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/abstracts/default-variables.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/abstracts/dart.yaml'
+
+test:all:
+  extends: '.dart'
+  stage: 'tests'
+  script:
+    - $SCRIPTS_DIR/global/scripts/languages/dart/test/run.sh
+  # The runner prints `COVERAGE_PERCENT=NN.NN%` from the LCOV totals. Dart emits
+  # coverage as LCOV and nothing else, so the Cobertura report GitLab renders is
+  # produced by the runner's own converter.
+  coverage: '/COVERAGE_PERCENT=([\d\.]+)%/'
+  artifacts:
+    when: 'always'
+    paths:
+      - "$REPORT_PATH"
+      - 'coverage/lcov.info'
+    reports:
+      junit: "$REPORT_PATH/junit.xml"
+      coverage_report:
+        coverage_format: 'cobertura'
+        path: "$REPORT_PATH/cobertura.xml"
+
+# Compiling is a check in its own right: `dart analyze` resolves and type-checks
+# but never runs the compiler back end, so a defect that only the AOT or web
+# compiler rejects (a const evaluation failure, a deferred-loading mistake, a
+# tree-shaking error on a non-constant icon) passes analysis and fails at
+# release time. Mirrors `test:build` in the Go and Python templates.
+test:build:
+  extends: '.dart'
+  stage: 'tests'
+  variables:
+    # Debug keeps this fast; the delivery stage builds the real release artifact.
+    DART_BUILD_MODE: '--debug'
+  script:
+    - $SCRIPTS_DIR/global/scripts/languages/dart/build/run.sh ${DART_TEST_BUILD_TARGETS:-}
+  rules:
+    - if: "$CI_MERGE_REQUEST_IID"
+    - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"
+    - if: "$CI_COMMIT_TAG"

--- a/gitlab/dart/stages/35-management/dart.yaml
+++ b/gitlab/dart/stages/35-management/dart.yaml
@@ -1,0 +1,40 @@
+include:
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/abstracts/default-variables.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/35-management/abstracts.yaml'
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/abstracts/dart.yaml'
+
+report:sonarqube:
+  extends: '.sonarqube'
+  script:
+    # Read the version from pubspec.yaml -- the single source of truth for a pub
+    # package's version, and the same field the build and publish jobs use.
+    - |
+      version=$(sed -n "s/^version:[[:space:]]*['\"]\{0,1\}\([^'\"#]*\)['\"]\{0,1\}[[:space:]]*$/\1/p" pubspec.yaml | head -n 1 | tr -d '[:space:]')
+      if [ -n "$version" ]; then
+        echo "sonar.projectVersion=$version" >> sonar-project.properties
+        echo "Updated sonar.projectVersion to $version"
+      else
+        echo "Couldn't read 'version:' from pubspec.yaml; leaving sonar.projectVersion unset."
+      fi
+    # Dart coverage is LCOV, and the two Sonar implementations spell the property
+    # differently: SonarQube Server 10.7+/Cloud ship a first-party Dart analyzer
+    # that reads `sonar.dart.lcov.reportPaths`, while the community
+    # `sonar-flutter` plugin (the only option on older servers) reads
+    # `sonar.flutter.coverage.reportPath`. Both are written because an unknown
+    # property is IGNORED by the scanner, whereas a missing one silently means
+    # zero coverage -- so writing both is free and writing one is a coin flip.
+    - |
+      if [ -f coverage/lcov.info ]; then
+        grep -q '^sonar.dart.lcov.reportPaths' sonar-project.properties 2>/dev/null \
+          || echo "sonar.dart.lcov.reportPaths=coverage/lcov.info" >> sonar-project.properties
+        grep -q '^sonar.flutter.coverage.reportPath' sonar-project.properties 2>/dev/null \
+          || echo "sonar.flutter.coverage.reportPath=coverage/lcov.info" >> sonar-project.properties
+      fi
+    - !reference [ .sonarqube, script ]
+
+report:dependency-track:
+  extends: [ '.dart', '.dependency-track' ]
+  script:
+    - mkdir -p "$PREFIX$REPORT_PATH"
+    - $SCRIPTS_DIR/global/scripts/languages/dart/cyclonedx/run.sh
+    - !reference [ .dependency-track, script ]

--- a/gitlab/dart/stages/40-delivery/dart-library.yaml
+++ b/gitlab/dart/stages/40-delivery/dart-library.yaml
@@ -1,0 +1,34 @@
+include:
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/abstracts/dart.yaml'
+
+# Validation on every default-branch build, publication only on a tag.
+#
+# The split is not ceremony. Publishing to pub.dev is IRREVERSIBLE -- a version
+# can be retracted but never replaced or re-uploaded -- so the checks pub.dev
+# performs at upload time (missing description, missing licence, unresolvable
+# constraints, files that would ship by mistake) have to run long before the
+# upload. `dart pub publish --dry-run` runs exactly those checks without
+# uploading, so a package that would be rejected fails on the merge instead of
+# on the release.
+publish:validate:
+  extends: '.dart'
+  stage: 'delivery'
+  variables:
+    DART_PUBLISH_DRY_RUN: 'true'
+  script:
+    - $SCRIPTS_DIR/global/scripts/languages/dart/publish/run.sh
+  rules:
+    - if: "$CI_MERGE_REQUEST_IID"
+    - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"
+
+publish:prod:
+  extends: '.dart'
+  stage: 'delivery'
+  script:
+    - $SCRIPTS_DIR/global/scripts/languages/dart/publish/run.sh
+  # PUB_TOKEN must be a masked, protected CI/CD variable. The runner passes its
+  # NAME to `dart pub token add --env-var PUB_TOKEN`, never its value, so the
+  # credential never reaches argv (where `ps` and the job's own recorded command
+  # line would both expose it).
+  rules:
+    - if: "$CI_COMMIT_TAG"

--- a/gitlab/dart/stages/40-delivery/flutter-artifacts.yaml
+++ b/gitlab/dart/stages/40-delivery/flutter-artifacts.yaml
@@ -1,0 +1,47 @@
+include:
+  - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/dart/abstracts/dart.yaml'
+
+# Flutter web bundle. Runs on the plain `.dart` image because a web build needs
+# only the Flutter SDK -- no Android SDK, no JDK -- so it works on any runner.
+delivery:web:
+  extends: '.dart'
+  stage: 'delivery'
+  variables:
+    DART_BUILD_TARGETS: 'web'
+  script:
+    - $SCRIPTS_DIR/global/scripts/languages/dart/build/run.sh
+  artifacts:
+    paths:
+      - 'build/web'
+    expire_in: '30 days'
+  rules:
+    - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"
+    - if: "$CI_COMMIT_TAG"
+
+# Android artifacts. Extends `.dart-android` because these need the Android SDK
+# and a JDK, which the default Debian image does not carry -- see the abstract
+# for why this repository will not install them ad hoc.
+#
+# `DART_BUILD_TARGETS` defaults to both an APK (sideloadable, useful for QA
+# distribution) and an App Bundle (the only format Google Play accepts for new
+# releases). Override it to build just one.
+delivery:android:
+  extends: '.dart-android'
+  stage: 'delivery'
+  variables:
+    DART_BUILD_TARGETS: 'apk appbundle'
+  script:
+    - $SCRIPTS_DIR/global/scripts/languages/dart/build/run.sh
+  artifacts:
+    paths:
+      - 'build/app/outputs/flutter-apk'
+      - 'build/app/outputs/bundle'
+    expire_in: '30 days'
+  rules:
+    # Opt-in: a project without Android signing configured, or without an
+    # Android-capable runner, should not get a red pipeline for a target it
+    # never asked for.
+    - if: "$ENABLE_ANDROID_DELIVERY != 'true'"
+      when: 'never'
+    - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"
+    - if: "$CI_COMMIT_TAG"

--- a/global/scripts/languages/README.md
+++ b/global/scripts/languages/README.md
@@ -17,7 +17,24 @@ languages/
     checkstyle/       # Java style checking (Google style)
   python/
     cyclonedx/        # Python SBOM generation
+  dart/
+    common.sh         # shared helpers (SOURCED, not executed)
+    setup/            # Dart or Flutter SDK install from Google's archive
+    format/           # dart format gate (--fix rewrites in place)
+    analyze/          # dart analyze -> JUnit + JSON + severity gate
+    test/             # tests + coverage -> JUnit, Cobertura, LCOV
+    unused/           # unused code and unused file detection
+    sca/              # OSV-Scanner over pubspec.lock
+    cyclonedx/        # Dart SBOM generation
+    build/            # release artifacts (APK, AAB, web, exe, ...)
+    publish/          # pub.dev publication with a validation gate
 ```
+
+The Dart family picks its toolchain (`dart` vs `flutter`) from the project's own
+`pubspec.yaml`, so one set of scripts serves both. It also supports
+`DART_DRY_RUN=true`, which resolves and records every command without installing
+or executing anything -- that is what lets `make test` exercise the whole family
+offline, with no SDK and no network.
 
 ## Convention
 

--- a/global/scripts/languages/dart/analyze/dart_analyze_report.py
+++ b/global/scripts/languages/dart/analyze/dart_analyze_report.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Turn `dart analyze --format=machine` output into CI-consumable reports.
+
+Reads the machine format on stdin and writes a JSON report and a JUnit XML
+report, then prints a grouped human summary and exits with the gate's verdict.
+
+Why the machine format and not the default one
+----------------------------------------------
+`dart analyze` has three output formats (`default`, `json`, `machine`).  The
+default one is explicitly documented as unstable ("the format is not specified
+and can change"), so parsing it would be building on sand.  `machine` is the
+stable line-oriented contract:
+
+    SEVERITY|TYPE|ERROR_CODE|FILE_PATH|LINE|COLUMN|LENGTH|ERROR_MESSAGE
+
+with `|` and `\\` backslash-escaped inside the path and message fields.  The
+unescaping below is the whole reason this is a parser rather than an `awk`
+one-liner: a lint message containing a pipe (they do -- anything quoting an
+operator or a shell snippet) splits into the wrong number of fields otherwise,
+and the row silently lands in the report attributed to the wrong file.
+
+`flutter analyze` is deliberately not used even for Flutter projects: it has no
+`--format` option at all (flutter/flutter#95090), so it can only be scraped.
+The Flutter SDK's bundled `dart` runs the same analyzer over the same
+`analysis_options.yaml`, which is why `common.sh` symlinks it.
+
+Gating
+------
+Errors always fail.  Warnings fail unless `DART_FATAL_WARNINGS=false`.  Infos
+(which is where every lint from `package:lints` / `package:flutter_lints`
+lands) fail only when `DART_FATAL_INFOS=true`, because a repository adopting a
+stricter lint set should be able to see the findings before it has to fix all
+of them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from xml.sax.saxutils import escape, quoteattr
+
+SEVERITY_ORDER = ("ERROR", "WARNING", "INFO")
+
+
+def _truthy(value: str | None, default: bool = False) -> bool:
+    if value is None or value == "":
+        return default
+    return value.strip().lower() in ("true", "1", "yes")
+
+
+def _split_machine_line(line: str) -> list[str] | None:
+    """Split one machine-format row on unescaped pipes.
+
+    Returns None for anything that is not a diagnostic row, which covers the
+    progress and summary lines `dart analyze` still prints on stderr/stdout in
+    some SDK versions.
+    """
+    fields: list[str] = []
+    current: list[str] = []
+    escaped = False
+    for char in line:
+        if escaped:
+            current.append(char)
+            escaped = False
+        elif char == "\\":
+            escaped = True
+        elif char == "|":
+            fields.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+    fields.append("".join(current))
+
+    if len(fields) < 8:
+        return None
+    if fields[0] not in SEVERITY_ORDER:
+        return None
+    # The trailing message may itself contain pipes that were NOT escaped by
+    # older SDKs; rejoin any surplus fields back into it rather than dropping
+    # them.
+    if len(fields) > 8:
+        fields = fields[:7] + ["|".join(fields[7:])]
+    return fields
+
+
+def parse(stream) -> list[dict]:
+    diagnostics = []
+    for raw in stream:
+        line = raw.rstrip("\n").rstrip("\r")
+        if not line.strip():
+            continue
+        fields = _split_machine_line(line)
+        if fields is None:
+            continue
+        severity, kind, code, path, line_no, column, length, message = fields
+        diagnostics.append(
+            {
+                "severity": severity,
+                "type": kind,
+                "code": code,
+                "file": path,
+                "line": int(line_no) if line_no.isdigit() else 0,
+                "column": int(column) if column.isdigit() else 0,
+                "length": int(length) if length.isdigit() else 0,
+                "message": message,
+            }
+        )
+    return diagnostics
+
+
+def write_json(diagnostics: list[dict], path: str, counts: dict) -> None:
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(
+            {"tool": "dart analyze", "summary": counts, "diagnostics": diagnostics},
+            handle,
+            indent=2,
+        )
+        handle.write("\n")
+
+
+def write_junit(diagnostics: list[dict], path: str, fatal: set[str]) -> None:
+    failures = [d for d in diagnostics if d["severity"] in fatal]
+    total = len(diagnostics) or 1
+
+    rows = []
+    for diagnostic in diagnostics:
+        name = "{code} {file}:{line}:{column}".format(**diagnostic)
+        classname = diagnostic["file"].replace("/", ".").removesuffix(".dart")
+        body = "{severity} {type} {code}: {message}".format(**diagnostic)
+        if diagnostic["severity"] in fatal:
+            inner = "      <failure message={message} type={kind}>{body}</failure>\n".format(
+                message=quoteattr(diagnostic["message"]),
+                kind=quoteattr(diagnostic["severity"]),
+                body=escape(body),
+            )
+        else:
+            # Non-fatal findings are recorded as skipped rather than omitted:
+            # they stay visible in every platform's Tests tab (which is the
+            # point of publishing this at all) without turning the job red.
+            inner = "      <skipped message={message}/>\n".format(
+                message=quoteattr(body)
+            )
+        rows.append(
+            "    <testcase name={name} classname={classname}>\n{inner}    </testcase>\n".format(
+                name=quoteattr(name), classname=quoteattr(classname or "dart"), inner=inner
+            )
+        )
+
+    if not diagnostics:
+        rows.append(
+            '    <testcase name="dart analyze" classname="dart"/>\n'
+        )
+
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+        handle.write(
+            '<testsuites name="dart-analyze" tests="{tests}" failures="{failures}">\n'.format(
+                tests=total, failures=len(failures)
+            )
+        )
+        handle.write(
+            '  <testsuite name="dart-analyze" tests="{tests}" failures="{failures}">\n'.format(
+                tests=total, failures=len(failures)
+            )
+        )
+        handle.writelines(rows)
+        handle.write("  </testsuite>\n</testsuites>\n")
+
+
+def main() -> int:
+    report_dir = sys.argv[1] if len(sys.argv) > 1 else "build/reports/dart-analyze"
+    os.makedirs(report_dir, exist_ok=True)
+
+    diagnostics = parse(sys.stdin)
+
+    fatal = {"ERROR"}
+    if _truthy(os.environ.get("DART_FATAL_WARNINGS"), default=True):
+        fatal.add("WARNING")
+    if _truthy(os.environ.get("DART_FATAL_INFOS"), default=False):
+        fatal.add("INFO")
+
+    counts = {level: sum(1 for d in diagnostics if d["severity"] == level) for level in SEVERITY_ORDER}
+    counts["total"] = len(diagnostics)
+
+    write_json(diagnostics, os.path.join(report_dir, "analyze.json"), counts)
+    write_junit(diagnostics, os.path.join(report_dir, "junit-analyze.xml"), fatal)
+
+    print(
+        "dart analyze found {total} issue(s): {ERROR} error(s), {WARNING} warning(s), "
+        "{INFO} info(s).".format(**counts)
+    )
+
+    for level in SEVERITY_ORDER:
+        rows = [d for d in diagnostics if d["severity"] == level]
+        if not rows:
+            continue
+        marker = "FATAL" if level in fatal else "non-fatal"
+        print("\n{level} ({count}, {marker}):".format(level=level, count=len(rows), marker=marker))
+        for diagnostic in rows:
+            print(
+                "  - {file}:{line}:{column} [{code}] {message}".format(**diagnostic)
+            )
+
+    blocking = sum(counts[level] for level in fatal)
+    if blocking:
+        print(
+            "\n{count} finding(s) at or above the configured severity gate; failing.".format(
+                count=blocking
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/global/scripts/languages/dart/analyze/run.sh
+++ b/global/scripts/languages/dart/analyze/run.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env sh
+set -e
+
+# `dart analyze` gate for the `10-code-check` stage -- the static analysis every
+# Dart and Flutter project already runs in its editor, promoted to a CI gate
+# with machine-readable reports.
+#
+# This job carries more weight in a Dart pipeline than its equivalent does
+# elsewhere, because two of the tools this repository leans on for other
+# languages have nothing to offer Dart:
+#
+#   - CodeQL has NO Dart extractor (dart-lang/sdk#52953, open since 2023), so
+#     the `sast:codeql` job is absent from every Dart template.
+#   - The Semgrep registry publishes no Dart rules at all: `p/dart` is a 404 and
+#     `r/dart` returns a literally empty `rules: []`. Semgrep still runs for its
+#     language-agnostic packs (secrets, Dockerfile, OWASP) plus the Dart rules
+#     this repository ships itself at
+#     `global/scripts/tools/semgrep/rules/dart.yaml`.
+#
+# The Dart analyzer is therefore the primary source of language-level
+# correctness findings, which is why its severity gate is configurable rather
+# than fixed -- see `dart_analyze_report.py` for `DART_FATAL_WARNINGS` /
+# `DART_FATAL_INFOS`.
+
+if [ -z "$SCRIPTS_DIR" ]; then
+  SCRIPTS_DIR="$(echo "$(dirname "$(realpath "$0")")" | sed 's|\(.*pipelines\).*|\1|')"
+  export SCRIPTS_DIR
+fi
+
+. "$SCRIPTS_DIR/global/scripts/languages/dart/common.sh"
+
+TARGETS="$*"
+[ -n "$TARGETS" ] || TARGETS="."
+
+dart_prepare_reports "dart-analyze"
+dart_ensure_sdk
+dart_pub_get
+
+# A project with no `analysis_options.yaml` gets the SDK's bare defaults, which
+# enable almost no lints -- the job would pass while checking nothing. Say so
+# once, loudly, instead of reporting a clean run that means nothing.
+if [ ! -f "analysis_options.yaml" ]; then
+  echo "WARNING: no 'analysis_options.yaml' found. The analyzer is running with SDK defaults," >&2
+  echo "         which enable very few lints. Add one that includes package:lints/recommended.yaml" >&2
+  echo "         (or package:flutter_lints/flutter.yaml for Flutter) to get real coverage." >&2
+fi
+
+echo "Running 'dart analyze' over: $TARGETS"
+
+if dart_is_dry_run; then
+  # shellcheck disable=SC2086
+  dart_run dart analyze --format=machine $TARGETS
+  echo "DRY RUN: no analysis was performed and no report was written."
+  exit 0
+fi
+
+ANALYZE_OUT="$(mktemp)"
+ANALYZE_ERR="$(mktemp)"
+cleanup_tmp() { rm -f "$ANALYZE_OUT" "$ANALYZE_ERR"; }
+trap cleanup_tmp EXIT
+
+# The analyzer's own exit code is deliberately ignored here and the verdict is
+# recomputed from the parsed diagnostics instead. Two reasons: `dart analyze`
+# maps severities onto exit codes in a way that has changed across SDK releases,
+# and this pipeline's gate is configurable (a repository may accept INFO-level
+# lints while it adopts a stricter set), so the tool's own all-or-nothing
+# verdict is the wrong one to propagate.
+ANALYZE_STATUS=0
+# shellcheck disable=SC2086
+dart analyze --format=machine $TARGETS > "$ANALYZE_OUT" 2> "$ANALYZE_ERR" || ANALYZE_STATUS=$?
+
+# Distinguish "the analyzer ran and found problems" from "the analyzer could not
+# run". The second case produces a non-zero status and NO parseable diagnostic
+# rows, and treating it as a clean result is the quiet failure this guard
+# exists to prevent: an unresolved package or a broken SDK would otherwise be
+# published as a green analysis with an empty report.
+if [ "$ANALYZE_STATUS" -ne 0 ] && ! grep -qE '^(INFO|WARNING|ERROR)\|' "$ANALYZE_OUT"; then
+  echo "ERROR: 'dart analyze' failed to run (exit $ANALYZE_STATUS) and produced no diagnostics." >&2
+  cat "$ANALYZE_ERR" >&2
+  exit "$ANALYZE_STATUS"
+fi
+
+[ -s "$ANALYZE_ERR" ] && cat "$ANALYZE_ERR" >&2
+
+REPORT_EXIT=0
+python3 "$SCRIPTS_DIR/global/scripts/languages/dart/analyze/dart_analyze_report.py" "$DART_TOOL_REPORT_PATH" \
+  < "$ANALYZE_OUT" || REPORT_EXIT=$?
+
+echo ""
+echo "Reports written to: $DART_TOOL_REPORT_PATH"
+exit "$REPORT_EXIT"

--- a/global/scripts/languages/dart/build/run.sh
+++ b/global/scripts/languages/dart/build/run.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env sh
+set -e
+
+# Artifact builder for the `40-delivery` stage.
+#
+# Usage: run.sh [target ...]      (default: DART_BUILD_TARGETS, else auto)
+#
+# Flutter targets: apk appbundle web linux macos windows ipa
+# Dart targets:    exe js aot-snapshot
+#
+# Dispatch is by FUNCTION NAME rather than a `case` chain -- the shell's version
+# of the mapper pattern. Adding a target means adding a `dart_build_<target>`
+# function and nothing else: no existing branch is edited, and the list of
+# supported targets is derivable from the functions that exist. A `case` with
+# nine arms would have to be reopened for every new one.
+
+if [ -z "$SCRIPTS_DIR" ]; then
+  SCRIPTS_DIR="$(echo "$(dirname "$(realpath "$0")")" | sed 's|\(.*pipelines\).*|\1|')"
+  export SCRIPTS_DIR
+fi
+
+. "$SCRIPTS_DIR/global/scripts/languages/dart/common.sh"
+
+dart_prepare_reports "dart-build"
+
+# `--build-name` is the user-visible version and `--build-number` the internal
+# one both app stores order releases by. Defaulting the name from `pubspec.yaml`
+# keeps the shipped artifact's version honest without asking the pipeline to
+# repeat it; the number defaults to the CI build counter, which is monotonic on
+# every platform here.
+BUILD_NAME="${DART_BUILD_NAME:-$(dart_pubspec_field version | sed 's/+.*//')}"
+BUILD_NUMBER="${DART_BUILD_NUMBER:-${BUILD_BUILDID:-${CI_PIPELINE_IID:-${GITHUB_RUN_NUMBER:-}}}}"
+BUILD_MODE="${DART_BUILD_MODE:---release}"
+
+# Resolved once into a plain variable rather than recomputed by a command
+# substitution at each call site: the flags have to word-split to reach the CLI
+# as separate arguments, and an unquoted `$(...)` splitting is exactly what
+# ShellCheck's SC2046 flags (with no way to say "this splitting is intended",
+# unlike SC2086 for a variable).
+VERSION_FLAGS=""
+[ -n "$BUILD_NAME" ] && VERSION_FLAGS="$VERSION_FLAGS --build-name=$BUILD_NAME"
+[ -n "$BUILD_NUMBER" ] && VERSION_FLAGS="$VERSION_FLAGS --build-number=$BUILD_NUMBER"
+
+dart_build_apk() {
+  # shellcheck disable=SC2086
+  dart_run flutter build apk $BUILD_MODE $VERSION_FLAGS $DART_BUILD_ARGS
+}
+
+dart_build_appbundle() {
+  # shellcheck disable=SC2086
+  dart_run flutter build appbundle $BUILD_MODE $VERSION_FLAGS $DART_BUILD_ARGS
+}
+
+dart_build_web() {
+  # shellcheck disable=SC2086
+  dart_run flutter build web $BUILD_MODE $VERSION_FLAGS $DART_BUILD_ARGS
+}
+
+dart_build_linux() {
+  # shellcheck disable=SC2086
+  dart_run flutter build linux $BUILD_MODE $VERSION_FLAGS $DART_BUILD_ARGS
+}
+
+dart_build_macos() {
+  # shellcheck disable=SC2086
+  dart_run flutter build macos $BUILD_MODE $VERSION_FLAGS $DART_BUILD_ARGS
+}
+
+dart_build_windows() {
+  # shellcheck disable=SC2086
+  dart_run flutter build windows $BUILD_MODE $VERSION_FLAGS $DART_BUILD_ARGS
+}
+
+dart_build_ipa() {
+  # An unsigned archive is the only thing a Linux or unsigned macOS runner can
+  # produce; signing needs a provisioning profile the pipeline does not hold.
+  # shellcheck disable=SC2086
+  dart_run flutter build ipa $BUILD_MODE --no-codesign $VERSION_FLAGS $DART_BUILD_ARGS
+}
+
+dart_build_exe() {
+  _entry="${DART_ENTRYPOINT:-$(dart_default_entrypoint)}"
+  if [ -z "$_entry" ]; then
+    echo "ERROR: no entry point found for the 'exe' target." >&2
+    echo "Expected a file under bin/ (or set DART_ENTRYPOINT)." >&2
+    exit 1
+  fi
+  mkdir -p build
+  _name="$(basename "$_entry" .dart)"
+  # shellcheck disable=SC2086
+  dart_run dart compile exe "$_entry" -o "build/$_name" $DART_BUILD_ARGS
+}
+
+dart_build_js() {
+  _entry="${DART_ENTRYPOINT:-$(dart_default_entrypoint)}"
+  mkdir -p build
+  # shellcheck disable=SC2086
+  dart_run dart compile js "$_entry" -o "build/main.js" $DART_BUILD_ARGS
+}
+
+dart_build_aot_snapshot() {
+  _entry="${DART_ENTRYPOINT:-$(dart_default_entrypoint)}"
+  mkdir -p build
+  _name="$(basename "$_entry" .dart)"
+  # shellcheck disable=SC2086
+  dart_run dart compile aot-snapshot "$_entry" -o "build/$_name.aot" $DART_BUILD_ARGS
+}
+
+# dart_default_entrypoint
+#
+# A pub package's executables live in `bin/`. Prefer one named after the package
+# (the pub convention), then a lone `bin/*.dart`, then `bin/main.dart`.
+dart_default_entrypoint() {
+  _de_name="$(dart_pubspec_field name)"
+  if [ -n "$_de_name" ] && [ -f "bin/$_de_name.dart" ]; then
+    printf 'bin/%s.dart' "$_de_name"
+    return 0
+  fi
+  _de_count="$(find bin -maxdepth 1 -name '*.dart' 2>/dev/null | wc -l | tr -d ' ')"
+  if [ "$_de_count" = "1" ]; then
+    find bin -maxdepth 1 -name '*.dart' 2>/dev/null | head -n 1
+    return 0
+  fi
+  [ -f "bin/main.dart" ] && printf 'bin/main.dart'
+  return 0
+}
+
+TARGETS="$*"
+if [ -z "$TARGETS" ]; then
+  TARGETS="${DART_BUILD_TARGETS:-}"
+fi
+
+dart_ensure_sdk
+dart_pub_get
+
+# With nothing requested, build the one artifact the project's own shape implies
+# rather than guessing a list. A Flutter app almost always wants an APK from
+# Linux CI; a pure Dart package with a `bin/` wants a native executable; a
+# library has nothing to build and should not fail for it.
+if [ -z "$TARGETS" ]; then
+  if [ "$DART_TOOLCHAIN" = "flutter" ]; then
+    TARGETS="apk"
+  elif [ -n "$(dart_default_entrypoint)" ]; then
+    TARGETS="exe"
+  else
+    echo "No build target requested and this package declares no executable; nothing to build."
+    echo "Set DART_BUILD_TARGETS (e.g. 'web appbundle') to build explicitly."
+    exit 0
+  fi
+  echo "No build target requested; defaulting to '$TARGETS' for this $DART_TOOLCHAIN project."
+fi
+
+for target in $TARGETS; do
+  # `-` is legal in a target name but not in a function name.
+  handler="dart_build_$(printf '%s' "$target" | tr '-' '_')"
+  if ! command -v "$handler" > /dev/null 2>&1; then
+    echo "ERROR: unknown build target '$target'." >&2
+    echo "Supported: apk appbundle web linux macos windows ipa exe js aot-snapshot" >&2
+    exit 1
+  fi
+  echo ""
+  echo "=== Building '$target' ==="
+  "$handler"
+done
+
+if dart_is_dry_run; then
+  echo "DRY RUN: nothing was built."
+  exit 0
+fi
+
+echo ""
+echo "Build output:"
+find build -maxdepth 4 \
+  \( -name '*.apk' -o -name '*.aab' -o -name '*.ipa' -o -name '*.js' -o -name '*.aot' \) \
+  -print 2>/dev/null | sed 's/^/  /' || true
+[ -d build/web ] && echo "  build/web/ (Flutter web bundle)"
+exit 0

--- a/global/scripts/languages/dart/build/run.sh
+++ b/global/scripts/languages/dart/build/run.sh
@@ -78,13 +78,30 @@ dart_build_ipa() {
   dart_run flutter build ipa $BUILD_MODE --no-codesign $VERSION_FLAGS $DART_BUILD_ARGS
 }
 
-dart_build_exe() {
-  _entry="${DART_ENTRYPOINT:-$(dart_default_entrypoint)}"
-  if [ -z "$_entry" ]; then
-    echo "ERROR: no entry point found for the 'exe' target." >&2
+# dart_resolve_entrypoint <target>
+#
+# Echo the entry point for a `dart compile` target, or fail with an actionable
+# message when there is none.
+#
+# Every `dart compile` target needs one, and NONE of them fails usefully without
+# it: an empty path makes the compiler complain about a file it was never given,
+# and the snapshot targets go further and derive their OUTPUT name from it too,
+# so an empty entry point silently produces `build/.aot`. Resolving and
+# validating in one place is what keeps all three consistent -- the check used to
+# live in `exe` alone, which is exactly how `js` and `aot-snapshot` ended up
+# without it.
+dart_resolve_entrypoint() {
+  _re_entry="${DART_ENTRYPOINT:-$(dart_default_entrypoint)}"
+  if [ -z "$_re_entry" ]; then
+    echo "ERROR: no entry point found for the '$1' target." >&2
     echo "Expected a file under bin/ (or set DART_ENTRYPOINT)." >&2
     exit 1
   fi
+  printf '%s' "$_re_entry"
+}
+
+dart_build_exe() {
+  _entry="$(dart_resolve_entrypoint exe)" || exit 1
   mkdir -p build
   _name="$(basename "$_entry" .dart)"
   # shellcheck disable=SC2086
@@ -92,14 +109,14 @@ dart_build_exe() {
 }
 
 dart_build_js() {
-  _entry="${DART_ENTRYPOINT:-$(dart_default_entrypoint)}"
+  _entry="$(dart_resolve_entrypoint js)" || exit 1
   mkdir -p build
   # shellcheck disable=SC2086
   dart_run dart compile js "$_entry" -o "build/main.js" $DART_BUILD_ARGS
 }
 
 dart_build_aot_snapshot() {
-  _entry="${DART_ENTRYPOINT:-$(dart_default_entrypoint)}"
+  _entry="$(dart_resolve_entrypoint aot-snapshot)" || exit 1
   mkdir -p build
   _name="$(basename "$_entry" .dart)"
   # shellcheck disable=SC2086

--- a/global/scripts/languages/dart/common.sh
+++ b/global/scripts/languages/dart/common.sh
@@ -1,0 +1,478 @@
+#!/usr/bin/env sh
+
+# Shared helpers for the Dart / Flutter language scripts.
+#
+# This file is SOURCED, never executed, so it carries no `run.sh` name and no
+# executable bit -- same contract as `global/scripts/deploy/common.sh`.
+#
+# Three decisions shape this family; none of them is incidental.
+#
+# 1. THE SDK IS INSTALLED FROM GOOGLE'S OWN ARCHIVE, NEVER FROM DOCKER HUB.
+#    The obvious way to get Flutter into CI is `image: ghcr.io/cirruslabs/flutter`
+#    or `docker run instrumentisto/flutter`, and the obvious way is the one this
+#    repository has already ruled out everywhere else: Docker Hub rate-limits
+#    anonymous pulls, so a cache-cold runner fails the whole job with
+#    `toomanyrequests` for a reason unrelated to the code under scan. Both SDKs
+#    publish plain archives on `storage.googleapis.com`, which is neither rate
+#    limited nor a third-party mirror, so that is what these scripts fetch.
+#
+# 2. EVERY SCRIPT IS SELF-SUFFICIENT ABOUT THE SDK.
+#    CI jobs on all three platforms run each step in a fresh shell, so a `PATH`
+#    exported by a previous step is gone. Rather than make every template repeat
+#    an install step, each `run.sh` calls `dart_ensure_sdk`, which reuses an SDK
+#    already on `PATH` (or already unpacked under `~/.local/share`) and only
+#    downloads when there is nothing to reuse. The cost of the check is one
+#    `command -v`.
+#
+# 3. `DART_DRY_RUN=true` RESOLVES AND RECORDS COMMANDS WITHOUT RUNNING THEM.
+#    This is the only reason `make test` can exercise the whole Dart family
+#    offline, on a machine with no Dart SDK, no Flutter SDK and no network. A
+#    dry run installs nothing and touches no network, so the validation harness
+#    asserts on the argv each script actually builds rather than on what the
+#    source looks like it says -- the same technique `test-deploy-providers.sh`
+#    and `test-dependency-check.sh` already use.
+
+# dart_is_truthy <value>
+#
+# Case-insensitive boolean test. Azure DevOps stringifies a `boolean` template
+# parameter as `True` / `False` (PascalCase), so a strict `= "true"` comparison
+# silently turns a requested dry run into a real run on that platform alone.
+# Same reasoning as `deploy_is_truthy`.
+dart_is_truthy() {
+  case "$(printf '%s' "${1:-false}" | tr '[:upper:]' '[:lower:]')" in
+    true | 1 | yes) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# dart_is_dry_run
+dart_is_dry_run() {
+  dart_is_truthy "${DART_DRY_RUN:-false}"
+}
+
+# dart_report_root
+#
+# The directory every Dart script writes into. `PREFIX` is honoured because the
+# GitLab templates set it (see `gitlab/python/stages/35-management/pdm.yaml`).
+#
+# The value is memoised on first use. That is not a micro-optimisation: the
+# shared `cleanup.sh` REWRITES `REPORT_PATH` to a per-tool subdirectory, so a
+# root recomputed from `REPORT_PATH` after any such rewrite would nest one level
+# deeper on every call and land the reports somewhere no template looks. Pinning
+# it once removes the ordering dependency entirely.
+dart_report_root() {
+  if [ -z "${DART_REPORT_ROOT:-}" ]; then
+    DART_REPORT_ROOT="${PREFIX:-}${REPORT_PATH:-build/reports}"
+    export DART_REPORT_ROOT
+  fi
+  printf '%s' "$DART_REPORT_ROOT"
+}
+
+# dart_prepare_reports <name>
+#
+# Create this job's private report directory under the report root and point the
+# command journal at it. Exports:
+#
+#   DART_TOOL_REPORT_PATH -- <root>/<name>, freshly emptied
+#   DART_COMMAND_LOG      -- <root>/<name>/command.txt
+#
+# `REPORT_PATH` itself is deliberately left ALONE. The test runner publishes
+# `junit.xml` and `cobertura.xml` at the report root (that is where every
+# platform's publish step looks for them) while still wanting a private command
+# journal, so a helper that redirected `REPORT_PATH` would force that script to
+# undo the redirection. Being explicit about which of the two paths each file
+# belongs to is shorter than the alternative and impossible to get subtly wrong.
+#
+# The journal is APPENDED to, not overwritten as in the deploy family: a Dart
+# job legitimately runs several commands in sequence (activate a global package,
+# fetch dependencies, run tests, format coverage), and the interesting assertion
+# is usually the whole sequence rather than its last line.
+dart_prepare_reports() {
+  DART_TOOL_REPORT_PATH="$(dart_report_root)/$1"
+  export DART_TOOL_REPORT_PATH
+  rm -rf "$DART_TOOL_REPORT_PATH"
+  mkdir -p "$DART_TOOL_REPORT_PATH"
+
+  DART_COMMAND_LOG="$DART_TOOL_REPORT_PATH/command.txt"
+  export DART_COMMAND_LOG
+  : > "$DART_COMMAND_LOG"
+}
+
+# dart_run <command> [args...]
+#
+# Record the resolved command line, then run it -- or, on a dry run, stop at the
+# recording and return success so the rest of the script continues to resolve.
+#
+# Recording unconditionally (not only on the dry-run path) means a failed real
+# job also leaves the exact invocation that failed in its published artifact,
+# which is the first thing anyone debugging a red job asks for.
+#
+# EVERY line this function prints itself goes to STDERR, and that is load-
+# bearing rather than stylistic. Several callers capture the wrapped command's
+# stdout because that stdout IS the machine-readable payload -- `dart test
+# --reporter json`, `flutter test --machine` and `osv-scanner --format json` all
+# write their entire result there. A progress line on stdout would be
+# interleaved into that payload, and the consumer on the other side (`tojunit`,
+# `jq`) would reject the whole document over one unexpected leading line. The
+# command journal, not stdout, is what the validation harness asserts on.
+dart_run() {
+  if [ -n "${DART_COMMAND_LOG:-}" ]; then
+    printf '%s\n' "$*" >> "$DART_COMMAND_LOG"
+  fi
+
+  if dart_is_dry_run; then
+    echo "DRY RUN (not executed): $*" >&2
+    return 0
+  fi
+
+  echo "Running: $*" >&2
+  "$@"
+}
+
+# dart_detect_toolchain
+#
+# Echo `flutter` or `dart`. An explicit `DART_TOOLCHAIN` always wins; otherwise
+# the project's own `pubspec.yaml` decides.
+#
+# The detection reads the `sdk: flutter` dependency rather than the top-level
+# `flutter:` key. A pure Dart package can carry a `flutter:` section (to declare
+# assets consumed by a dependent app) without depending on Flutter at all, while
+# EVERY Flutter project -- app, plugin and package alike -- declares
+# `flutter:\n    sdk: flutter` under `dependencies`. Getting this backwards
+# picks the wrong CLI, and the failure is confusing rather than obvious: `dart
+# test` on a Flutter project fails deep inside the widget-test bindings.
+dart_detect_toolchain() {
+  if [ -n "${DART_TOOLCHAIN:-}" ] && [ "$DART_TOOLCHAIN" != "auto" ]; then
+    printf '%s' "$DART_TOOLCHAIN"
+    return 0
+  fi
+
+  if [ -f "${DART_PUBSPEC:-pubspec.yaml}" ] &&
+    grep -qE '^[[:space:]]+sdk:[[:space:]]*flutter[[:space:]]*$' "${DART_PUBSPEC:-pubspec.yaml}"; then
+    printf 'flutter'
+  else
+    printf 'dart'
+  fi
+}
+
+# dart_sdk_install_dir
+#
+# The PARENT directory both SDKs are unpacked into (they each carry their own
+# top-level directory inside the archive, `dart-sdk/` and `flutter/`).
+#
+# Overridable via `DART_SDK_INSTALL_DIR` because GitLab CI can only cache paths
+# INSIDE `$CI_PROJECT_DIR` -- an SDK under `$HOME` is re-downloaded by every job
+# of every pipeline there, which for Flutter is several hundred megabytes each
+# time. The GitLab templates point this at `$CI_PROJECT_DIR/.sdk` and cache it.
+dart_sdk_install_dir() {
+  printf '%s' "${DART_SDK_INSTALL_DIR:-$HOME/.local/share}"
+}
+
+# dart_sdk_arch
+#
+# Map `uname -m` onto the architecture slug Google uses in both archive layouts
+# (`x64` / `arm64`). Unknown architectures fail loudly rather than producing a
+# 404 that reads like a network problem.
+dart_sdk_arch() {
+  case "$(uname -m)" in
+    x86_64 | amd64) printf 'x64' ;;
+    aarch64 | arm64) printf 'arm64' ;;
+    *)
+      echo "ERROR: no Dart/Flutter SDK archive is published for architecture '$(uname -m)'." >&2
+      echo "Supported: x86_64 (x64) and aarch64 (arm64). Run this stage on a supported runner." >&2
+      exit 1
+      ;;
+  esac
+}
+
+# dart_extract_archive <archive> <destination-dir>
+#
+# Unpack a `.zip` or `.tar.xz` without assuming which extractors the runner has.
+# `unzip` in particular is absent from several slim CI images, and its absence
+# used to surface as `unzip: not found` three lines after a successful download.
+# Python 3 is already a hard dependency of the Semgrep tool script, so it is the
+# fallback for both formats.
+dart_extract_archive() {
+  _da_archive="$1"
+  _da_dest="$2"
+
+  mkdir -p "$_da_dest"
+  case "$_da_archive" in
+    *.zip)
+      if command -v unzip > /dev/null 2>&1; then
+        unzip -q "$_da_archive" -d "$_da_dest"
+      elif command -v python3 > /dev/null 2>&1; then
+        python3 -m zipfile -e "$_da_archive" "$_da_dest"
+      else
+        echo "ERROR: cannot unpack '$_da_archive' -- neither 'unzip' nor 'python3' is available." >&2
+        exit 1
+      fi
+      ;;
+    *.tar.xz)
+      # BusyBox tar understands `-J`; GNU tar does too. `xz` itself is the part
+      # that is occasionally missing, and tar reports that clearly.
+      tar -xJf "$_da_archive" -C "$_da_dest"
+      ;;
+    *)
+      echo "ERROR: unsupported archive format for '$_da_archive'." >&2
+      exit 1
+      ;;
+  esac
+
+  unset _da_archive _da_dest
+  return 0
+}
+
+# dart_install_dart_sdk
+#
+# Install the standalone Dart SDK under `~/.local/share/dart-sdk`.
+#
+# `DART_SDK_VERSION` defaults to `latest`, which the archive server accepts as a
+# path segment -- so the common case needs no version lookup and no `jq`.
+dart_install_dart_sdk() {
+  _dd_channel="${DART_SDK_CHANNEL:-stable}"
+  _dd_version="${DART_SDK_VERSION:-latest}"
+  _dd_arch="$(dart_sdk_arch)"
+  _dd_root="$(dart_sdk_install_dir)/dart-sdk"
+
+  if [ -x "$_dd_root/bin/dart" ]; then
+    echo "Reusing the Dart SDK already unpacked at $_dd_root."
+  else
+    _dd_url="https://storage.googleapis.com/dart-archive/channels/$_dd_channel/release/$_dd_version/sdk/dartsdk-linux-$_dd_arch-release.zip"
+    echo "Downloading the Dart SDK ($_dd_channel/$_dd_version/$_dd_arch)..."
+    if ! curl -fsSL --show-error "$_dd_url" -o /tmp/dartsdk.zip; then
+      echo "ERROR: could not download the Dart SDK from $_dd_url" >&2
+      echo "Check DART_SDK_CHANNEL ('stable', 'beta' or 'dev') and DART_SDK_VERSION." >&2
+      exit 1
+    fi
+    # The archive already contains a top-level `dart-sdk/` directory, so extract
+    # into the PARENT and let it create that directory itself.
+    rm -rf "$_dd_root"
+    dart_extract_archive /tmp/dartsdk.zip "$(dart_sdk_install_dir)"
+    rm -f /tmp/dartsdk.zip
+    chmod +x "$_dd_root/bin/dart" 2>/dev/null || true
+  fi
+
+  ln -sf "$_dd_root/bin/dart" "$HOME/.local/bin/dart"
+
+  unset _dd_channel _dd_version _dd_arch _dd_root _dd_url
+  return 0
+}
+
+# dart_resolve_flutter_archive <channel>
+#
+# Echo the archive path (relative to the releases base URL) for the requested
+# Flutter release.
+#
+# An explicit `FLUTTER_VERSION` short-circuits the lookup and composes the path
+# directly, so pinning a version needs neither the network manifest nor `jq`.
+# Resolving "whatever is current on this channel" does need the manifest, and
+# `jq` with it; that is stated in the error rather than left to a `jq: not
+# found` further down.
+dart_resolve_flutter_archive() {
+  _df_channel="$1"
+  _df_arch="$(dart_sdk_arch)"
+
+  if [ -n "${FLUTTER_VERSION:-}" ]; then
+    if [ "$_df_arch" = "arm64" ]; then
+      printf '%s/linux/flutter_linux_arm64_%s-%s.tar.xz' "$_df_channel" "$FLUTTER_VERSION" "$_df_channel"
+    else
+      printf '%s/linux/flutter_linux_%s-%s.tar.xz' "$_df_channel" "$FLUTTER_VERSION" "$_df_channel"
+    fi
+    return 0
+  fi
+
+  if ! command -v jq > /dev/null 2>&1; then
+    echo "ERROR: resolving the current Flutter '$_df_channel' release needs 'jq' to read the release manifest." >&2
+    echo "Install jq on the runner, or pin an exact version with FLUTTER_VERSION (e.g. FLUTTER_VERSION=3.47.0)." >&2
+    exit 1
+  fi
+
+  _df_manifest="$(mktemp)"
+  if ! curl -fsSL --show-error \
+    "https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json" \
+    -o "$_df_manifest"; then
+    echo "ERROR: could not download the Flutter release manifest." >&2
+    rm -f "$_df_manifest"
+    exit 1
+  fi
+
+  # Pick the release whose hash the manifest names as current for the channel,
+  # narrowed to this machine's architecture -- the manifest carries x64 and
+  # arm64 entries under the same hash.
+  _df_archive="$(jq -r --arg ch "$_df_channel" --arg arch "$_df_arch" '
+    .current_release[$ch] as $hash
+    | [ .releases[]
+        | select(.hash == $hash and .channel == $ch and ((.dart_sdk_arch // "x64") == $arch)) ]
+    | first
+    | .archive // empty
+  ' "$_df_manifest")"
+  rm -f "$_df_manifest"
+
+  if [ -z "$_df_archive" ]; then
+    echo "ERROR: the Flutter manifest lists no '$_df_channel' release for architecture '$_df_arch'." >&2
+    echo "Pin one explicitly with FLUTTER_VERSION." >&2
+    exit 1
+  fi
+
+  printf '%s' "$_df_archive"
+  unset _df_channel _df_arch _df_manifest _df_archive
+  return 0
+}
+
+# dart_install_flutter_sdk
+#
+# Install the Flutter SDK under `~/.local/share/flutter` and symlink both
+# `flutter` and its bundled `dart` into `~/.local/bin`.
+#
+# Symlinking `dart` matters: `dart analyze --format=machine` is the only
+# machine-readable analyzer output there is (`flutter analyze` has no `--format`
+# -- flutter/flutter#95090), so the analyze and format jobs drive `dart` even on
+# a Flutter project. It must be the Flutter SDK's OWN Dart, not a separately
+# installed one, or the analysis runs against a different SDK than the app is
+# built with and reports imports it cannot resolve.
+dart_install_flutter_sdk() {
+  _dfi_channel="${FLUTTER_CHANNEL:-stable}"
+  _dfi_root="$(dart_sdk_install_dir)/flutter"
+
+  if [ -x "$_dfi_root/bin/flutter" ]; then
+    echo "Reusing the Flutter SDK already unpacked at $_dfi_root."
+  else
+    _dfi_archive="$(dart_resolve_flutter_archive "$_dfi_channel")" || exit 1
+    _dfi_url="https://storage.googleapis.com/flutter_infra_release/releases/$_dfi_archive"
+    echo "Downloading the Flutter SDK ($_dfi_archive)..."
+    if ! curl -fsSL --show-error "$_dfi_url" -o /tmp/flutter-sdk.tar.xz; then
+      echo "ERROR: could not download the Flutter SDK from $_dfi_url" >&2
+      exit 1
+    fi
+    # The archive contains a top-level `flutter/` directory.
+    rm -rf "$_dfi_root"
+    dart_extract_archive /tmp/flutter-sdk.tar.xz "$(dart_sdk_install_dir)"
+    rm -f /tmp/flutter-sdk.tar.xz
+  fi
+
+  # The Flutter SDK is a git checkout and `flutter` shells out to git on almost
+  # every invocation. When the checkout's owner differs from the process user --
+  # routine on shared and containerised runners -- git refuses with `detected
+  # dubious ownership in repository`, and `flutter` reports that as its own
+  # unrelated-looking startup failure. Marking it safe up front costs nothing
+  # and removes a failure mode that is very hard to read from the flutter side.
+  if command -v git > /dev/null 2>&1; then
+    git config --global --add safe.directory "$_dfi_root" 2>/dev/null || true
+  fi
+
+  ln -sf "$_dfi_root/bin/flutter" "$HOME/.local/bin/flutter"
+  ln -sf "$_dfi_root/bin/dart" "$HOME/.local/bin/dart"
+
+  unset _dfi_channel _dfi_root _dfi_archive _dfi_url
+  return 0
+}
+
+# dart_ensure_sdk
+#
+# Make the toolchain this project needs runnable, and export `DART_TOOLCHAIN`.
+# Idempotent and cheap when the SDK is already present.
+dart_ensure_sdk() {
+  DART_TOOLCHAIN="$(dart_detect_toolchain)"
+  export DART_TOOLCHAIN
+
+  mkdir -p "$HOME/.local/bin" "$(dart_sdk_install_dir)"
+  case ":$PATH:" in
+    *":$HOME/.local/bin:"*) ;;
+    *) PATH="$HOME/.local/bin:$PATH" && export PATH ;;
+  esac
+  # `dart pub global activate` drops launchers here for both toolchains.
+  # `PUB_CACHE` is honoured rather than assuming `$HOME/.pub-cache`: the GitLab
+  # templates relocate it into `$CI_PROJECT_DIR` so it can be cached, and a
+  # hardcoded `$HOME` path would leave `tojunit` and `metrics` off `PATH` there
+  # -- installed successfully, then reported as "not found".
+  _de_pub_bin="${PUB_CACHE:-$HOME/.pub-cache}/bin"
+  mkdir -p "$_de_pub_bin"
+  case ":$PATH:" in
+    *":$_de_pub_bin:"*) ;;
+    *) PATH="$PATH:$_de_pub_bin" && export PATH ;;
+  esac
+  unset _de_pub_bin
+
+  if dart_is_dry_run; then
+    echo "DRY RUN: skipping SDK installation (toolchain resolved as '$DART_TOOLCHAIN')."
+    return 0
+  fi
+
+  if [ "$DART_TOOLCHAIN" = "flutter" ]; then
+    if ! command -v flutter > /dev/null 2>&1; then
+      dart_install_flutter_sdk
+    fi
+    # A pre-installed Flutter (e.g. `subosito/flutter-action`, or a self-hosted
+    # agent's own SDK) puts `flutter` on PATH but not always `dart`. Recover the
+    # bundled one from the SDK root rather than installing a second SDK.
+    if ! command -v dart > /dev/null 2>&1; then
+      _de_flutter_bin="$(dirname "$(command -v flutter)")"
+      if [ -x "$_de_flutter_bin/dart" ]; then
+        ln -sf "$_de_flutter_bin/dart" "$HOME/.local/bin/dart"
+      fi
+      unset _de_flutter_bin
+    fi
+  else
+    if ! command -v dart > /dev/null 2>&1; then
+      dart_install_dart_sdk
+    fi
+  fi
+
+  return 0
+}
+
+# dart_pub_get
+#
+# Resolve dependencies with the project's own toolchain. `flutter pub get` and
+# `dart pub get` are not interchangeable on a Flutter project: only the former
+# resolves the `sdk: flutter` pseudo-dependencies.
+dart_pub_get() {
+  if [ "${DART_SKIP_PUB_GET:-false}" != "false" ] && dart_is_truthy "${DART_SKIP_PUB_GET}"; then
+    echo "DART_SKIP_PUB_GET is set; not resolving dependencies."
+    return 0
+  fi
+
+  if [ "$DART_TOOLCHAIN" = "flutter" ]; then
+    dart_run flutter pub get
+  else
+    dart_run dart pub get
+  fi
+}
+
+# dart_global_activate <package> [binary]
+#
+# Install a pub-published CLI (`junitreport`, `dart_code_linter`, `coverage`)
+# and make its launcher runnable. Skipped when the launcher is already present,
+# so a persistent agent pays for it once.
+#
+# `dart pub global activate` is used even under Flutter: Flutter's `pub` is the
+# same tool and shares `~/.pub-cache`.
+dart_global_activate() {
+  _dga_package="$1"
+  _dga_binary="${2:-$1}"
+
+  if command -v "$_dga_binary" > /dev/null 2>&1; then
+    unset _dga_package _dga_binary
+    return 0
+  fi
+
+  dart_run dart pub global activate "$_dga_package"
+
+  unset _dga_package _dga_binary
+  return 0
+}
+
+# dart_pubspec_field <field>
+#
+# Read a top-level scalar from `pubspec.yaml` (`name`, `version`, ...) without a
+# YAML parser. Only top-level keys are matched -- the leading-space anchor is
+# what stops a nested `version:` under `dependencies:` from winning.
+dart_pubspec_field() {
+  _dpf_file="${DART_PUBSPEC:-pubspec.yaml}"
+  [ -f "$_dpf_file" ] || return 0
+  sed -n "s/^$1:[[:space:]]*['\"]\{0,1\}\([^'\"#]*\)['\"]\{0,1\}[[:space:]]*$/\1/p" "$_dpf_file" |
+    head -n 1 |
+    sed 's/[[:space:]]*$//'
+  unset _dpf_file
+}

--- a/global/scripts/languages/dart/cyclonedx/run.sh
+++ b/global/scripts/languages/dart/cyclonedx/run.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env sh
+set -e
+
+# Generates a CycloneDX Software Bill of Materials for a Dart or Flutter
+# project, for the `35-management` stage's Dependency-Track upload.
+#
+# WHY TRIVY AND NOT A DART-NATIVE GENERATOR
+# There isn't one. `package:sbom` -- the only SBOM generator published on
+# pub.dev -- emits SPDX and states CycloneDX is a future release; Dependency-
+# Track ingests CycloneDX. `cdxgen` does emit CycloneDX for pub, but it is an
+# npm package, so using it would drag a whole Node.js toolchain into a Dart job
+# for one file. Trivy is already a dependency of this repository's security
+# stage, already parses `pubspec.lock`, and already emits CycloneDX -- which is
+# exactly how the Terraform SBOM is produced here, so this script is
+# deliberately its close sibling.
+#
+# Read the Dart caveat in `../sca/run.sh` alongside this: Trivy records SDK-
+# provided dependencies at version `0.0.0`, so those components appear in the
+# BOM without a resolvable version. That is a completeness limitation of the
+# BOM, not of the vulnerability scanning -- OSV-Scanner covers that separately.
+
+if [ -z "$SCRIPTS_DIR" ]; then
+  SCRIPTS_DIR="$(echo "$(dirname "$(realpath "$0")")" | sed 's|\(.*pipelines\).*|\1|')"
+  export SCRIPTS_DIR
+fi
+
+. "$SCRIPTS_DIR/global/scripts/languages/dart/common.sh"
+
+# Journals the Trivy invocation under `<reports>/dart-cyclonedx/`. The BOM
+# itself does NOT go there -- see below.
+dart_prepare_reports "dart-cyclonedx"
+
+# The BOM goes at the TOP of the reports directory, with no per-tool subdir:
+# `global/scripts/tools/dependency-track/run.sh` looks for it at exactly
+# `$PREFIX$REPORT_PATH/bom.json`, matching the Go, Python and Terraform
+# generators.
+BOM_PATH="${PREFIX:-}${REPORT_PATH:-build/reports}"
+mkdir -p "$BOM_PATH"
+bomFile="$BOM_PATH/bom.json"
+
+mkdir -p "$HOME/.local/bin"
+case ":$PATH:" in
+  *":$HOME/.local/bin:"*) ;;
+  *) PATH="$HOME/.local/bin:$PATH" && export PATH ;;
+esac
+
+if [ ! -f "${DART_PUBSPEC:-pubspec.yaml}" ]; then
+  echo "ERROR: no pubspec.yaml in $(pwd); this is not a Dart or Flutter package." >&2
+  exit 1
+fi
+
+if [ ! -f "${DART_LOCKFILE:-pubspec.lock}" ]; then
+  echo "WARNING: no pubspec.lock found. Trivy resolves pub components from the LOCKFILE," >&2
+  echo "         so the BOM will list few or no dependencies. Run 'dart pub get' first," >&2
+  echo "         or commit the lockfile." >&2
+fi
+
+# Same self-updating install as the sibling generators (see
+# `../../terraform/cyclonedx/run.sh` for the full rationale). Fail-safe: any
+# uncertainty in the version lookup returns "no update", so a lookup blip never
+# forces a needless re-download.
+trivy_update_available() {
+  _tv_latest=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/aquasecurity/trivy/releases/latest 2>/dev/null | sed 's#.*/tag/v\{0,1\}##')
+  _tv_current=$(trivy --version 2>/dev/null | awk '/^Version:/{print $2}')
+  case "$_tv_latest" in [0-9]*.[0-9]*) ;; *) return 1 ;; esac
+  case "$_tv_current" in [0-9]*.[0-9]*) ;; *) return 1 ;; esac
+  [ "$_tv_latest" != "$_tv_current" ]
+}
+
+if dart_is_dry_run; then
+  echo "DRY RUN: skipping the Trivy install and the BOM generation."
+elif ! command -v trivy > /dev/null 2>&1 || trivy_update_available; then
+  echo "Downloading Trivy..."
+  curl -fsSL --show-error https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp || true
+  if [ ! -x /tmp/trivy ]; then
+    : "${TRIVY_PINNED_VERSION:=v0.72.0}"
+    echo "Trivy 'latest' install failed; falling back to pinned $TRIVY_PINNED_VERSION..." >&2
+    curl -fsSL --show-error https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp "$TRIVY_PINNED_VERSION" || true
+  fi
+  if [ ! -x /tmp/trivy ]; then
+    echo "ERROR: Trivy install failed (latest and pinned ${TRIVY_PINNED_VERSION:-v0.72.0}). See install output above." >&2
+    exit 1
+  fi
+  mv /tmp/trivy "$HOME/.local/bin/trivy"
+fi
+
+# The pubspec is the authoritative identity for a pub package, so prefer it over
+# the git remote the other generators fall back to.
+PROJECT_NAME="${DT_PROJECT_NAME:-$(dart_pubspec_field name)}"
+if [ -z "$PROJECT_NAME" ]; then
+  originUrl="$(git remote get-url origin 2>/dev/null || echo unknown)"
+  originRepo="$(basename "$originUrl")"
+  PROJECT_NAME="${originRepo%.git}"
+fi
+PROJECT_VERSION="${DT_PROJECT_VERSION:-$(dart_pubspec_field version)}"
+if [ -z "$PROJECT_VERSION" ]; then
+  PROJECT_VERSION="$(git describe --tags --abbrev=0 2>/dev/null || echo latest)"
+fi
+
+echo "Generating CycloneDX BOM for Dart project '$PROJECT_NAME' ($PROJECT_VERSION)..."
+dart_run trivy filesystem --format cyclonedx --output "$bomFile" "$(pwd)"
+
+if dart_is_dry_run; then
+  echo "DRY RUN: no BOM was written."
+  exit 0
+fi
+
+# Trivy names the root component after the scan target's basename (the CI
+# working directory, e.g. `s`), and always emits its newest supported CycloneDX
+# spec while Dependency-Track ingests only up to 1.6 -- rejecting anything newer
+# with HTTP 400 `Unrecognized specVersion`. Both are corrected here exactly as
+# in the Terraform generator; see that file for the upstream references.
+maxSpec="${DT_CYCLONEDX_MAX_SPEC_VERSION:-1.6}"
+if ! printf '%s' "$maxSpec" | grep -qE '^[0-9]+\.[0-9]+$'; then
+  echo "ERROR: DT_CYCLONEDX_MAX_SPEC_VERSION='$maxSpec' is not a MAJOR.MINOR CycloneDX spec version (e.g. '1.6')." >&2
+  exit 1
+fi
+
+tmpFile="$BOM_PATH/bom.tmp.json"
+jq --arg name "$PROJECT_NAME" \
+   --arg version "$PROJECT_VERSION" \
+   --arg maxSpec "$maxSpec" \
+   '
+     .metadata.component.name = $name
+     | .metadata.component.version = $version
+     | if ((.specVersion // "0") | split(".") | map(tonumber)) > ($maxSpec | split(".") | map(tonumber))
+       then .specVersion = $maxSpec
+            | (if has("$schema") then ."$schema" = "http://cyclonedx.org/schema/bom-\($maxSpec).schema.json" else . end)
+       else . end
+   ' \
+   "$bomFile" > "$tmpFile"
+mv "$tmpFile" "$bomFile"
+
+echo "CycloneDX BOM written to $bomFile (name=$PROJECT_NAME version=$PROJECT_VERSION, spec $(jq -r '.specVersion' "$bomFile"))."

--- a/global/scripts/languages/dart/format/run.sh
+++ b/global/scripts/languages/dart/format/run.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env sh
+set -e
+
+# `dart format` gate for the `10-code-check` stage.
+#
+# Dart has exactly one formatter, it ships in the SDK, and its output is not
+# configurable -- so unlike the Python stack (isort + black) or JavaScript
+# (prettier + eslint) this is a single job with nothing to choose.
+#
+# Two modes:
+#   check (default) -- `--output=none --set-exit-if-changed`, the CI gate
+#   --fix           -- rewrite the files in place, for `make lint`
+#
+# `--set-exit-if-changed` is what makes the check meaningful. Plain `dart format
+# --output=none` formats to nowhere and always exits 0, so a check written that
+# way passes on every unformatted repository in existence.
+
+if [ -z "$SCRIPTS_DIR" ]; then
+  SCRIPTS_DIR="$(echo "$(dirname "$(realpath "$0")")" | sed 's|\(.*pipelines\).*|\1|')"
+  export SCRIPTS_DIR
+fi
+
+. "$SCRIPTS_DIR/global/scripts/languages/dart/common.sh"
+
+MODE="check"
+TARGETS=""
+for arg in "$@"; do
+  case "$arg" in
+    --fix) MODE="fix" ;;
+    *) TARGETS="$TARGETS $arg" ;;
+  esac
+done
+
+# `.` covers `lib/`, `test/`, `bin/`, `tool/` and `example/` in one pass, which
+# is what a repository-wide gate should do. `dart format` already skips
+# `.dart_tool/` and anything listed in `.gitignore`-style hidden directories.
+if [ -z "$TARGETS" ]; then
+  TARGETS="."
+fi
+
+dart_prepare_reports "dart-format"
+dart_ensure_sdk
+
+# shellcheck disable=SC2086
+if [ "$MODE" = "fix" ]; then
+  echo "Formatting Dart sources in place..."
+  dart_run dart format $TARGETS
+else
+  echo "Checking Dart formatting..."
+  EXIT_CODE=0
+  # shellcheck disable=SC2086
+  dart_run dart format --output=none --set-exit-if-changed $TARGETS || EXIT_CODE=$?
+  if [ "$EXIT_CODE" -ne 0 ]; then
+    echo "" >&2
+    echo "ERROR: some files are not formatted. Run 'dart format .' (or 'make lint') and commit the result." >&2
+    exit "$EXIT_CODE"
+  fi
+  echo "All Dart sources are correctly formatted."
+fi

--- a/global/scripts/languages/dart/publish/run.sh
+++ b/global/scripts/languages/dart/publish/run.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env sh
+set -e
+
+# Publishes a package to pub.dev (or a self-hosted pub server) for the
+# `40-delivery` stage of the library templates.
+#
+# THE CREDENTIAL IS NEVER PASSED ON ARGV. `dart pub token add` accepts
+# `--env-var PUB_TOKEN`, which tells pub to read the token from THAT ENVIRONMENT
+# VARIABLE AT USE TIME -- the name travels on the command line, the value never
+# does. Argv is world-readable through `ps` for the lifetime of the process on a
+# shared or self-hosted runner, and this repository additionally records
+# resolved command lines into `command.txt`, which all three platforms publish
+# as a downloadable artifact. Same reasoning as `-DnvdApiKeyEnvironmentVariable`
+# in the Dependency-Check runner (GHSA-qqhq-8r2c-c3f5) and as the deploy family.
+#
+# A dry run always precedes the real publish. `dart pub publish --dry-run`
+# performs the full validation pub.dev would -- missing description, missing
+# licence, unresolvable constraints, files that would be shipped by mistake --
+# without uploading. Publishing to pub.dev is IRREVERSIBLE: a version can be
+# retracted but never replaced or deleted, so a failed validation must stop the
+# job before the upload rather than be discovered after it.
+
+if [ -z "$SCRIPTS_DIR" ]; then
+  SCRIPTS_DIR="$(echo "$(dirname "$(realpath "$0")")" | sed 's|\(.*pipelines\).*|\1|')"
+  export SCRIPTS_DIR
+fi
+
+. "$SCRIPTS_DIR/global/scripts/languages/dart/common.sh"
+
+dart_prepare_reports "dart-publish"
+
+PUB_SERVER="${PUB_HOSTED_URL:-https://pub.dev}"
+PACKAGE_NAME="$(dart_pubspec_field name)"
+PACKAGE_VERSION="$(dart_pubspec_field version)"
+
+echo "Package: ${PACKAGE_NAME:-<unknown>} ${PACKAGE_VERSION:-<unknown>}"
+echo "Server:  $PUB_SERVER"
+
+if grep -qE '^publish_to:[[:space:]]*none[[:space:]]*$' "${DART_PUBSPEC:-pubspec.yaml}" 2>/dev/null; then
+  echo "pubspec.yaml sets 'publish_to: none'; this package is not meant to be published. Skipping."
+  exit 0
+fi
+
+dart_ensure_sdk
+dart_pub_get
+
+echo ""
+echo "=== Validating the package (dry run) ==="
+dart_run dart pub publish --dry-run
+
+if dart_is_truthy "${DART_PUBLISH_DRY_RUN:-false}" || dart_is_dry_run; then
+  echo ""
+  echo "Validation only; not publishing (DART_PUBLISH_DRY_RUN / DART_DRY_RUN is set)."
+  exit 0
+fi
+
+if [ -z "${PUB_TOKEN:-}" ]; then
+  echo "ERROR: PUB_TOKEN is not set, so the package cannot be published." >&2
+  echo "  pub.dev: create a token with 'dart pub token add https://pub.dev' locally, or use a" >&2
+  echo "  short-lived OIDC token via pub.dev's automated publishing. Expose it to the job as the" >&2
+  echo "  secret variable PUB_TOKEN. Set DART_PUBLISH_DRY_RUN=true to validate without publishing." >&2
+  exit 1
+fi
+
+echo ""
+echo "=== Authenticating ==="
+# The token VALUE stays in the environment; only its NAME is on argv.
+dart_run dart pub token add "$PUB_SERVER" --env-var PUB_TOKEN
+
+echo ""
+echo "=== Publishing ==="
+# `--force` skips the interactive confirmation, which no CI runner can answer.
+# It does NOT skip validation: the dry run above already had to pass, and pub
+# re-runs the same checks server-side.
+dart_run dart pub publish --force
+
+echo ""
+echo "Published ${PACKAGE_NAME} ${PACKAGE_VERSION} to $PUB_SERVER."

--- a/global/scripts/languages/dart/sca/run.sh
+++ b/global/scripts/languages/dart/sca/run.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env sh
+set -e
+
+# Dependency vulnerability scanning for pub packages, via OSV-Scanner.
+#
+# This is the Dart member of the family that already holds `govulncheck` (Go),
+# `safety` (Python) and OWASP Dependency-Check (Java): a language-native SCA
+# that runs ALONGSIDE the shared `sca:trivy` job rather than instead of it.
+# Two sources is the point. Trivy does read `pubspec.lock`, but its own
+# documentation records a real gap for this ecosystem -- Dart pins SDK-provided
+# dependencies (Flutter itself, and anything resolved through it) at version
+# `0.0.0`, and Trivy takes that literally, so those components are effectively
+# unmatched against any advisory. OSV queries the Pub advisory database that the
+# Dart team publishes into OSV.dev directly.
+#
+# OSV-Scanner is fetched as a self-contained release binary from the project's
+# GitHub releases -- the same install shape as gitleaks, hadolint and shellcheck,
+# and for the same reason: no Docker Hub pull, so no anonymous rate limit can
+# fail the job for a reason unrelated to the dependencies under scan.
+
+if [ -z "$SCRIPTS_DIR" ]; then
+  SCRIPTS_DIR="$(echo "$(dirname "$(realpath "$0")")" | sed 's|\(.*pipelines\).*|\1|')"
+  export SCRIPTS_DIR
+fi
+
+. "$SCRIPTS_DIR/global/scripts/languages/dart/common.sh"
+
+dart_prepare_reports "osv-scanner"
+REPORT_FILE="$DART_TOOL_REPORT_PATH/osv-scanner.json"
+LOCKFILE="${DART_LOCKFILE:-pubspec.lock}"
+
+# `pubspec.lock` is what OSV resolves against; `pubspec.yaml` alone carries
+# version RANGES, which cannot be matched to an advisory. Applications commit
+# the lockfile; published packages conventionally do not, so this is a skip
+# rather than a failure.
+if [ ! -f "$LOCKFILE" ]; then
+  echo "No '$LOCKFILE' found; skipping the OSV dependency scan." >&2
+  echo "  Applications should commit pubspec.lock so their exact dependency set can be scanned." >&2
+  printf '{"results":[],"skipped":"no %s"}\n' "$LOCKFILE" > "$REPORT_FILE"
+  exit 0
+fi
+
+case "$(uname -m)" in
+  x86_64 | amd64) OSV_ARCH="amd64" ;;
+  aarch64 | arm64) OSV_ARCH="arm64" ;;
+  *)
+    echo "ERROR: OSV-Scanner publishes no Linux binary for architecture '$(uname -m)'." >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "$HOME/.local/bin"
+case ":$PATH:" in
+  *":$HOME/.local/bin:"*) ;;
+  *) PATH="$HOME/.local/bin:$PATH" && export PATH ;;
+esac
+
+if ! command -v osv-scanner > /dev/null 2>&1; then
+  if dart_is_dry_run; then
+    echo "DRY RUN: skipping the OSV-Scanner download."
+  else
+    OSV_URL="https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_linux_$OSV_ARCH"
+    echo "Downloading OSV-Scanner (linux/$OSV_ARCH)..."
+    if ! curl -fsSL --show-error "$OSV_URL" -o /tmp/osv-scanner; then
+      echo "ERROR: could not download OSV-Scanner from $OSV_URL" >&2
+      exit 1
+    fi
+    chmod +x /tmp/osv-scanner
+    mv /tmp/osv-scanner "$HOME/.local/bin/osv-scanner"
+  fi
+fi
+
+echo "Scanning '$LOCKFILE' against the OSV Pub advisory database..."
+
+# JSON goes to stdout and everything else to stderr, which upstream documents as
+# making the redirect safe.
+if dart_is_dry_run; then
+  dart_run osv-scanner scan --format json --lockfile "$LOCKFILE"
+  echo "DRY RUN: no scan was performed."
+  exit 0
+fi
+
+# Only STDOUT is captured. Upstream documents the split -- "Outputs the results
+# as a JSON object to stdout, with all other output being directed to stderr -
+# this makes it safe to redirect the output to a file" -- so folding stderr in
+# with `2>&1` would put progress lines inside the JSON document and leave `jq`
+# (and Dependency-Track, and any reviewer) with an unparseable report.
+SCAN_EXIT=0
+dart_run osv-scanner scan --format json --lockfile "$LOCKFILE" > "$REPORT_FILE" || SCAN_EXIT=$?
+
+# OSV-Scanner's exit codes are documented and NOT a simple pass/fail:
+#
+#   0        clean
+#   1-126    vulnerabilities/findings (1 in practice)
+#   127      general error
+#   128      no packages found
+#   129-255  non-result errors
+#
+# 128 is the one that must not fail the job. A `pubspec.lock` holding only
+# SDK-provided dependencies produces it, and treating "nothing to scan" as a
+# vulnerability would make the job red for a repository with no third-party
+# dependencies at all -- the safest possible dependency set.
+if [ "$SCAN_EXIT" -eq 0 ]; then
+  echo "OSV-Scanner found no known vulnerabilities."
+elif [ "$SCAN_EXIT" -eq 128 ]; then
+  echo "OSV-Scanner found no packages to scan in '$LOCKFILE'; nothing to report."
+  SCAN_EXIT=0
+elif [ "$SCAN_EXIT" -eq 127 ] || [ "$SCAN_EXIT" -ge 129 ]; then
+  echo "ERROR: OSV-Scanner failed to run (exit $SCAN_EXIT)." >&2
+  [ -s "$REPORT_FILE" ] && head -50 "$REPORT_FILE" >&2
+else
+  echo "OSV-Scanner reported vulnerable dependencies:"
+  # Render the findings back into the log. Without this the job goes red having
+  # named not one package, and the only way to learn what broke is to download
+  # the artifact -- the same reasoning as the Trivy SCA runner's table render.
+  if command -v jq > /dev/null 2>&1 && jq -e . "$REPORT_FILE" > /dev/null 2>&1; then
+    jq -r '
+      .results[]?.packages[]? as $p
+      | $p.vulnerabilities[]?
+      | "  - \($p.package.name) \($p.package.version): \(.id) \(.summary // "")"
+    ' "$REPORT_FILE" | sort -u
+  else
+    head -100 "$REPORT_FILE"
+  fi
+fi
+
+echo "Report written to: $REPORT_FILE"
+exit "$SCAN_EXIT"

--- a/global/scripts/languages/dart/setup/run.sh
+++ b/global/scripts/languages/dart/setup/run.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env sh
+set -e
+
+# Installs the toolchain a Dart or Flutter project needs and reports what it
+# resolved.
+#
+# Every other script in this directory calls `dart_ensure_sdk` itself, so this
+# one is not a prerequisite for them -- it exists for the two cases where an
+# explicit step is worth having:
+#
+#   - A pipeline that wants the (potentially slow) first SDK download to happen
+#     in a named step, so a cold-runner install is legible in the job log
+#     instead of being attributed to whichever job happened to run first.
+#   - `make setup-dart` locally.
+#
+# The toolchain is detected from `pubspec.yaml` unless `DART_TOOLCHAIN` forces
+# it. See `../common.sh` for why the SDK comes from Google's archive rather than
+# a Docker image.
+
+if [ -z "$SCRIPTS_DIR" ]; then
+  SCRIPTS_DIR="$(echo "$(dirname "$(realpath "$0")")" | sed 's|\(.*pipelines\).*|\1|')"
+  export SCRIPTS_DIR
+fi
+
+. "$SCRIPTS_DIR/global/scripts/languages/dart/common.sh"
+
+dart_prepare_reports "dart-setup"
+dart_ensure_sdk
+
+echo "Toolchain: $DART_TOOLCHAIN"
+
+if dart_is_dry_run; then
+  echo "DRY RUN: no SDK was installed and no dependencies were resolved."
+  exit 0
+fi
+
+if [ "$DART_TOOLCHAIN" = "flutter" ]; then
+  flutter --version
+  # Fail fast and readably when the SDK is unusable (missing engine artifacts,
+  # a broken checkout). Without this the first real failure surfaces inside
+  # `flutter test` as a stack trace that names Flutter internals rather than the
+  # environment. `--no-version-check` keeps the doctor from adding a network
+  # round-trip just to tell us a newer Flutter exists.
+  flutter --no-version-check doctor -v || true
+else
+  dart --version
+fi
+
+dart_pub_get
+
+echo "Dart/Flutter toolchain is ready."

--- a/global/scripts/languages/dart/test/lcov_to_cobertura.py
+++ b/global/scripts/languages/dart/test/lcov_to_cobertura.py
@@ -171,9 +171,21 @@ def write_cobertura(files: list[FileCoverage], output: str, sources_root: str) -
         pkg_valid = sum(f.lines_valid for f in members)
         pkg_covered = sum(f.lines_covered for f in members)
         pkg_rate = (pkg_covered / pkg_valid) if pkg_valid else 0.0
+        # Aggregated from the members' BRDA rows, not hard-coded. A fixed `0.0`
+        # here would disagree with the branch rates on the `<class>` elements
+        # inside this very package and with the document-level totals, so any
+        # consumer that aggregates per package (rather than per file) would read
+        # fully branch-covered code as having none.
+        pkg_branches_valid = sum(f.branches_valid for f in members)
+        pkg_branches_covered = sum(f.branches_covered for f in members)
+        pkg_branch_rate = (
+            (pkg_branches_covered / pkg_branches_valid) if pkg_branches_valid else 0.0
+        )
         out.append(
-            '    <package name={name} line-rate="{lr:.4f}" branch-rate="0.0" '
-            'complexity="0">\n      <classes>\n'.format(name=quoteattr(name), lr=pkg_rate)
+            '    <package name={name} line-rate="{lr:.4f}" branch-rate="{br:.4f}" '
+            'complexity="0">\n      <classes>\n'.format(
+                name=quoteattr(name), lr=pkg_rate, br=pkg_branch_rate
+            )
         )
         for entry in members:
             class_name = os.path.basename(entry.path)

--- a/global/scripts/languages/dart/test/lcov_to_cobertura.py
+++ b/global/scripts/languages/dart/test/lcov_to_cobertura.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Convert an LCOV tracefile into a Cobertura XML report.
+
+Dart and Flutter emit coverage as LCOV and nothing else: `flutter test
+--coverage` writes `coverage/lcov.info`, and `package:coverage`'s
+`format_coverage --lcov` produces the same shape for pure Dart packages.  Two of
+the three platforms this repository targets cannot read that format --
+Azure DevOps' `PublishCodeCoverageResults@2` takes Cobertura or JaCoCo, and
+GitLab CI's coverage visualisation takes Cobertura -- so something has to
+convert it.
+
+This is that converter, written against the standard library only, for the same
+reason `check_order.py` and `gen_smoke_tests.py` are: the alternative is a pip
+install (`lcov_cobertura`) inside a Dart job, which means a Python toolchain, a
+virtualenv and a network round-trip on a runner that otherwise needs none of
+them -- and an offline `make test` could not exercise it.
+
+LCOV is a line-oriented format; only the records that carry information
+Cobertura can represent are read:
+
+    SF:<path>                       start of a file record
+    DA:<line>,<hits>[,<checksum>]   per-line execution count
+    BRDA:<line>,<block>,<branch>,<taken|->
+    end_of_record
+
+`LF`/`LH`/`BRF`/`BRH` totals are deliberately ignored and recomputed from the
+`DA`/`BRDA` rows instead.  They are summaries the producer is free to get wrong
+(and merged tracefiles routinely do), whereas the per-line rows are the data
+every consumer actually renders.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from xml.sax.saxutils import quoteattr
+
+
+class FileCoverage:
+    __slots__ = ("path", "lines", "branches")
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        # line number -> hits
+        self.lines: dict[int, int] = {}
+        # (line, block, branch) -> taken count
+        self.branches: dict[tuple[int, str, str], int] = {}
+
+    @property
+    def lines_valid(self) -> int:
+        return len(self.lines)
+
+    @property
+    def lines_covered(self) -> int:
+        return sum(1 for hits in self.lines.values() if hits > 0)
+
+    @property
+    def branches_valid(self) -> int:
+        return len(self.branches)
+
+    @property
+    def branches_covered(self) -> int:
+        return sum(1 for taken in self.branches.values() if taken > 0)
+
+    @property
+    def line_rate(self) -> float:
+        return (self.lines_covered / self.lines_valid) if self.lines_valid else 0.0
+
+    @property
+    def branch_rate(self) -> float:
+        return (self.branches_covered / self.branches_valid) if self.branches_valid else 0.0
+
+
+def parse_lcov(path: str) -> list[FileCoverage]:
+    """Parse a tracefile into per-source-file coverage.
+
+    Records for the same source file are MERGED rather than replaced.  A Dart
+    project that runs more than one test entry point produces several `SF:`
+    records for the same library, and taking the last one would silently discard
+    every hit the other suites contributed -- reporting a real 90% as whatever
+    the final suite happened to touch.
+    """
+    files: dict[str, FileCoverage] = {}
+    current: FileCoverage | None = None
+
+    with open(path, "r", encoding="utf-8", errors="replace") as handle:
+        for raw in handle:
+            line = raw.strip()
+            if not line:
+                continue
+
+            if line.startswith("SF:"):
+                source = line[3:].strip()
+                # LCOV paths may be absolute (format_coverage emits them that
+                # way for some inputs). Cobertura consumers match findings
+                # against the repository tree, so make them relative to the
+                # working directory when we can.
+                if os.path.isabs(source):
+                    try:
+                        source = os.path.relpath(source, os.getcwd())
+                    except ValueError:
+                        pass
+                source = source.replace("\\", "/")
+                current = files.setdefault(source, FileCoverage(source))
+            elif line == "end_of_record":
+                current = None
+            elif current is None:
+                continue
+            elif line.startswith("DA:"):
+                parts = line[3:].split(",")
+                if len(parts) < 2 or not parts[0].strip().isdigit():
+                    continue
+                number = int(parts[0])
+                try:
+                    hits = int(parts[1])
+                except ValueError:
+                    hits = 0
+                current.lines[number] = current.lines.get(number, 0) + hits
+            elif line.startswith("BRDA:"):
+                parts = line[5:].split(",")
+                if len(parts) < 4 or not parts[0].strip().isdigit():
+                    continue
+                key = (int(parts[0]), parts[1], parts[2])
+                taken = 0 if parts[3] == "-" else int(parts[3] or 0)
+                current.branches[key] = current.branches.get(key, 0) + taken
+
+    return [files[key] for key in sorted(files)]
+
+
+def package_name(source: str) -> str:
+    """Cobertura's `package` is a grouping label; use the source directory."""
+    directory = os.path.dirname(source)
+    return directory.replace("/", ".") if directory else "."
+
+
+def write_cobertura(files: list[FileCoverage], output: str, sources_root: str) -> tuple[int, int]:
+    lines_valid = sum(f.lines_valid for f in files)
+    lines_covered = sum(f.lines_covered for f in files)
+    branches_valid = sum(f.branches_valid for f in files)
+    branches_covered = sum(f.branches_covered for f in files)
+    line_rate = (lines_covered / lines_valid) if lines_valid else 0.0
+    branch_rate = (branches_covered / branches_valid) if branches_valid else 0.0
+
+    grouped: dict[str, list[FileCoverage]] = {}
+    for entry in files:
+        grouped.setdefault(package_name(entry.path), []).append(entry)
+
+    out = [
+        '<?xml version="1.0" ?>\n',
+        "<!DOCTYPE coverage SYSTEM "
+        "'http://cobertura.sourceforge.net/xml/coverage-04.dtd'>\n",
+        '<coverage line-rate="{lr:.4f}" branch-rate="{br:.4f}" '
+        'lines-covered="{lc}" lines-valid="{lv}" '
+        'branches-covered="{bc}" branches-valid="{bv}" '
+        'complexity="0" version="2.0.3" timestamp="{ts}">\n'.format(
+            lr=line_rate,
+            br=branch_rate,
+            lc=lines_covered,
+            lv=lines_valid,
+            bc=branches_covered,
+            bv=branches_valid,
+            ts=int(time.time()),
+        ),
+        "  <sources>\n    <source>{}</source>\n  </sources>\n".format(sources_root),
+        "  <packages>\n",
+    ]
+
+    for name in sorted(grouped):
+        members = grouped[name]
+        pkg_valid = sum(f.lines_valid for f in members)
+        pkg_covered = sum(f.lines_covered for f in members)
+        pkg_rate = (pkg_covered / pkg_valid) if pkg_valid else 0.0
+        out.append(
+            '    <package name={name} line-rate="{lr:.4f}" branch-rate="0.0" '
+            'complexity="0">\n      <classes>\n'.format(name=quoteattr(name), lr=pkg_rate)
+        )
+        for entry in members:
+            class_name = os.path.basename(entry.path)
+            out.append(
+                '        <class name={cn} filename={fn} line-rate="{lr:.4f}" '
+                'branch-rate="{br:.4f}" complexity="0">\n'
+                "          <methods/>\n          <lines>\n".format(
+                    cn=quoteattr(class_name),
+                    fn=quoteattr(entry.path),
+                    lr=entry.line_rate,
+                    br=entry.branch_rate,
+                )
+            )
+            for number in sorted(entry.lines):
+                out.append(
+                    '            <line number="{n}" hits="{h}"/>\n'.format(
+                        n=number, h=entry.lines[number]
+                    )
+                )
+            out.append("          </lines>\n        </class>\n")
+        out.append("      </classes>\n    </package>\n")
+
+    out.append("  </packages>\n</coverage>\n")
+
+    os.makedirs(os.path.dirname(os.path.abspath(output)), exist_ok=True)
+    with open(output, "w", encoding="utf-8") as handle:
+        handle.writelines(out)
+
+    return lines_covered, lines_valid
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print(
+            "Usage: lcov_to_cobertura.py <lcov.info> <cobertura.xml> [sources-root]",
+            file=sys.stderr,
+        )
+        return 2
+
+    lcov_path, output_path = sys.argv[1], sys.argv[2]
+    sources_root = sys.argv[3] if len(sys.argv) > 3 else "."
+
+    if not os.path.isfile(lcov_path):
+        print("ERROR: no LCOV tracefile at '{}'.".format(lcov_path), file=sys.stderr)
+        return 1
+
+    files = parse_lcov(lcov_path)
+    covered, valid = write_cobertura(files, output_path, sources_root)
+
+    percent = (covered / valid * 100.0) if valid else 0.0
+    # The exact spelling matters: the GitLab templates scrape this line with a
+    # `coverage:` regex, so changing it silently drops coverage reporting on
+    # that platform while every job stays green.
+    print(
+        "COVERAGE_PERCENT={percent:.2f}% ({covered}/{valid} lines across {files} file(s))".format(
+            percent=percent, covered=covered, valid=valid, files=len(files)
+        )
+    )
+
+    minimum = os.environ.get("DART_COVERAGE_MINIMUM", "").strip()
+    if minimum:
+        try:
+            threshold = float(minimum)
+        except ValueError:
+            print(
+                "WARNING: DART_COVERAGE_MINIMUM={!r} is not a number; ignoring.".format(minimum),
+                file=sys.stderr,
+            )
+            return 0
+        if percent + 1e-9 < threshold:
+            print(
+                "ERROR: coverage {:.2f}% is below the required {:.2f}%.".format(percent, threshold),
+                file=sys.stderr,
+            )
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/global/scripts/languages/dart/test/run.sh
+++ b/global/scripts/languages/dart/test/run.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env sh
+set -e
+
+# Test + coverage runner for the `30-tests` stage, for both toolchains.
+#
+# Produces the same three artefacts every other language runner in this
+# repository produces, so the platform templates publish them identically:
+#
+#   build/reports/junit.xml       -- JUnit XML (Tests tab on all three platforms)
+#   build/reports/cobertura.xml   -- Cobertura (Azure DevOps + GitLab coverage)
+#   build/reports/lcov.info       -- raw LCOV (SonarQube reads this one directly)
+#
+# `coverage/lcov.info` is left in place as well, because that is the path
+# SonarQube's `sonar.dart.lcov.reportPaths` and the community `sonar-flutter`
+# plugin's `sonar.flutter.coverage.reportPath` both default to.
+#
+# Neither toolchain can emit JUnit on its own -- `dart test` and `flutter test`
+# both offer a machine-readable JSON event stream and nothing else -- so
+# `package:junitreport`'s `tojunit` converts the stream. It is the only
+# maintained converter for this format, it is published on pub.dev, and it
+# installs with the same `dart pub global activate` the rest of this family
+# uses, so it costs no extra toolchain.
+#
+# The two CLIs spell the same flag differently: `dart test --reporter json` vs
+# `flutter test --machine`. `flutter test` rejects `--reporter json` outright,
+# which is why the invocation is branched rather than parameterised.
+
+if [ -z "$SCRIPTS_DIR" ]; then
+  SCRIPTS_DIR="$(echo "$(dirname "$(realpath "$0")")" | sed 's|\(.*pipelines\).*|\1|')"
+  export SCRIPTS_DIR
+fi
+
+. "$SCRIPTS_DIR/global/scripts/languages/dart/common.sh"
+
+dart_prepare_reports "dart-test"
+REPORT_ROOT="$(dart_report_root)"
+mkdir -p "$REPORT_ROOT"
+
+JUNIT_FILE="$REPORT_ROOT/junit.xml"
+COBERTURA_FILE="$REPORT_ROOT/cobertura.xml"
+LCOV_FILE="coverage/lcov.info"
+EVENTS_FILE="$DART_TOOL_REPORT_PATH/test-events.json"
+
+dart_ensure_sdk
+
+TEST_DIR="${DART_TEST_DIR:-test}"
+
+# A repository with no test directory is a real situation (a freshly generated
+# plugin, an example app, a package whose suite lives elsewhere), and `dart
+# test` / `flutter test` both fail outright on it. Emit an empty-but-valid JUnit
+# and pass, matching the opt-in contract the Terraform test tiers already
+# establish -- but make it loud, and let a project that considers this a defect
+# flip it with DART_REQUIRE_TESTS=true.
+if [ ! -d "$TEST_DIR" ]; then
+  if dart_is_truthy "${DART_REQUIRE_TESTS:-false}"; then
+    echo "ERROR: no '$TEST_DIR' directory found and DART_REQUIRE_TESTS is set." >&2
+    exit 1
+  fi
+  echo "WARNING: no '$TEST_DIR' directory found; nothing to run." >&2
+  echo "         Set DART_REQUIRE_TESTS=true to make this a failure." >&2
+  printf '<?xml version="1.0" encoding="UTF-8"?>\n<testsuites name="dart-test"/>\n' > "$JUNIT_FILE"
+  exit 0
+fi
+
+dart_pub_get
+dart_global_activate junitreport tojunit
+
+echo ""
+echo "=========================================="
+echo "RUNNING TESTS ($DART_TOOLCHAIN)"
+echo "=========================================="
+
+TEST_EXIT=0
+if [ "$DART_TOOLCHAIN" = "flutter" ]; then
+  # `--machine` and `--coverage` compose: the JSON event stream goes to stdout
+  # while the tracefile is written to `coverage/lcov.info`.
+  # shellcheck disable=SC2086
+  if dart_is_dry_run; then
+    dart_run flutter test --machine --coverage $DART_TEST_ARGS
+  else
+    dart_run flutter test --machine --coverage $DART_TEST_ARGS > "$EVENTS_FILE" || TEST_EXIT=$?
+  fi
+else
+  dart_global_activate coverage format_coverage
+  # shellcheck disable=SC2086
+  if dart_is_dry_run; then
+    dart_run dart test --reporter json --coverage=coverage $DART_TEST_ARGS
+  else
+    dart_run dart test --reporter json --coverage=coverage $DART_TEST_ARGS > "$EVENTS_FILE" || TEST_EXIT=$?
+  fi
+
+  # `dart test --coverage=<dir>` drops raw VM coverage JSON, not LCOV; only
+  # `flutter test --coverage` produces the tracefile directly. Report on the
+  # directories that actually exist so a CLI package (sources in `bin/`) is not
+  # reported as 0% because only `lib/` was considered.
+  REPORT_ON=""
+  for candidate in ${DART_COVERAGE_REPORT_ON:-lib bin}; do
+    [ -d "$candidate" ] && REPORT_ON="$REPORT_ON --report-on=$candidate"
+  done
+  [ -n "$REPORT_ON" ] || REPORT_ON="--report-on=lib"
+
+  if ! dart_is_dry_run && [ -d coverage ]; then
+    # shellcheck disable=SC2086
+    format_coverage --lcov --in=coverage --out="$LCOV_FILE" --check-ignore $REPORT_ON \
+      || echo "WARNING: could not format coverage data; continuing without a tracefile." >&2
+  else
+    # shellcheck disable=SC2086
+    dart_run format_coverage --lcov --in=coverage --out="$LCOV_FILE" --check-ignore $REPORT_ON
+  fi
+fi
+
+if dart_is_dry_run; then
+  echo "DRY RUN: no tests were executed and no reports were written."
+  exit 0
+fi
+
+echo ""
+echo "=========================================="
+echo "GENERATING REPORTS"
+echo "=========================================="
+
+# Reports are generated even when the suite failed -- a red build is exactly
+# when someone needs to see which test failed and what the coverage was.
+if [ -s "$EVENTS_FILE" ]; then
+  tojunit --input "$EVENTS_FILE" --output "$JUNIT_FILE" \
+    || echo "WARNING: 'tojunit' could not convert the test event stream." >&2
+fi
+
+if [ ! -s "$JUNIT_FILE" ]; then
+  echo "WARNING: no JUnit report was produced; writing an empty one." >&2
+  printf '<?xml version="1.0" encoding="UTF-8"?>\n<testsuites name="dart-test"/>\n' > "$JUNIT_FILE"
+fi
+
+COVERAGE_EXIT=0
+if [ -s "$LCOV_FILE" ]; then
+  cp "$LCOV_FILE" "$REPORT_ROOT/lcov.info"
+  python3 "$SCRIPTS_DIR/global/scripts/languages/dart/test/lcov_to_cobertura.py" \
+    "$LCOV_FILE" "$COBERTURA_FILE" "." || COVERAGE_EXIT=$?
+else
+  echo "WARNING: no coverage tracefile at '$LCOV_FILE'; skipping the Cobertura report." >&2
+fi
+
+echo ""
+echo "JUnit:     $JUNIT_FILE"
+[ -f "$COBERTURA_FILE" ] && echo "Cobertura: $COBERTURA_FILE"
+[ -f "$REPORT_ROOT/lcov.info" ] && echo "LCOV:      $REPORT_ROOT/lcov.info"
+
+# The suite's own verdict wins over the coverage gate's: a failing test is the
+# more important thing to report, and reporting the coverage shortfall instead
+# would send someone chasing the wrong problem.
+if [ "$TEST_EXIT" -ne 0 ]; then
+  exit "$TEST_EXIT"
+fi
+exit "$COVERAGE_EXIT"

--- a/global/scripts/languages/dart/unused/run.sh
+++ b/global/scripts/languages/dart/unused/run.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env sh
+set -e
+
+# Dead-code detection for Dart, the counterpart of `vulture` (Python), `knip`
+# (JavaScript), `debride` (Ruby) and golangci-lint's `unused` (Go).
+#
+# `dart analyze` already reports unused imports, locals, fields and private
+# elements, so this job exists for the two things the analyzer structurally
+# cannot see: a PUBLIC declaration that nothing in the package references, and a
+# `.dart` FILE that nothing imports. Both are invisible to a per-library
+# analyzer because, from its point of view, a public API may have callers it
+# cannot see -- only a whole-package pass can conclude otherwise.
+#
+# The tool is `dart_code_linter`, the maintained community fork of Dart Code
+# Metrics. The original went commercial (DCM) and its last open-source release
+# no longer supports current SDKs; the fork is Apache-2.0, actively released,
+# and keeps the same `check-unused-code` / `check-unused-files` commands.
+#
+# Findings are advisory by default. Whole-package reachability analysis has a
+# false-positive tail that the analyzer's local checks do not -- entry points
+# invoked by the framework, generated code, `@visibleForTesting` members -- so
+# this job matches how `vulture` and `knip` are wired in the other pipelines
+# (`continueOnError`). Set DART_UNUSED_FATAL=true to make it a gate.
+
+if [ -z "$SCRIPTS_DIR" ]; then
+  SCRIPTS_DIR="$(echo "$(dirname "$(realpath "$0")")" | sed 's|\(.*pipelines\).*|\1|')"
+  export SCRIPTS_DIR
+fi
+
+. "$SCRIPTS_DIR/global/scripts/languages/dart/common.sh"
+
+dart_prepare_reports "dart-unused"
+
+TARGETS="$*"
+[ -n "$TARGETS" ] || TARGETS="${DART_UNUSED_TARGETS:-lib}"
+
+if [ ! -d "${TARGETS%% *}" ]; then
+  echo "No '${TARGETS%% *}' directory found; skipping the unused-code scan."
+  exit 0
+fi
+
+dart_ensure_sdk
+dart_pub_get
+
+# Prefer the project's own dev_dependency over a globally activated copy. A
+# project that pins `dart_code_linter` also configures it through the
+# `dart_code_linter:` section of its `analysis_options.yaml`, and running a
+# different version against that configuration is how a scan starts reporting
+# rules the project never enabled. Falling back to a global activation keeps the
+# job useful for projects that have not adopted the dependency yet.
+RUNNER=""
+if grep -q 'dart_code_linter' "${DART_PUBSPEC:-pubspec.yaml}" 2>/dev/null; then
+  echo "Using the project's own 'dart_code_linter' dev_dependency."
+  RUNNER="project"
+else
+  echo "'dart_code_linter' is not a dev_dependency; activating it globally."
+  echo "  Consider 'dart pub add --dev dart_code_linter' so the version is pinned with the project."
+  dart_global_activate dart_code_linter metrics
+  RUNNER="global"
+fi
+
+run_metrics() {
+  if [ "$RUNNER" = "project" ]; then
+    # shellcheck disable=SC2086
+    dart_run dart run dart_code_linter:metrics "$@"
+  else
+    # shellcheck disable=SC2086
+    dart_run metrics "$@"
+  fi
+}
+
+EXIT_CODE=0
+
+echo ""
+echo "--- Unused code ---"
+# shellcheck disable=SC2086
+run_metrics check-unused-code $TARGETS --reporter=console > "$DART_TOOL_REPORT_PATH/unused-code.txt" 2>&1 \
+  || EXIT_CODE=$?
+cat "$DART_TOOL_REPORT_PATH/unused-code.txt"
+
+echo ""
+echo "--- Unused files ---"
+UNUSED_FILES_EXIT=0
+# shellcheck disable=SC2086
+run_metrics check-unused-files $TARGETS --reporter=console > "$DART_TOOL_REPORT_PATH/unused-files.txt" 2>&1 \
+  || UNUSED_FILES_EXIT=$?
+cat "$DART_TOOL_REPORT_PATH/unused-files.txt"
+[ "$EXIT_CODE" -eq 0 ] && EXIT_CODE="$UNUSED_FILES_EXIT"
+
+if dart_is_dry_run; then
+  echo "DRY RUN: no scan was performed."
+  exit 0
+fi
+
+echo ""
+echo "Reports written to: $DART_TOOL_REPORT_PATH"
+
+if [ "$EXIT_CODE" -ne 0 ] && ! dart_is_truthy "${DART_UNUSED_FATAL:-false}"; then
+  echo "Unused-code findings are advisory here; set DART_UNUSED_FATAL=true to fail the job on them."
+  exit 0
+fi
+
+exit "$EXIT_CODE"

--- a/global/scripts/tools/semgrep/rules/dart.yaml
+++ b/global/scripts/tools/semgrep/rules/dart.yaml
@@ -1,0 +1,229 @@
+# First-party Semgrep rules for Dart and Flutter.
+#
+# WHY THIS FILE EXISTS
+# The Semgrep Registry publishes NO Dart rules. `p/dart` returns HTTP 404 and
+# the language-scoped `r/dart` returns a literal `rules: []`. Semgrep's Dart
+# PARSER works (the language is listed as experimental and has had active
+# grammar fixes through 2026), so the engine can match Dart -- there is simply
+# nothing published to match with. Without this file a Dart project's
+# `sast:semgrep` job would run only the language-agnostic packs (secrets,
+# Dockerfile, OWASP) and report zero Dart-level findings while looking green.
+#
+# That gap matters more for Dart than it would for most languages, because
+# CodeQL has no Dart extractor either (dart-lang/sdk#52953), so Semgrep is the
+# only pattern-based SAST left in the stack.
+#
+# SCOPE
+# These are the mobile/Dart issues that are both high-consequence and reliably
+# expressible as a pattern. Style and correctness lints are deliberately absent:
+# `dart analyze` already owns those and does them better, with the project's own
+# `analysis_options.yaml` deciding what counts.
+#
+# Every rule is `pattern`-based rather than `pattern-regex`-based wherever the
+# Dart parser allows it, so they match the syntax tree and not the text.
+rules:
+  - id: dart-tls-verification-disabled
+    languages: [dart]
+    severity: ERROR
+    message: >-
+      TLS certificate validation is disabled: this `badCertificateCallback`
+      accepts every certificate, which makes the connection trivially
+      interceptable by any machine-in-the-middle. This is the single most common
+      critical defect in Flutter networking code, usually added to get a
+      self-signed development certificate working and then shipped. Trust a
+      specific certificate instead (`SecurityContext.setTrustedCertificates`),
+      or scope the override to debug builds behind `kDebugMode`.
+    metadata:
+      category: security
+      cwe: 'CWE-295: Improper Certificate Validation'
+      owasp: 'A02:2021 - Cryptographic Failures'
+      references:
+        - https://api.flutter.dev/flutter/dart-io/HttpClient/badCertificateCallback.html
+      confidence: HIGH
+    patterns:
+      - pattern-either:
+          - pattern: $CLIENT.badCertificateCallback = (...) => true;
+          - pattern: |
+              $CLIENT.badCertificateCallback = (...) {
+                ...
+                return true;
+              };
+
+  - id: dart-webview-javascript-unrestricted
+    languages: [dart]
+    severity: WARNING
+    message: >-
+      This WebView runs JavaScript without restriction. Combined with remote or
+      user-influenced content it exposes the app's JavaScript channels to the
+      loaded page. Keep JavaScript disabled unless the WebView needs it, and
+      when it does, restrict navigation to an allowlist of origins with a
+      `NavigationDelegate`.
+    metadata:
+      category: security
+      cwe: 'CWE-79: Improper Neutralization of Input During Web Page Generation'
+      owasp: 'A03:2021 - Injection'
+      confidence: MEDIUM
+    pattern-either:
+      - pattern: JavascriptMode.unrestricted
+      - pattern: JavaScriptMode.unrestricted
+
+  - id: dart-webview-file-access-from-urls
+    languages: [dart]
+    severity: ERROR
+    message: >-
+      Allowing file access from file URLs lets a loaded local page read other
+      files in the app sandbox through `file://` requests, turning any HTML
+      injection into local file disclosure. Leave `allowFileAccessFromFileURLs`
+      and `allowUniversalAccessFromFileURLs` disabled.
+    metadata:
+      category: security
+      cwe: 'CWE-200: Exposure of Sensitive Information to an Unauthorized Actor'
+      confidence: HIGH
+    # Both the bare and the receiver-qualified forms are listed. A bare
+    # `allowFileAccessFromFileURLs = true` pattern does NOT match
+    # `controller.settings.allowFileAccessFromFileURLs = true`, which is how
+    # every real `webview_flutter` call site spells it -- so the receiver-
+    # qualified variants are the ones that do the work here.
+    pattern-either:
+      - pattern: allowFileAccessFromFileURLs = true
+      - pattern: allowUniversalAccessFromFileURLs = true
+      - pattern: $X.allowFileAccessFromFileURLs = true
+      - pattern: $X.allowUniversalAccessFromFileURLs = true
+      - pattern: $X.setAllowFileAccessFromFileURLs(true)
+      - pattern: $X.setAllowUniversalAccessFromFileURLs(true)
+      - pattern: setAllowFileAccessFromFileURLs(true)
+      - pattern: setAllowUniversalAccessFromFileURLs(true)
+
+  - id: dart-insecure-random-for-secret
+    languages: [dart]
+    severity: WARNING
+    message: >-
+      `Random()` is a deterministic pseudo-random generator seeded from a
+      predictable source; a value derived from it is guessable. Use
+      `Random.secure()` for anything used as a token, nonce, salt, OTP or key.
+    metadata:
+      category: security
+      cwe: 'CWE-338: Use of Cryptographically Weak Pseudo-Random Number Generator'
+      owasp: 'A02:2021 - Cryptographic Failures'
+      confidence: MEDIUM
+    patterns:
+      # Deliberately narrowed to values whose NAME says they are security
+      # sensitive. A bare `Random()` is perfectly correct in animation, sampling
+      # and game code, and flagging every one of them would make this rule the
+      # first thing a team disables.
+      - pattern: var $NAME = Random();
+      - metavariable-regex:
+          metavariable: $NAME
+          regex: (?i).*(token|nonce|salt|secret|otp|passw|apikey|api_key|session|csrf).*
+
+  - id: dart-shell-command-injection
+    languages: [dart]
+    severity: ERROR
+    message: >-
+      Running a command through a shell (`runInShell: true`) with an
+      interpolated string lets any shell metacharacter in the interpolated value
+      run as a command. Pass the executable and its arguments as separate list
+      elements and leave `runInShell` at its default of false, which executes
+      the binary directly with no shell to interpret.
+    metadata:
+      category: security
+      cwe: 'CWE-78: Improper Neutralization of Special Elements used in an OS Command'
+      owasp: 'A03:2021 - Injection'
+      confidence: MEDIUM
+    # Two Dart-specific mechanics are load-bearing here and in the two rules
+    # below, both verified against the engine rather than assumed:
+    #
+    #   - The patterns are QUOTED. An unquoted scalar containing
+    #     `runInShell: true` is read by YAML as a nested mapping, and the rule
+    #     file fails to load entirely.
+    #   - Interpolation is detected with `metavariable-regex`, NOT with
+    #     Semgrep's `"...$..."` string-ellipsis idiom. That idiom is not
+    #     implemented for Dart -- it parses, loads and then matches nothing, so
+    #     a rule written that way is silently dead. Binding the whole literal to
+    #     a metavariable and testing it with a regex does work; the bound text
+    #     includes the surrounding quotes.
+    patterns:
+      - pattern-either:
+          - pattern: 'Process.run($CMD, ..., runInShell: true, ...)'
+          - pattern: 'Process.runSync($CMD, ..., runInShell: true, ...)'
+          - pattern: 'Process.start($CMD, ..., runInShell: true, ...)'
+      - metavariable-regex:
+          metavariable: $CMD
+          regex: .*\$\{?[A-Za-z_]
+
+  - id: dart-sql-injection-raw-query
+    languages: [dart]
+    severity: ERROR
+    message: >-
+      This SQL statement is built by string interpolation, so any quote in the
+      interpolated value changes the statement's structure. Use `?` placeholders
+      and pass the values through the `arguments` parameter, which the driver
+      binds instead of concatenating.
+    metadata:
+      category: security
+      cwe: 'CWE-89: Improper Neutralization of Special Elements used in an SQL Command'
+      owasp: 'A03:2021 - Injection'
+      confidence: HIGH
+    patterns:
+      - pattern-either:
+          - pattern: $DB.rawQuery($SQL, ...)
+          - pattern: $DB.rawInsert($SQL, ...)
+          - pattern: $DB.rawUpdate($SQL, ...)
+          - pattern: $DB.rawDelete($SQL, ...)
+          - pattern: $DB.execute($SQL, ...)
+      # `$name` and `${expr}` are the two Dart interpolation forms. A statement
+      # built with neither is a constant string and cannot be injected into --
+      # which is what keeps the parameterised call on the next line from being
+      # flagged alongside the vulnerable one.
+      - metavariable-regex:
+          metavariable: $SQL
+          regex: .*\$\{?[A-Za-z_]
+
+  - id: dart-insecure-cleartext-url
+    languages: [dart]
+    severity: WARNING
+    message: >-
+      This request targets a cleartext `http://` URL, so the traffic and
+      anything it carries (credentials, tokens, personal data) is readable and
+      modifiable on the network path. Use `https://`. Loopback and `.local`
+      addresses are excluded from this rule.
+    metadata:
+      category: security
+      cwe: 'CWE-319: Cleartext Transmission of Sensitive Information'
+      owasp: 'A02:2021 - Cryptographic Failures'
+      confidence: MEDIUM
+    patterns:
+      - pattern: Uri.parse($URL)
+      # Loopback and `.local` are excluded because they are the addresses a
+      # device emulator and a local dev server actually use (`10.0.2.2` is the
+      # host as seen from the Android emulator), and flagging them would make
+      # this rule fire on every project's development configuration.
+      - metavariable-regex:
+          metavariable: $URL
+          regex: '^"http://(?!localhost|127\.0\.0\.1|10\.0\.2\.2|\[::1\]|[^/]*\.local[:/"])'
+
+  - id: dart-sensitive-data-in-shared-preferences
+    languages: [dart]
+    severity: WARNING
+    message: >-
+      `SharedPreferences` is plaintext storage -- an XML file on Android and a
+      plist on iOS -- readable by anything with filesystem access to the app
+      sandbox, which includes any rooted or jailbroken device and most backup
+      extractions. Store credentials in the platform keystore instead (e.g.
+      `flutter_secure_storage`).
+    metadata:
+      category: security
+      cwe: 'CWE-922: Insecure Storage of Sensitive Information'
+      owasp: 'A04:2021 - Insecure Design'
+      confidence: MEDIUM
+    patterns:
+      - pattern-either:
+          - pattern: $PREFS.setString($KEY, ...)
+          - pattern: $PREFS.setStringList($KEY, ...)
+      # The bound metavariable text INCLUDES the surrounding quotes, so the
+      # regex is anchored on the quote rather than on the word. Writing
+      # `setString("$KEY", ...)` instead -- the intuitive spelling -- matches
+      # nothing at all in Dart.
+      - metavariable-regex:
+          metavariable: $KEY
+          regex: (?i)^["'].*(token|secret|passw|credential|apikey|api_key|private_key|refresh).*["']$

--- a/global/scripts/tools/semgrep/run.sh
+++ b/global/scripts/tools/semgrep/run.sh
@@ -54,10 +54,53 @@ else
   fi
 fi
 
-# Collect optional arguments (project-provided rule exclusions and custom
-# rules) into the positional parameters so they are passed safely without
+# Collect optional arguments (rule configs, project-provided rule exclusions and
+# custom rules) into the positional parameters so they are passed safely without
 # `eval`.
 set --
+
+# semgrep_registry_pack_exists <config>
+#
+# True when the Semgrep Registry publishes the given config.
+#
+# Not every language Semgrep can PARSE has a rule pack published for it, and
+# passing one that does not exist is fatal: `--config p/dart` fails the whole
+# invocation, taking the language-agnostic packs (secrets, Dockerfile, OWASP)
+# down with it. Dart is the concrete case -- `p/dart` is a 404 and the
+# language-scoped `r/dart` returns an empty `rules: []` -- but the check is
+# written generically so the next language in the same position needs no code.
+#
+# The fail-safe direction is deliberate: only an explicit 404 skips the pack.
+# A timeout, a proxy error or any other inconclusive response keeps it, so a
+# transient network problem can never quietly downgrade a scan to fewer rules
+# while the job still reports success. If the registry really is unreachable,
+# semgrep itself says so, in its own words.
+semgrep_registry_pack_exists() {
+  _sr_code="$(curl -sSL -o /dev/null -w '%{http_code}' --max-time 15 "https://semgrep.dev/c/$1" 2>/dev/null)"
+  [ "$_sr_code" != "404" ]
+}
+
+if [ -z "$SEMGREP_LANGUAGE" ] || [ "$SEMGREP_LANGUAGE" = "none" ]; then
+  # An empty language used to compose the meaningless config `p/`, which fails
+  # the run. Treat it as "language-agnostic packs only" instead.
+  echo "No language pack requested; running the language-agnostic rule packs only."
+elif semgrep_registry_pack_exists "p/$SEMGREP_LANGUAGE"; then
+  set -- "$@" --config "p/$SEMGREP_LANGUAGE"
+else
+  echo "WARNING: the Semgrep Registry publishes no 'p/$SEMGREP_LANGUAGE' rule pack; skipping it." >&2
+  echo "         The language-agnostic packs still run." >&2
+fi
+
+# Rules this repository ships for languages the registry does not cover. This is
+# what keeps a Dart scan from being language-agnostic-only -- see
+# `rules/dart.yaml` for why that file has to exist at all.
+if [ -n "$SEMGREP_LANGUAGE" ]; then
+  localRules="$SCRIPTS_DIR/global/scripts/tools/semgrep/rules/$SEMGREP_LANGUAGE.yaml"
+  if [ -f "$localRules" ]; then
+    echo "Adding the pipelines' own '$SEMGREP_LANGUAGE' rules: $localRules"
+    set -- "$@" --config "$localRules"
+  fi
+fi
 
 if [ -f ".semgrepexcluderules" ]; then # check if you have rules to exclude
   while IFS= read -r line || [ -n "$line" ]; do
@@ -73,7 +116,6 @@ fi
 
 semgrep \
   --metrics=off \
-  --config "p/$SEMGREP_LANGUAGE" \
   --config "p/docker" \
   --config "p/dockerfile" \
   --config "p/secrets" \

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -13,8 +13,25 @@
 setup:
 	@curl -sSL https://raw.githubusercontent.com/rios0rios0/pipelines/main/clone.sh | bash
 
+# Skipped, with an explanation, when no language is configured. Not every
+# language this repository supports HAS a CodeQL extractor -- Dart notably does
+# not (dart-lang/sdk#52953) -- and its `.mk` fragment signals that by leaving
+# CODEQL_LANGUAGE unset. Without this guard the run script rejects the empty
+# argument with a bare usage message that reads like a misconfiguration, on
+# every `make sast` of such a project.
+# The emptiness test lives in the RECIPE, not in a make-level `ifeq`. A
+# conditional is evaluated while the makefile is being parsed, and this file is
+# included BEFORE the language fragment that sets CODEQL_LANGUAGE -- so an
+# `ifeq` here reads the variable while it is still empty and takes the skip
+# branch for EVERY language, silently disabling CodeQL repository-wide. Recipe
+# text is expanded at execution time, once every include has been read, which is
+# the only point at which the value is trustworthy.
 codeql:
-	-@$(SCRIPTS_DIR)/global/scripts/tools/codeql/run.sh "$(CODEQL_LANGUAGE)"
+	@if [ -z "$(strip $(CODEQL_LANGUAGE))" ]; then \
+	  echo "CODEQL_LANGUAGE is not set; skipping CodeQL (no extractor for this language)."; \
+	else \
+	  $(SCRIPTS_DIR)/global/scripts/tools/codeql/run.sh "$(CODEQL_LANGUAGE)" || true; \
+	fi
 
 semgrep:
 	-@$(SCRIPTS_DIR)/global/scripts/tools/semgrep/run.sh "$(SEMGREP_LANGUAGE)"

--- a/makefiles/dart.mk
+++ b/makefiles/dart.mk
@@ -1,0 +1,69 @@
+# dart.mk -- Dart and Flutter language pipeline targets (lint, test, ...).
+#
+# Usage: Add the following to your project's Makefile:
+#   SCRIPTS_DIR ?= $(HOME)/Development/github.com/rios0rios0/pipelines
+#   -include $(SCRIPTS_DIR)/makefiles/common.mk
+#   -include $(SCRIPTS_DIR)/makefiles/dart.mk
+#
+# Targets provided: lint, analyze, test, unused, sca, cyclonedx, build, setup-dart
+#
+# CODEQL_LANGUAGE IS DELIBERATELY NOT SET, and `common.mk`'s `sast` target is
+# narrowed below because of it. CodeQL has no Dart extractor at all
+# (dart-lang/sdk#52953), so `make codeql` on a Dart project cannot do anything
+# but fail. `SEMGREP_LANGUAGE=dart` IS set: the Semgrep engine parses Dart, and
+# although the registry publishes no Dart rules (`p/dart` is a 404), the runner
+# skips the missing pack and loads this repository's own Dart ruleset instead.
+#
+# The `sca` target is the Dart counterpart of `make safety` (Python) and
+# `govulncheck` (Go): it runs OSV-Scanner over `pubspec.lock` against the Pub
+# advisory database, which covers the SDK-provided dependencies Trivy records as
+# version `0.0.0` and therefore cannot match.
+#
+# Prerequisites: none. The Dart or Flutter SDK is installed on demand from
+# Google's release archive, and the toolchain is chosen from your pubspec.yaml.
+
+SEMGREP_LANGUAGE ?= dart
+export PREFIX ?= .
+export REPORT_PATH ?= ./reports
+
+.PHONY: setup-dart lint format analyze test unused sca cyclonedx build sast
+
+setup-dart:
+	@$(SCRIPTS_DIR)/global/scripts/languages/dart/setup/run.sh
+
+# `lint` formats in place (the `--fix` mode) and then analyses, matching how the
+# other language fragments behave: `make lint` is expected to leave the tree
+# clean, not merely to report that it is not.
+lint:
+	@$(SCRIPTS_DIR)/global/scripts/languages/dart/format/run.sh --fix
+	@$(SCRIPTS_DIR)/global/scripts/languages/dart/analyze/run.sh
+	-@$(SCRIPTS_DIR)/global/scripts/languages/dart/unused/run.sh
+
+format:
+	@$(SCRIPTS_DIR)/global/scripts/languages/dart/format/run.sh --fix
+
+analyze:
+	@$(SCRIPTS_DIR)/global/scripts/languages/dart/analyze/run.sh
+
+test:
+	@$(SCRIPTS_DIR)/global/scripts/languages/dart/test/run.sh
+
+unused:
+	-@$(SCRIPTS_DIR)/global/scripts/languages/dart/unused/run.sh
+
+sca:
+	@$(SCRIPTS_DIR)/global/scripts/languages/dart/sca/run.sh
+
+cyclonedx:
+	@$(SCRIPTS_DIR)/global/scripts/languages/dart/cyclonedx/run.sh
+
+build:
+	@$(SCRIPTS_DIR)/global/scripts/languages/dart/build/run.sh
+
+# ADDS the Dart-native SCA to `common.mk`'s `sast` rather than redefining it.
+# `sast` there is a prerequisite-only rule (it carries no recipe), so naming it
+# again here appends to its prerequisite list -- the documented Make behaviour --
+# instead of triggering the "overriding recipe for target" warning a redefinition
+# would produce. CodeQL drops out on its own: this file leaves CODEQL_LANGUAGE
+# unset, and `common.mk`'s `codeql` target skips with an explanation when it is.
+sast: sca


### PR DESCRIPTION
Adds full Dart and Flutter support to the pipelines library — all five stages, on GitHub Actions, GitLab CI and Azure DevOps.

One set of templates and scripts serves both toolchains: `dart_detect_toolchain` reads the project's `pubspec.yaml` and picks `flutter` when it finds a `flutter:\n    sdk: flutter` dependency, `dart` otherwise (`DART_TOOLCHAIN` overrides). The detection keys on that dependency rather than a top-level `flutter:` key — a pure Dart package can carry the latter to declare assets without depending on Flutter, and picking the wrong CLI fails deep inside the widget-test bindings.

## Some of the existing tools do not support Dart

This was the main research question, and three of them genuinely don't. Each gap is handled by a deliberate absence or substitution rather than by a job that silently checks nothing:

| Tool | Dart support | What this PR does |
|------|--------------|-------------------|
| **CodeQL** | ❌ No extractor ([dart-lang/sdk#52953](https://github.com/dart-lang/sdk/issues/52953), open since 2023) | **Omits** `sast:codeql` from every Dart template. `make sast` skips it with an explanation. |
| **Semgrep Registry** | ❌ Publishes **zero** Dart rules — `p/dart` returns HTTP 404, `r/dart` returns a literal `rules: []` (verified against the live registry) | Ships a **first-party Dart ruleset**. The engine itself parses Dart, so the job still runs. |
| **OWASP Dependency-Check** | ❌ No pub analyzer | Replaced by **OSV-Scanner** against the Pub advisory database. |
| **Trivy** (IaC + SCA) | ✅ Parses `pubspec.lock` | Runs unchanged — but it records SDK-provided dependencies as version `0.0.0`, which is *why* OSV-Scanner runs alongside rather than instead. |
| **SonarQube** | ✅ First-party analyzer (Server 10.7+/Cloud); community `sonar-flutter` on older | Writes **both** `sonar.dart.lcov.reportPaths` and `sonar.flutter.coverage.reportPath`, so either implementation finds the coverage. An unknown property is ignored by the scanner; a missing one silently means zero coverage. |
| **Gitleaks / Hadolint / ShellCheck** | ✅ Language-agnostic | Run unchanged. |
| **Dependency-Track** | ✅ via CycloneDX | BOM generated with Trivy (`package:sbom` emits SPDX only; `cdxgen` would drag a Node.js toolchain into a Dart job). |

The shipped Semgrep ruleset holds eight rules: TLS verification bypass via `badCertificateCallback`, WebView JavaScript and file-URL access, shell and SQL injection through string interpolation, weak randomness for security-sensitive values, cleartext `http://`, and secrets in `SharedPreferences`. Style and correctness lints are left to `dart analyze`, which does them better with the project's own `analysis_options.yaml` deciding what counts.

Two Dart-specific Semgrep mechanics were verified against the engine rather than assumed, and both are load-bearing: patterns containing `runInShell: true` must be **quoted** (YAML otherwise reads them as a nested mapping and the rule file fails to load), and interpolation must be detected with `metavariable-regex` — the `"...$..."` string-ellipsis idiom is **not implemented for Dart**, so a rule written with it loads cleanly and then matches nothing.

## What's included

**Nine runners** under `global/scripts/languages/dart/` (`setup`, `format`, `analyze`, `test`, `unused`, `sca`, `cyclonedx`, `build`, `publish`) plus a sourced `common.sh`.

**Two format converters**, both standard-library Python, because Dart emits neither format the CI platforms consume:
- `lcov_to_cobertura.py` — Dart emits coverage as LCOV only; Azure DevOps' `PublishCodeCoverageResults@2` and GitLab's coverage view both need Cobertura. Repeated `SF:` records for one file are **merged**, not replaced — a multi-entry-point suite emits several, and taking the last would report only that suite's hits.
- `dart_analyze_report.py` — parses `dart analyze --format=machine` into JUnit + JSON with a configurable severity gate. `flutter analyze` has no `--format` option at all ([flutter/flutter#95090](https://github.com/flutter/flutter/issues/95090)), so the analyze path drives the Flutter SDK's bundled `dart`.

**Four entry templates per platform**: `dart-docker`, `dart-library`, `flutter-docker`, `flutter-artifacts`.

**`makefiles/dart.mk`** with `lint`, `test`, `sca`, `cyclonedx`, `build` and friends.

**`.github/tests/test-dart-pipeline.sh`** — 166 assertions, wired into `make test`. Runs **offline with no Dart SDK, no Flutter SDK and no network**: every runner honours `DART_DRY_RUN=true`, which resolves and records commands without installing or executing anything, so the suite asserts on the argv each script actually builds rather than on what the source looks like it says. Covers cross-platform wiring (a stage added to one platform and forgotten on the other two leaves three files that are each valid YAML on their own — nothing else in CI catches that), toolchain dispatch, both tool-gap decisions, the converters' known-tricky cases, and a credential-leak check.

## Changes to shared code

- **`semgrep/run.sh`** now probes the registry before passing a language pack, and loads `global/scripts/tools/semgrep/rules/<language>.yaml` when this repository ships one. Passing an unpublished pack is *fatal to the whole invocation*, so `--config p/dart` would have taken the language-agnostic packs (secrets, Dockerfile, OWASP) down with it. Only an explicit 404 skips the pack — a timeout or proxy error keeps it, so a transient network problem can never quietly downgrade a scan while the job still reports success. An empty or `none` language is now accepted too, where it previously composed the meaningless config `p/`.
- **`common.mk`** — the `codeql` target now skips with an explanation when `CODEQL_LANGUAGE` is unset. The test lives in the **recipe**, not in a make-level `ifeq`: a conditional is evaluated while `common.mk` is parsed, *before* the language fragment that sets the variable is included, so an `ifeq` would have disabled CodeQL for every language. The test suite pins this both ways.

## Security

No credential reaches a recorded command line. `dart pub token add --env-var PUB_TOKEN` passes the variable's *name* — pub reads the value from the environment. Argv is world-readable via `ps` on a shared runner, and every platform here publishes `build/reports/` (including `command.txt`) as a downloadable artifact. Same reasoning as `-DnvdApiKeyEnvironmentVariable` in the Dependency-Check runner. The test suite feeds a sentinel token and greps the whole report tree for it.

The SDK is fetched from `storage.googleapis.com`, never pulled as a Docker image — the same anonymous-rate-limit reasoning that governs every other tool install here. `flyctl`-style `curl | sh` is not used anywhere in this change.

## Validation

- `make test-dart-pipeline` — 166/166 passing
- ShellCheck clean across `global/scripts` and the new test harness
- All 36 new YAML files parse
- Gitleaks: no leaks found (both passes)
- Semgrep ruleset validated with `semgrep --validate` and matched against vulnerable *and* safe Dart samples: all 8 rules fire, zero false positives

**Pre-existing failures, untouched by this PR** (confirmed identical on a clean `HEAD` worktree): `test-go-script` hardcodes `/home/runner/work/pipelines/pipelines/...` so it only passes on a GitHub Actions runner; `test-yaml-merge` and `test-docker-multi-arch` assume mikefarah `yq` and fail against the Python `yq` wrapper. Happy to fix those in a separate PR if wanted.

## Docs

README (language matrix, per-platform templates and usage examples, a Dart & Flutter Tool Coverage section), CHANGELOG, CLAUDE.md, `.github/copilot-instructions.md`, `global/scripts/languages/README.md`, and two complete examples under `.docs/examples/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
