### PR TITLE
fix(golang): skip the setup-go cache on self-hosted runners

### DIFF
--- a/github/golang/stages/10-code-check/cross-compile/action.yaml
+++ b/github/golang/stages/10-code-check/cross-compile/action.yaml
@@ -19,6 +19,20 @@ runs:
       with:
         go-version-file: 'go.mod'
         cache-dependency-path: 'go.sum'
+        # Skipped on a self-hosted runner, where GOMODCACHE and GOCACHE persist on local
+        # disk between jobs. There the restore is not merely redundant -- it untars the archive
+        # over files that already exist, `tar` exits 2 with `Cannot open: File exists`, the
+        # action logs `Failed to restore`, and the entire download is discarded. Measured on a
+        # 12-vCPU self-hosted runner: 2.3-2.5 GB pulled at ~8 MB/s, 344-702s PER JOB across four
+        # jobs of the same run, against 1s when that job happens to miss the cache.
+        #
+        # This is the reasoning the codeql stage already applies, read the other way round: it
+        # skips the cache because its runner is thrown away, and these skip it because theirs
+        # is not.
+        #
+        # `!= 'self-hosted'` rather than `== 'github-hosted'` so an empty context keeps
+        # today's behaviour instead of silently disabling the cache for hosted consumers.
+        cache: ${{ runner.environment != 'self-hosted' }}
 
     - uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
 

--- a/github/golang/stages/10-code-check/golangci-lint/action.yaml
+++ b/github/golang/stages/10-code-check/golangci-lint/action.yaml
@@ -9,6 +9,20 @@ runs:
       with:
         go-version-file: 'go.mod'
         cache-dependency-path: 'go.sum'
+        # Skipped on a self-hosted runner, where GOMODCACHE and GOCACHE persist on local
+        # disk between jobs. There the restore is not merely redundant -- it untars the archive
+        # over files that already exist, `tar` exits 2 with `Cannot open: File exists`, the
+        # action logs `Failed to restore`, and the entire download is discarded. Measured on a
+        # 12-vCPU self-hosted runner: 2.3-2.5 GB pulled at ~8 MB/s, 344-702s PER JOB across four
+        # jobs of the same run, against 1s when that job happens to miss the cache.
+        #
+        # This is the reasoning the codeql stage already applies, read the other way round: it
+        # skips the cache because its runner is thrown away, and these skip it because theirs
+        # is not.
+        #
+        # `!= 'self-hosted'` rather than `== 'github-hosted'` so an empty context keeps
+        # today's behaviour instead of silently disabling the cache for hosted consumers.
+        cache: ${{ runner.environment != 'self-hosted' }}
 
     - uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
 

--- a/github/golang/stages/10-code-check/openapi-sync/action.yaml
+++ b/github/golang/stages/10-code-check/openapi-sync/action.yaml
@@ -26,6 +26,20 @@ runs:
       with:
         go-version-file: 'go.mod'
         cache-dependency-path: 'go.sum'
+        # Skipped on a self-hosted runner, where GOMODCACHE and GOCACHE persist on local
+        # disk between jobs. There the restore is not merely redundant -- it untars the archive
+        # over files that already exist, `tar` exits 2 with `Cannot open: File exists`, the
+        # action logs `Failed to restore`, and the entire download is discarded. Measured on a
+        # 12-vCPU self-hosted runner: 2.3-2.5 GB pulled at ~8 MB/s, 344-702s PER JOB across four
+        # jobs of the same run, against 1s when that job happens to miss the cache.
+        #
+        # This is the reasoning the codeql stage already applies, read the other way round: it
+        # skips the cache because its runner is thrown away, and these skip it because theirs
+        # is not.
+        #
+        # `!= 'self-hosted'` rather than `== 'github-hosted'` so an empty context keeps
+        # today's behaviour instead of silently disabling the cache for hosted consumers.
+        cache: ${{ runner.environment != 'self-hosted' }}
 
     - name: 'Load Custom Configuration'
       shell: 'bash'

--- a/github/golang/stages/20-security/govulncheck/action.yaml
+++ b/github/golang/stages/20-security/govulncheck/action.yaml
@@ -9,6 +9,20 @@ runs:
       with:
         go-version-file: 'go.mod'
         cache-dependency-path: 'go.sum'
+        # Skipped on a self-hosted runner, where GOMODCACHE and GOCACHE persist on local
+        # disk between jobs. There the restore is not merely redundant -- it untars the archive
+        # over files that already exist, `tar` exits 2 with `Cannot open: File exists`, the
+        # action logs `Failed to restore`, and the entire download is discarded. Measured on a
+        # 12-vCPU self-hosted runner: 2.3-2.5 GB pulled at ~8 MB/s, 344-702s PER JOB across four
+        # jobs of the same run, against 1s when that job happens to miss the cache.
+        #
+        # This is the reasoning the codeql stage already applies, read the other way round: it
+        # skips the cache because its runner is thrown away, and these skip it because theirs
+        # is not.
+        #
+        # `!= 'self-hosted'` rather than `== 'github-hosted'` so an empty context keeps
+        # today's behaviour instead of silently disabling the cache for hosted consumers.
+        cache: ${{ runner.environment != 'self-hosted' }}
 
     - uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
 

--- a/github/golang/stages/30-tests/all/action.yaml
+++ b/github/golang/stages/30-tests/all/action.yaml
@@ -117,6 +117,20 @@ runs:
       with:
         go-version-file: 'go.mod'
         cache-dependency-path: 'go.sum'
+        # Skipped on a self-hosted runner, where GOMODCACHE and GOCACHE persist on local
+        # disk between jobs. There the restore is not merely redundant -- it untars the archive
+        # over files that already exist, `tar` exits 2 with `Cannot open: File exists`, the
+        # action logs `Failed to restore`, and the entire download is discarded. Measured on a
+        # 12-vCPU self-hosted runner: 2.3-2.5 GB pulled at ~8 MB/s, 344-702s PER JOB across four
+        # jobs of the same run, against 1s when that job happens to miss the cache.
+        #
+        # This is the reasoning the codeql stage already applies, read the other way round: it
+        # skips the cache because its runner is thrown away, and these skip it because theirs
+        # is not.
+        #
+        # `!= 'self-hosted'` rather than `== 'github-hosted'` so an empty context keeps
+        # today's behaviour instead of silently disabling the cache for hosted consumers.
+        cache: ${{ runner.environment != 'self-hosted' }}
 
     # Resolve the directory `go install` actually targets. `go install`
     # honours `$GOBIN` if set, otherwise falls back to `$(go env GOPATH)/bin`.


### PR DESCRIPTION
## The defect

`actions/setup-go` restores `GOMODCACHE` and `GOCACHE` from GitHub's cache service. On a **self-hosted** runner those directories persist on local disk between jobs, so the archive is untarred over files that already exist:

```
Cache hit for: setup-go-Linux-x64-undefined-go-1.25.7-6f6b58...
Received 2302914179 of 2302914179 (100.0%), 8.4 MBs/sec
/usr/bin/tar: .../go/pkg/mod/modernc.org/libc@v1.74.3/builtin32.go: Cannot open: File exists
  ... tens of thousands of identical lines ...
/usr/bin/tar: Exiting with failure status due to previous errors
##[warning]Failed to restore: "/usr/bin/tar" failed with error: exit code 2
Cache is not found
```

**2.3 GB downloaded at ~8 MB/s, then discarded.** The restore cannot succeed, so the cost is paid on every run and nothing is ever gained.

## Measured

One repository, one workflow run (`main` of a private consumer), four jobs that call these stages:

| Job | Total | inside `setup-go` | Downloaded |
|---|---|---|---|
| `code-check > style:golangci-lint` | 422s | **356s** | 2.25 GB |
| `code-check > docs:openapi-sync` | 422s | **344s** | 2.25 GB |
| `security > sca:govulncheck` | 457s | **376s** | 2.25 GB |
| `tests > test:all` | 505s | **345s** | 2.25 GB |

~9 GB per pipeline run, all of it thrown away. The worst single observation was **702s** in one job.

The jobs on the same runner that do *not* call `setup-go` are unaffected: `gitleaks` 15s, `hadolint` 13s, `semgrep` 34s, `basic-checks` 11s. And `codeql` — which already sets `cache: false` — runs in 116s.

When a job happens to **miss** the cache, `setup-go` completes in **1s** and the same suite finishes in `19s / 13s / 32s / 107s`.

## The change

One line per stage:

```yaml
cache: ${{ runner.environment != 'self-hosted' }}
```

This is the reasoning the `codeql` stage already applies, read the other way round. Its comment says:

> The analysis compiles the module once and **the runner is thrown away**; a cache keyed on a lockfile this action never resolves would cost more to warm than it saves.

A self-hosted runner is precisely the one that is *not* thrown away — so the same conclusion follows from the opposite premise.

`!= 'self-hosted'` rather than `== 'github-hosted'`: if the context were ever empty, this keeps today's behaviour instead of silently disabling the cache for hosted consumers.

## Blast radius

**Hosted consumers are unaffected** — `runner.environment` is `github-hosted` there, the expression is `true`, and the cache behaves exactly as it does today. Only self-hosted consumers change, and for them the cache never worked in the first place.

Stages touched: `golangci-lint`, `openapi-sync`, `cross-compile`, `govulncheck`, `30-tests/all`. The 7 MB `actions/cache` for the test-tool binaries in `30-tests/all` is **left alone** — that one restores into a directory the job creates, it works, and it saves a `go install` chain on every run.

## Why not an input

An input would put the burden on every self-hosted consumer to discover this and set it. The runner already knows which kind it is.
