### PR TITLE
fix(azure): remove duplicate scripts-repo include in govulncheck job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - fixed `global/containers/bfg.latest/Dockerfile`, which **could not build**: `openjdk:8-jre` was removed when the `openjdk` Docker Official Image was deprecated, so the `FROM` 404s. Moved to `eclipse-temurin:8-jre`, the maintained successor upstream points to
 - fixed the GitLab SAM delivery job's base image, which referenced `ghcr.io/rios0rios0/pipelines/golang:1.19-awscli` -- a Go `1.19` image whose build directory no longer exists in this repository, so it can never receive another security update. Moved to the `1.26-awscli` image that is still built here
 - fixed a `-print0` that `yaml_files()` silently swallowed in the new supply-chain test, which had made three of its assertions pass without examining a single file. Every assertion in that suite was then individually proven to fire against a deliberate violation
+- fixed the Azure DevOps `sca:govulncheck` job, which failed with `The step name Scripts appears more than once` because it included the `scripts-repo` abstract twice -- directly and via `abstracts/go.yaml`. Dropped the redundant direct include
 
 ### Security
 

--- a/azure-devops/golang/stages/20-security/go.yaml
+++ b/azure-devops/golang/stages/20-security/go.yaml
@@ -28,7 +28,6 @@ stages:
           GOPATH: "$(Pipeline.Workspace)/.go"
         steps:
           - template: '../../abstracts/go.yaml'
-          - template: '../../../global/abstracts/scripts-repo.yaml'
 
           # Delegates to the shared runner instead of inlining `go install`, which is
           # what GitHub Actions already did and what this repository's architecture


### PR DESCRIPTION
- the sca:govulncheck job included the scripts-repo abstract twice: once directly and once transitively via abstracts/go.yaml, producing two steps named Scripts and failing with The step name Scripts appears more than once
- dropped the redundant direct include; abstracts/go.yaml already checks out the scripts and sets Scripts.Directory

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
