### PR TITLE
fix(ci): linted the whole repository with its own shellcheck runner

### DIFF
--- a/.changes/unreleased/1787806705481209347-938e.yaml
+++ b/.changes/unreleased/1787806705481209347-938e.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'fixed CI never linting most of the shell in this repository. The `Lint Shell Scripts` job iterated `find global/scripts`, so `.github/tests/` -- the largest body of shell here -- was outside its scope entirely, and ten ShellCheck warnings accumulated there unread, visible only to somebody invoking `global/scripts/tools/shellcheck/run.sh` by hand. The job now runs that same runner, which scans from the repository root, so this repository is linted by the tool it ships to consumers rather than by a second implementation maintained beside it'
+time: '2026-08-27T04:58:25.481129426Z'

--- a/.changes/unreleased/1787806705485399869-f328.yaml
+++ b/.changes/unreleased/1787806705485399869-f328.yaml
@@ -1,0 +1,3 @@
+kind: 'Security'
+body: 'pinned the ShellCheck used by this repository own CI. The `Lint Shell Scripts` job installed it with `apt-get install -y shellcheck`, taking whatever version the Ubuntu image shipped that day; it now comes from `global/scripts/tools/shellcheck/run.sh`, which installs a version pinned in `pinned-versions.sh` and verified against a committed SHA-256 by `verify-download.sh`. That is the supply-chain rule this repository documents and enforces on consumers, and the runner own rationale applies to it exactly: a new ShellCheck release adds checks, so an unchanged script could pass in the morning and fail in the afternoon with nothing in the diff to explain it'
+time: '2026-08-27T04:58:25.485334594Z'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,23 +107,25 @@ jobs:
       - name: 'Checkout code'
         uses: 'actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803' # v6.1.0
 
-      - name: 'Install ShellCheck'
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
-
+      # This repository lints itself with the same runner it ships to consumers, rather than
+      # with a second implementation maintained here. That closes two gaps at once.
+      #
+      # SCOPE: the loop this replaces iterated `find global/scripts`, so `.github/tests/` --
+      # the largest body of shell in the repository -- was never linted by CI at all. Ten
+      # warnings accumulated there unread, visible only to somebody invoking the runner by
+      # hand. The runner scans from the repository root, excluding `.git`, `node_modules`,
+      # `vendor` and `.codeql-db`.
+      #
+      # VERSION: `apt-get install shellcheck` took whatever the Ubuntu image shipped that day.
+      # The runner installs a version pinned in `pinned-versions.sh` and checksum-verified by
+      # `verify-download.sh` -- which is this repository's own supply-chain rule, and the
+      # reason the runner gives for pinning applies exactly here: a new ShellCheck release
+      # adds checks, so an unchanged script could pass in the morning and fail in the
+      # afternoon with nothing in the diff to explain it.
+      #
+      # Severity is unchanged (`--severity=warning`), and the runner already exits non-zero on
+      # a finding, so the gate keeps failing the build the way the loop did.
       - name: 'Run ShellCheck'
-        run: |
-          echo "Running ShellCheck on all shell scripts..."
-          errors=0
-          for script in $(find global/scripts -name "*.sh" -type f); do
-            echo "Checking $script..."
-            if shellcheck --severity=warning "$script"; then
-              echo "  ✓ $script"
-            else
-              echo "  ✗ $script has issues"
-              errors=$((errors + 1))
-            fi
-          done
-          if [ "$errors" -gt 0 ]; then
-            echo "ShellCheck found issues in $errors script(s)"
-            exit 1
-          fi
+        run: ./global/scripts/tools/shellcheck/run.sh
+        env:
+          SCRIPTS_DIR: ${{ github.workspace }}


### PR DESCRIPTION
Follow-up to #623, which fixed ten ShellCheck warnings. This fixes **why they were able to
accumulate unread**.

## The gap

`.github/workflows/ci.yaml`'s `Lint Shell Scripts` job iterated:

```sh
for script in $(find global/scripts -name "*.sh" -type f); do
```

So it covered `global/scripts/**` and nothing else. `.github/tests/` — the largest body of shell
in this repository, and where all ten of #623's findings lived — was outside its scope entirely.
This repository also never ran its own `global/scripts/tools/shellcheck/run.sh` (which scans from
`$(pwd)`) against itself, so those findings were visible only to somebody invoking that runner by
hand. Which is exactly how they were found.

## The change

The job now runs the shipped runner instead of a second implementation maintained beside it:

```yaml
- name: 'Run ShellCheck'
  run: ./global/scripts/tools/shellcheck/run.sh
  env:
    SCRIPTS_DIR: ${{ github.workspace }}
```

That closes two gaps for the price of one, and the second was not in the original follow-up note:

| | Before | After |
|---|---|---|
| **Scope** | `global/scripts` only | repository root, excluding `.git`, `node_modules`, `vendor`, `.codeql-db` |
| **ShellCheck version** | `apt-get install -y shellcheck` — whatever the image shipped that day | pinned in `pinned-versions.sh`, checksum-verified by `verify-download.sh` |

The version half matters as much as the scope half. Pinning downloaded binaries is **this
repository's own supply-chain rule**, enforced on consumers by `test-supply-chain.sh` — and the
runner's stated reason for pinning describes this job precisely: *"a new ShellCheck release adds
checks, so an unchanged script could pass in the morning and fail in the afternoon with nothing in
the diff to explain it."* The lint job was the one place that rule was not applied to itself.

Severity is unchanged (`--severity=warning`), and the runner already exits non-zero on a finding,
so the gate fails the build the way the loop did. The `Install ShellCheck` step is removed because
the runner installs it.

## Verification

Proven by mutation, not assertion. A dead variable added to `.github/tests/test-lambda-templates.sh`
— inside the directory the old loop never looked at:

```
OLD gate (find global/scripts):  scripts with issues: 0   -> would PASS, misses it
NEW gate (the runner):           findings: 1, exit 123    -> FAILS the build
                                 .github/tests/test-lambda-templates.sh SC2034 DEAD_PROBE appears unused
```

Reverted, the repository is clean repo-wide (**0 findings**, runner exit 0). `make test` passes
40/40. `ci.yaml` parses as valid YAML.

## Ordering

This **must not land before #623** — the widened gate only passes because that PR took the
repo-wide count to 0. #623 is merged, so this is based on current `main` and is ready.