### PR TITLE
feat(render): added a service-name input, so a derived name replaces a secret

### DIFF
--- a/.github/tests/test-basic-checks.sh
+++ b/.github/tests/test-basic-checks.sh
@@ -152,6 +152,13 @@ setup_repo() {
   cd "$work_dir"
   git config user.name "test" >/dev/null 2>&1
   git config user.email "test@test" >/dev/null 2>&1
+  # Throwaway repos must not inherit the developer's signing config. A machine with
+  # `commit.gpgsign = true` globally -- and a signer that needs an unlocked agent -- fails every
+  # commit below with `failed to write commit object`, which surfaces as `Error 128` from make and
+  # reads like a bug in the fixture rather than like the local environment. Nothing here is
+  # published, so a signature would prove nothing about anything.
+  git config commit.gpgsign false >/dev/null 2>&1
+  git config tag.gpgsign false >/dev/null 2>&1
   git checkout -b main >/dev/null 2>&1
 
   cat > CHANGELOG.md << 'CHANGELOG'

--- a/.github/tests/test-deploy-providers.sh
+++ b/.github/tests/test-deploy-providers.sh
@@ -113,7 +113,7 @@ run_provider() {
       CLOUDFLARE_PROJECT_NAME CLOUDFLARE_OUTPUT_DIRECTORY CLOUDFLARE_BRANCH \
       CLOUDFLARE_PRODUCTION_BRANCH CLOUDFLARE_API_URL \
       NETLIFY_AUTH_TOKEN NETLIFY_SITE_ID NETLIFY_OUTPUT_DIRECTORY NETLIFY_DEPLOY_MESSAGE \
-      RENDER_API_KEY RENDER_SERVICE_ID RENDER_DEPLOY_HOOK_URL \
+      RENDER_API_KEY RENDER_SERVICE_ID RENDER_SERVICE_NAME RENDER_DEPLOY_HOOK_URL \
       FLY_API_TOKEN FLY_APP_NAME FLY_CONFIG FLY_STRATEGY \
       DEPLOY_ENVIRONMENT
     export SCRIPTS_DIR
@@ -336,7 +336,22 @@ assert_true "render: the deploy-hook path warns that it cannot fail on a bad dep
   "grep -q 'cannot fail' <<< \"\$OUT\""
 
 run_provider render RENDER_API_KEY="$SENTINEL"
-assert_true "render: an API key without a service id fails the job" "[[ $STATUS -eq 1 ]]"
+assert_true "render: an API key with neither a service id nor a name fails the job" \
+  "[[ $STATUS -eq 1 ]]"
+assert_true "render: that failure names both ways to identify the service" \
+  "grep -q 'RENDER_SERVICE_NAME' <<< \"\$OUT\""
+
+# A name is resolved through the API, which a dry run must not call: resolution
+# is a read, but it still needs a live key and a reachable Render, and every
+# provider in this suite runs under DEPLOY_DRY_RUN. Without the guard this case
+# reaches out to api.render.com with the sentinel token.
+run_provider render RENDER_API_KEY="$SENTINEL" RENDER_SERVICE_NAME=api-staging
+assert_true "render: a service name is accepted in place of an id" "[[ $STATUS -eq 0 ]]"
+assert_true "render: a dry run records the lookup instead of performing it" \
+  "grep -q 'DRY RUN (no lookup performed)' <<< \"\$OUT\""
+assert_true "render: the dry-run receipt names the service that would be resolved" \
+  "grep -q 'api-staging' <<< \"\$CMD\" || grep -q 'api-staging' <<< \"\$OUT\""
+assert_no_leak "render: the API key is never recorded while resolving a name"
 
 # Exercise `render_api` directly with curl stubbed to echo its config. A GET
 # carrying a request body is rejected outright by some servers and proxies,

--- a/.github/tests/test-go-validation.sh
+++ b/.github/tests/test-go-validation.sh
@@ -3,6 +3,25 @@
 # This script creates multiple test scenarios to ensure the script works correctly
 # and reports comprehensive coverage including files without tests
 
+# Resolved from this script's own location rather than hardcoded.
+#
+# Every invocation below used to name `/home/runner/work/pipelines/pipelines/...`, the workspace
+# path of a GitHub-hosted runner. That made the suite pass only there: on a self-hosted runner, in
+# a container, or on a maintainer's machine it failed with `run.sh: not found` -- a message that
+# reads like the script is missing rather than like the path is wrong. `make test` has therefore
+# been red locally for anyone who ran it.
+#
+# POSIX `sh`, so no `BASH_SOURCE`: `$0` is the script's path and is enough, since the layout below
+# it is fixed.
+SCRIPTS_DIR="${SCRIPTS_DIR:-$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)}"
+GO_TEST_RUN="$SCRIPTS_DIR/global/scripts/languages/golang/test/run.sh"
+
+if [ ! -x "$GO_TEST_RUN" ]; then
+  echo "ERROR: the Go test runner was not found at $GO_TEST_RUN" >&2
+  echo "SCRIPTS_DIR resolved to '$SCRIPTS_DIR'; set it explicitly to override." >&2
+  exit 1
+fi
+
 echo "=== Testing Go Test Script with Comprehensive Coverage ==="
 
 # Test 1: Project with build tags and complete coverage
@@ -131,7 +150,7 @@ EOF
 
 cd "$TEST_DIR_COMPLETE"
 echo "Running comprehensive coverage test..."
-if /home/runner/work/pipelines/pipelines/global/scripts/languages/golang/test/run.sh; then
+if "$GO_TEST_RUN"; then
   echo "✓ Test 1 PASSED: Comprehensive coverage with build tags"
   echo "Verifying that untested package appears in coverage:"
   if grep -q "pkg/utils" coverage.txt; then
@@ -236,7 +255,7 @@ EOF
 
 cd "$TEST_DIR_NO_TAGS"
 echo "Running backward compatibility test with complete coverage..."
-if /home/runner/work/pipelines/pipelines/global/scripts/languages/golang/test/run.sh; then
+if "$GO_TEST_RUN"; then
   echo "✓ Test 2 PASSED: Backward compatibility with complete coverage"
   if grep -q "pkg/utils" coverage.txt; then
     echo "✓ Untested package correctly included in coverage report"
@@ -296,7 +315,7 @@ EOF
 
 cd "$TEST_DIR_NO_TESTS"
 echo "Running test with no test files (should handle gracefully)..."
-if /home/runner/work/pipelines/pipelines/global/scripts/languages/golang/test/run.sh; then
+if "$GO_TEST_RUN"; then
   echo "✓ Test 3 PASSED: No test files scenario handled gracefully"
 else
   echo "✗ Test 3 FAILED: No test files scenario"
@@ -392,7 +411,7 @@ EOF
 
 cd "$TEST_DIR_WITH_TEST_FOLDER"
 echo "Running test with test folder (should exclude test packages from coverage)..."
-if /home/runner/work/pipelines/pipelines/global/scripts/languages/golang/test/run.sh; then
+if "$GO_TEST_RUN"; then
   echo "✓ Test 4 PASSED: Test folder exclusion scenario"
   
   # Verify that test packages are NOT included in coverage
@@ -476,7 +495,7 @@ EOF
 cd "$TEST_DIR_FLAT" || exit 1
 echo "Running non-conventional layout test (should fall back to ./...)..."
 FALLBACK_LOG="/tmp/go-test-validation-flat-layout.log"
-if /home/runner/work/pipelines/pipelines/global/scripts/languages/golang/test/run.sh > "$FALLBACK_LOG" 2>&1; then
+if "$GO_TEST_RUN" > "$FALLBACK_LOG" 2>&1; then
   cat "$FALLBACK_LOG"
   echo "✓ Test 5 PASSED: Non-conventional layout handled via ./... fallback"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - changed the golang pipeline version from `1.26.5` to `1.26.6`
 - changed the java pipeline version from `17` to `25`
 
+### Fixed
+
+- fixed `test-go-validation.sh` naming `/home/runner/work/pipelines/pipelines/...` in five places -- the workspace path of a GitHub-hosted runner. The suite therefore passed only there: on a self-hosted runner, in a container or on a maintainer's machine every case failed with `run.sh: not found`, which reads like the runner script is missing rather than like the path is wrong, and it made `make test` red for anyone who ran it locally. The path is derived from the script's own location now, with `SCRIPTS_DIR` still able to override it, and a missing runner reports where it looked
+- fixed the `basic-checks` fixtures inheriting the developer's commit-signing configuration. They create throwaway git repositories and commit into them, so a machine with `commit.gpgsign = true` set globally -- and a signer needing an unlocked agent -- failed every one with `failed to write commit object`, surfacing as a bare `Error 128` from make that reads like a broken fixture. Signing is now disabled in those repositories explicitly; nothing they contain is ever published, so a signature proved nothing
+
 ## [4.21.0] - 2026-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added a `render_service_name` input to the Render deployment action, so a caller whose service name is derived -- `api-staging` on a branch, `api-production` on a tag -- needs no per-environment secret at all. The name is a value the workflow already knows, while a service id is one more thing to store, rotate and get wrong; a stale id is also the worse failure, because it deploys the WRONG service and reports success. `render_service_id` still works and still wins when both are given. The lookup is deliberately strict: `GET /services?name=` is a **substring filter** rather than an exact lookup, so asking for `api` answers `api-staging` and `api-production` too -- every candidate is compared to the requested name exactly, and a name matching more than one service is refused with the ids listed rather than resolved to whichever sorted first. It resolves an existing service and never creates one, so a name that matches nothing fails with the two ways to fix it
+
 ## [4.22.0] - 2026-08-15
 
 ### Added

--- a/azure-devops/global/stages/50-deployment/render.yaml
+++ b/azure-devops/global/stages/50-deployment/render.yaml
@@ -8,6 +8,9 @@ parameters:
   - name: 'RENDER_SERVICE_ID'
     type: 'string'
     default: "$(RENDER_SERVICE_ID)"
+  - name: 'RENDER_SERVICE_NAME'
+    type: 'string'
+    default: "$(RENDER_SERVICE_NAME)"
   - name: 'RENDER_DEPLOY_HOOK_URL'
     type: 'string'
     default: ''
@@ -39,6 +42,7 @@ jobs:
         env:
           RENDER_API_KEY: ${{ parameters.RENDER_API_KEY }}
           RENDER_SERVICE_ID: ${{ parameters.RENDER_SERVICE_ID }}
+          RENDER_SERVICE_NAME: ${{ parameters.RENDER_SERVICE_NAME }}
           RENDER_DEPLOY_HOOK_URL: ${{ parameters.RENDER_DEPLOY_HOOK_URL }}
           RENDER_POLL_TIMEOUT: ${{ parameters.POLL_TIMEOUT }}
           DEPLOY_ENVIRONMENT: ${{ parameters.ENVIRONMENT }}

--- a/github/global/stages/50-deployment/render/action.yaml
+++ b/github/global/stages/50-deployment/render/action.yaml
@@ -8,7 +8,25 @@ inputs:
     required: false
     default: ''
   render_service_id:
-    description: 'Service id (starts with `srv-`), from the service dashboard URL. Required with `render_api_key`.'
+    description: |
+      Service id (starts with `srv-`), from the service dashboard URL. Give this
+      or `render_service_name` alongside `render_api_key`; the id wins when both
+      are set, because it names one service and cannot be ambiguous.
+    type: 'string'
+    required: false
+    default: ''
+  render_service_name:
+    description: |
+      Service name, as it appears in the dashboard. Resolved to an id through the
+      API before the deploy.
+
+      It exists so a caller whose service name is DERIVED -- `api-staging` on a
+      branch, `api-production` on a tag -- needs no per-environment secret at
+      all: the name is a value the workflow already knows, while an id is one
+      more thing to store, rotate and get wrong. A stale id also fails silently
+      in the worst way, by deploying the wrong service.
+
+      The lookup is exact and refuses an ambiguous match rather than guessing.
     type: 'string'
     required: false
     default: ''
@@ -52,6 +70,7 @@ runs:
       env:
         RENDER_API_KEY: '${{ inputs.render_api_key }}'
         RENDER_SERVICE_ID: '${{ inputs.render_service_id }}'
+        RENDER_SERVICE_NAME: '${{ inputs.render_service_name }}'
         RENDER_DEPLOY_HOOK_URL: '${{ inputs.render_deploy_hook_url }}'
         RENDER_POLL_TIMEOUT: '${{ inputs.poll_timeout }}'
         DEPLOY_ENVIRONMENT: '${{ inputs.environment }}'

--- a/gitlab/global/stages/50-deployment/render.yaml
+++ b/gitlab/global/stages/50-deployment/render.yaml
@@ -5,9 +5,13 @@ include:
 # Deploy to Render.
 #
 # Required CI/CD variables -- one of these two pairings (mask the secret):
-#   RENDER_API_KEY + RENDER_SERVICE_ID   (preferred: the deploy is polled to a
-#                                         terminal state, so this job fails when
-#                                         the deploy fails)
+#   RENDER_API_KEY + RENDER_SERVICE_ID     (preferred: the deploy is polled to a
+#                                           terminal state, so this job fails
+#                                           when the deploy fails)
+#   RENDER_API_KEY + RENDER_SERVICE_NAME   (same, naming the service instead of
+#                                           identifying it -- for a name derived
+#                                           per environment, which needs no
+#                                           per-environment variable at all)
 #   RENDER_DEPLOY_HOOK_URL               (fire-and-forget: Render acknowledges
 #                                         the request without reporting the
 #                                         build result, so the job cannot fail
@@ -39,4 +43,5 @@ deployment:render:
   timeout: '45 minutes'
   rules:
     - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $RENDER_SERVICE_ID"
+    - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $RENDER_SERVICE_NAME"
     - if: "$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $RENDER_DEPLOY_HOOK_URL"

--- a/global/scripts/deploy/render/run.sh
+++ b/global/scripts/deploy/render/run.sh
@@ -80,8 +80,15 @@ if [ -z "${RENDER_API_KEY:-}" ]; then
 fi
 
 # ----------------------------------------------------------------- API path --
-deploy_require_env "RENDER_SERVICE_ID" \
-  "The service id (starts with 'srv-'), from the service's dashboard URL."
+# Either names the service. The id is exact; the name is resolved through the API
+# below, which is what lets a caller derive it (`api-staging` / `api-production`)
+# instead of storing one more secret per environment.
+if [ -z "${RENDER_SERVICE_ID:-}" ] && [ -z "${RENDER_SERVICE_NAME:-}" ]; then
+  echo "ERROR: set RENDER_SERVICE_ID or RENDER_SERVICE_NAME." >&2
+  echo "  RENDER_SERVICE_ID   the id from the service's dashboard URL (starts with 'srv-')." >&2
+  echo "  RENDER_SERVICE_NAME the service name, resolved to an id before deploying." >&2
+  exit 1
+fi
 
 if ! command -v jq > /dev/null 2>&1; then
   echo "ERROR: jq is required to parse the Render API response but is not installed." >&2
@@ -119,6 +126,57 @@ render_api() {
 
   return $?
 }
+
+# Resolve a name to an id, when the caller gave a name instead of an id.
+#
+# `GET /v1/services?name=<name>` is a FILTER, not an exact lookup: Render matches
+# on substring, so asking for `api` also answers `api-staging` and
+# `api-production`. Every candidate is therefore compared to the requested name
+# exactly, here, rather than trusting the first element -- deploying whichever
+# service happened to sort first is the kind of mistake that looks like a
+# successful deploy.
+#
+# `type=web_service` narrows it further: a name may be reused across service
+# types in one workspace, and this action deploys a web service.
+if [ -z "${RENDER_SERVICE_ID:-}" ]; then
+  echo "Resolving Render service '$RENDER_SERVICE_NAME'..."
+  # `--data-urlencode` on a GET would turn it into a POST body, so the name is
+  # percent-encoded here instead. Only the characters a Render service name can
+  # legally contain need escaping, and `jq -rR @uri` does it without adding a
+  # dependency this script does not already have.
+  ENCODED_NAME=$(printf '%s' "$RENDER_SERVICE_NAME" | jq -rR @uri)
+  LOOKUP_RESPONSE=$(render_api "GET" "/services?name=$ENCODED_NAME&type=web_service&limit=100")
+  if [ -z "$LOOKUP_RESPONSE" ]; then
+    echo "ERROR: the Render API returned nothing when looking up '$RENDER_SERVICE_NAME'." >&2
+    echo "Check that RENDER_API_KEY belongs to the workspace that owns the service." >&2
+    exit 1
+  fi
+
+  # The list endpoint wraps each item in `{cursor, service}`; a future shape that
+  # returns the service flat is tolerated by looking in both places.
+  MATCHES=$(printf '%s' "$LOOKUP_RESPONSE" \
+    | jq -r --arg name "$RENDER_SERVICE_NAME" \
+        '[.[] | (.service // .) | select(.name == $name) | .id] | unique | .[]')
+
+  MATCH_COUNT=$(printf '%s' "$MATCHES" | grep -c . || true)
+  if [ "$MATCH_COUNT" -eq 0 ]; then
+    echo "ERROR: no web service named '$RENDER_SERVICE_NAME' in this workspace." >&2
+    echo "This action deploys an existing service; it does not create one." >&2
+    echo "Create it once (dashboard or Blueprint), then re-run -- or pass RENDER_SERVICE_ID." >&2
+    exit 1
+  fi
+  if [ "$MATCH_COUNT" -gt 1 ]; then
+    echo "ERROR: '$RENDER_SERVICE_NAME' matched $MATCH_COUNT services:" >&2
+    printf '%s\n' "$MATCHES" | while IFS= read -r _match; do
+      [ -n "$_match" ] && echo "  $_match" >&2
+    done
+    echo "Refusing to guess which one to deploy; pass RENDER_SERVICE_ID." >&2
+    exit 1
+  fi
+
+  RENDER_SERVICE_ID=$MATCHES
+  echo "Resolved '$RENDER_SERVICE_NAME' to $RENDER_SERVICE_ID."
+fi
 
 if ! deploy_note_command "curl --config - # POST $RENDER_API_URL/services/$RENDER_SERVICE_ID/deploys"; then
   deploy_record "$PROVIDER" "$RENDER_SERVICE_ID"

--- a/global/scripts/deploy/render/run.sh
+++ b/global/scripts/deploy/render/run.sh
@@ -139,24 +139,74 @@ render_api() {
 # `type=web_service` narrows it further: a name may be reused across service
 # types in one workspace, and this action deploys a web service.
 if [ -z "${RENDER_SERVICE_ID:-}" ]; then
+  # A dry run must not call the API. Resolution is a read, but it still needs a
+  # live key and a reachable Render, which is exactly what a dry run promises not
+  # to require -- and the validation suite runs every provider this way.
+  if deploy_is_dry_run; then
+    echo "DRY RUN (no lookup performed): GET $RENDER_API_URL/services?name=$RENDER_SERVICE_NAME"
+    deploy_record "$PROVIDER" "$RENDER_SERVICE_NAME"
+    exit 0
+  fi
+
   echo "Resolving Render service '$RENDER_SERVICE_NAME'..."
   # `--data-urlencode` on a GET would turn it into a POST body, so the name is
   # percent-encoded here instead. Only the characters a Render service name can
   # legally contain need escaping, and `jq -rR @uri` does it without adding a
   # dependency this script does not already have.
   ENCODED_NAME=$(printf '%s' "$RENDER_SERVICE_NAME" | jq -rR @uri)
-  LOOKUP_RESPONSE=$(render_api "GET" "/services?name=$ENCODED_NAME&type=web_service&limit=100")
-  if [ -z "$LOOKUP_RESPONSE" ]; then
-    echo "ERROR: the Render API returned nothing when looking up '$RENDER_SERVICE_NAME'." >&2
-    echo "Check that RENDER_API_KEY belongs to the workspace that owns the service." >&2
-    exit 1
-  fi
 
-  # The list endpoint wraps each item in `{cursor, service}`; a future shape that
-  # returns the service flat is tolerated by looking in both places.
-  MATCHES=$(printf '%s' "$LOOKUP_RESPONSE" \
-    | jq -r --arg name "$RENDER_SERVICE_NAME" \
-        '[.[] | (.service // .) | select(.name == $name) | .id] | unique | .[]')
+  # Paginated, because the list endpoint caps a page and a workspace can hold
+  # more services than one page carries. Without this an exact match on page two
+  # is reported as "no service named ...", which sends the reader looking for a
+  # service that exists. The cursor is the last item's, per Render's own scheme.
+  RENDER_PAGE_SIZE=${RENDER_PAGE_SIZE:-100}
+  MATCHES=""
+  CURSOR=""
+  # Bounded so a server that keeps answering a full page can never spin forever:
+  # 100 pages of 100 is 10,000 services, past any real workspace.
+  PAGE=0
+  while [ "$PAGE" -lt 100 ]; do
+    PAGE=$((PAGE + 1))
+    LOOKUP_PATH="/services?name=$ENCODED_NAME&type=web_service&limit=$RENDER_PAGE_SIZE"
+    if [ -n "$CURSOR" ]; then
+      LOOKUP_PATH="$LOOKUP_PATH&cursor=$CURSOR"
+    fi
+
+    LOOKUP_RESPONSE=$(render_api "GET" "$LOOKUP_PATH")
+    if [ -z "$LOOKUP_RESPONSE" ]; then
+      echo "ERROR: the Render API returned nothing when looking up '$RENDER_SERVICE_NAME'." >&2
+      echo "Check that RENDER_API_KEY belongs to the workspace that owns the service." >&2
+      exit 1
+    fi
+
+    # The list endpoint wraps each item in `{cursor, service}`; a future shape
+    # that returns the service flat is tolerated by looking in both places.
+    #
+    # Only ids that LOOK like a Render service id are kept. An item missing `id`
+    # would otherwise reach `jq -r` as the string `null` and be deployed as
+    # `/services/null/deploys` -- a request that fails far from its cause.
+    PAGE_MATCHES=$(printf '%s' "$LOOKUP_RESPONSE" \
+      | jq -r --arg name "$RENDER_SERVICE_NAME" \
+          '[.[] | (.service // .)
+             | select(.name == $name)
+             | .id
+             | select(type == "string" and startswith("srv-"))] | .[]')
+    if [ -n "$PAGE_MATCHES" ]; then
+      MATCHES=$(printf '%s\n%s' "$MATCHES" "$PAGE_MATCHES" | grep -v '^$' | sort -u)
+    fi
+
+    PAGE_COUNT=$(printf '%s' "$LOOKUP_RESPONSE" | jq -r 'length')
+    if [ "$PAGE_COUNT" -lt "$RENDER_PAGE_SIZE" ]; then
+      break
+    fi
+    CURSOR=$(printf '%s' "$LOOKUP_RESPONSE" | jq -r '.[-1].cursor // empty')
+    if [ -z "$CURSOR" ]; then
+      # A full page with no cursor to continue from: report the cap rather than
+      # claiming the service does not exist.
+      echo "WARNING: the service list returned a full page with no cursor; results may be truncated." >&2
+      break
+    fi
+  done
 
   MATCH_COUNT=$(printf '%s' "$MATCHES" | grep -c . || true)
   if [ "$MATCH_COUNT" -eq 0 ]; then


### PR DESCRIPTION
A consumer (`medhub-tech/backend`) deploys one API to two environments — `api-staging` from `main`,
`api-production` from a tag. The service name is **derived from the ref**, but the action could only
be told an id, so each environment needed its own `RENDER_SERVICE_ID` secret to say something the
workflow already knew.

## What this adds

`render_service_name`, resolved to an id through the API before the deploy. `render_service_id`
still works and still wins when both are given — it names one service and cannot be ambiguous.

```yaml
render_service_name: 'api-${{ env.DEPLOY_ENVIRONMENT }}'
```

A name is better than an id here for a reason beyond convenience: **a stale id fails in the worst
possible way.** It deploys the wrong service and reports success. A stale name cannot — it either
resolves to the service that carries it, or fails saying so.

## The lookup is strict, deliberately

`GET /v1/services?name=` is a **substring filter**, not an exact lookup. Asking for `api` answers
`api-staging` and `api-production` too, so trusting the first element would deploy whichever service
happened to sort first — a mistake that looks exactly like a successful deploy.

So every candidate is compared to the requested name exactly, and:

- **no match** → fails, saying the action deploys an existing service rather than creating one, and
  naming the two ways forward (create it once, or pass an id);
- **more than one match** → fails with the ids listed, rather than guessing.

`type=web_service` narrows it further, since a name can be reused across service types in one
workspace.

## Verified

The action cannot be exercised end to end without a Render key, so the resolution logic was tested
directly against the documented payload shape:

| case | result |
|---|---|
| `api-staging` among three similar names | 1 match → `srv-aaa` |
| `api-production` | 1 match → `srv-ccc` |
| `api` (the substring trap) | 0 matches → fails rather than deploying `api-staging` |
| same name twice | 2 matches → refuses, lists both |
| flat `{id,name}` instead of `{cursor,service}` | tolerated |
| a name with a space and a slash | percent-encoded correctly |

`sh -n` passes and `shellcheck -s sh` reports no new findings — the four it does report are
pre-existing and untouched.

**Not implemented: creating the service.** It was considered and rejected. Creation needs the full
spec — runtime, region, plan, dockerfile path, health check, env vars — which would add roughly
eight inputs to this action and duplicate what a Blueprint already declares. That is more
configuration, not less, and the point of this change is less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8RnQJp6KhiQH65XDyLrCV