### PR TITLE
fix(basic-checks): detected chlog by the fragment directory too

### DIFF
--- a/.changes/unreleased/1787713808476568893-f80e.yaml
+++ b/.changes/unreleased/1787713808476568893-f80e.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'fixed the changelog check in `basic-checks` treating a repository as non-chlog when it carries no `.chlog.yaml`. Detection now also accepts `.chlog.yml` and a `.changes/unreleased/` directory, mirroring AutoBump''s `DetectChlog`. The config file is optional -- chlog falls back to its built-in defaults when none is found -- so a project that dropped the redundant config fell through to the plain `CHANGELOG.md` branch and was asked to hand-edit a changelog it generates from fragments. Applied to the GitHub, Azure DevOps, and GitLab variants'
+time: '2026-08-26T03:10:08.476510872Z'

--- a/azure-devops/global/stages/10-code-check/basic-checks.yaml
+++ b/azure-devops/global/stages/10-code-check/basic-checks.yaml
@@ -56,8 +56,15 @@ jobs:
           echo ""
           echo "=== Changelog Check ==="
 
-          if [ -f ".chlog.yaml" ]; then
-            echo "Detected chlog-based changelog (found .chlog.yaml)."
+          # A repository counts as a chlog user when it commits a config file OR when it
+          # merely carries the fragment directory: the config is optional, and chlog falls
+          # back to its built-in defaults when none is found. Testing only for .chlog.yaml
+          # made a repository that dropped the redundant config fall through to the plain
+          # CHANGELOG.md branch below, demanding a hand-edited changelog from a project that
+          # generates it from fragments. Mirrors AutoBump's DetectChlog so the two cannot
+          # disagree about whether a repository uses chlog.
+          if [ -f ".chlog.yaml" ] || [ -f ".chlog.yml" ] || [ -d ".changes/unreleased" ]; then
+            echo "Detected chlog-based changelog."
 
             case "$SOURCE_BRANCH" in
               chore/bump-*|bump/*)

--- a/github/global/stages/10-code-check/basic-checks/action.yaml
+++ b/github/global/stages/10-code-check/basic-checks/action.yaml
@@ -67,8 +67,15 @@ runs:
           exit 0
         fi
 
-        if [ -f ".chlog.yaml" ]; then
-          echo "Detected chlog-based changelog (found .chlog.yaml)."
+        # A repository counts as a chlog user when it commits a config file OR when it
+        # merely carries the fragment directory: the config is optional, and chlog falls
+        # back to its built-in defaults when none is found. Testing only for .chlog.yaml
+        # made a repository that dropped the redundant config fall through to the plain
+        # CHANGELOG.md branch below, demanding a hand-edited changelog from a project that
+        # generates it from fragments. Mirrors AutoBump's DetectChlog so the two cannot
+        # disagree about whether a repository uses chlog.
+        if [ -f ".chlog.yaml" ] || [ -f ".chlog.yml" ] || [ -d ".changes/unreleased" ]; then
+          echo "Detected chlog-based changelog."
 
           case "$SOURCE_BRANCH" in
             chore/bump-*|bump/*)

--- a/gitlab/global/stages/10-code-check/basic-checks.yaml
+++ b/gitlab/global/stages/10-code-check/basic-checks.yaml
@@ -40,8 +40,15 @@ quality:basic-checks:
       echo ""
       echo "=== Changelog Check ==="
 
-      if [ -f ".chlog.yaml" ]; then
-        echo "Detected chlog-based changelog (found .chlog.yaml)."
+      # A repository counts as a chlog user when it commits a config file OR when it
+      # merely carries the fragment directory: the config is optional, and chlog falls
+      # back to its built-in defaults when none is found. Testing only for .chlog.yaml
+      # made a repository that dropped the redundant config fall through to the plain
+      # CHANGELOG.md branch below, demanding a hand-edited changelog from a project that
+      # generates it from fragments. Mirrors AutoBump's DetectChlog so the two cannot
+      # disagree about whether a repository uses chlog.
+      if [ -f ".chlog.yaml" ] || [ -f ".chlog.yml" ] || [ -d ".changes/unreleased" ]; then
+        echo "Detected chlog-based changelog."
 
         case "$SOURCE_BRANCH" in
           chore/bump-*|bump/*)


### PR DESCRIPTION
## What

`basic-checks` now treats a repository as a chlog user when it carries `.chlog.yaml`, `.chlog.yml`, **or** a `.changes/unreleased/` directory — previously only `.chlog.yaml`. Applied to the GitHub, Azure DevOps, and GitLab variants.

## Why

The changelog check branched on `[ -f ".chlog.yaml" ]` alone. But the config file is **optional**: chlog's `LoadConfig()` returns `DefaultConfig()` on `ErrConfigNotFound`, and its docs say "Defaults used when not found."

So a chlog project that committed no config — or that dropped a redundant one — fell through to the `else` branch and was told:

```
ERROR: CHANGELOG.md was NOT modified.
Every change must include an entry in CHANGELOG.md under the [Unreleased] section.
```

That is the exact opposite of the chlog workflow, where `CHANGELOG.md` is generated from fragments and never hand-edited. The check also silently stopped enforcing that a fragment was added, so the real requirement went unchecked.

This surfaced when the redundant `.chlog.yaml` was removed fleet-wide: the file was byte-for-byte identical to chlog v0.4.0's `DefaultConfig()`, so removing it changed no chlog behaviour — but it flipped this check into the wrong branch on every affected repository, including this one.

AutoBump already had this right. `DetectChlog` in `internal/domain/commands/chlog.go`:

> A repository counts as a chlog user when it commits a .chlog.yaml or when the unreleased fragment directory exists -- the configuration file is optional.

The two now agree, so they cannot disagree about whether a repository uses chlog.

## Verification

Detection was exercised across all five cases:

| Repository state | Before | After |
|---|---|---|
| `.chlog.yaml` only | fragment required | fragment required |
| `.chlog.yml` only | **CHANGELOG.md required** | fragment required |
| `.changes/unreleased/` only | **CHANGELOG.md required** | fragment required |
| both config and directory | fragment required | fragment required |
| neither (non-chlog repo) | CHANGELOG.md required | CHANGELOG.md required |

Only the two broken rows change; non-chlog repositories are unaffected.

All three files were checked for YAML validity, and the extracted shell script passes `bash -n`.

This repository is itself a case in point: it no longer carries a `.chlog.yaml`, so its own changelog enforcement depends on this fix.
