### PR TITLE
feat(workflows): added the `go-flyio.yaml` reusable workflow mirroring `go-render.yaml`

### DIFF
--- a/.changes/unreleased/1787864587252682667-4cee.yaml
+++ b/.changes/unreleased/1787864587252682667-4cee.yaml
@@ -1,0 +1,3 @@
+kind: 'Added'
+body: 'added the `go-flyio.yaml` reusable workflow: `go-docker.yaml` plus a `deployment > flyio` fifth-stage job over the existing `50-deployment/flyio` composite action, mirroring `go-render.yaml` — the app is named by ref through `fly_app_name` (never a stored id), `deployment_required_checks` re-asserts the checks on tag builds, and `fly_api_token` is a repository-scope secret checked at runtime with the cross-repository environment-secret cause named in the error'
+time: '2026-08-27T21:03:07.252603339Z'

--- a/.github/workflows/go-flyio.yaml
+++ b/.github/workflows/go-flyio.yaml
@@ -1,0 +1,222 @@
+# Go, delivered as a container image and deployed to Fly.io.
+#
+# `go-docker.yaml` plus one deployment job, exactly the shape `go-render.yaml` takes — which is
+# itself `go.yaml` plus the delivery jobs, one file per stage. A consumer that ships a Go service
+# to Fly.io calls this and writes no pipeline of its own.
+#
+# **The deploy is a job with `needs:`, never a second workflow.** The alternative a consumer reaches
+# for is `on: workflow_run: workflows: [ '<name>' ]`, which couples two files by a DISPLAY NAME and
+# fails silently when that name changes: a `workflow_run` naming a workflow that does not exist is
+# not an error, it simply never fires. One consumer renamed its CI workflow while adopting this
+# library and went four days without deploying, with every pipeline green the whole time. A `needs:`
+# edge cannot drift, and a deploy that does not run is a skipped job rather than silence.
+#
+# The deployment itself is the same `50-deployment/flyio` action GitLab and Azure DevOps reach
+# through their own templates, so the behaviour is one shared script (`global/scripts/deploy/flyio/
+# run.sh`) on all three platforms. This file is the GitHub convenience layer over it, not a second
+# implementation of it. The build stays `--remote-only` on Fly's builder, so no Docker daemon is
+# required in the deployment job.
+#
+# Consumers pin this workflow to a FULL 40-character commit SHA (an abbreviated one is rejected
+# before any job starts, with an error that reads like the commit is missing rather than like the
+# ref is the wrong shape); internal `rios0rios0/pipelines/...@main` references below deliberately
+# follow the latest first-party implementation, per the Workflow Composition Standard.
+on:
+  workflow_call:
+    inputs:
+      sonar_host:
+        description: 'SonarQube/SonarCloud host URL (leave empty to skip SonarQube)'
+        required: false
+        type: string
+        default: ''
+      runs_on:
+        type: 'string'
+        required: false
+        default: '["ubuntu-latest"]'
+        description: 'JSON array of runner labels (e.g. ''["self-hosted"]''). See go.yaml.'
+      go_version_file:
+        type: 'string'
+        required: false
+        default: 'go.mod'
+        description: |
+          Path to the `go.mod` whose `go` directive decides which Go the CodeQL analysis runs
+          with. Leave it alone unless this repository has SEVERAL modules: the shared action
+          finds a single module wherever it lives, and only an ambiguous tree needs telling.
+
+          It is a file rather than a version on purpose. The `go` directive is a minimum
+          language version, and the CodeQL runner sets `GOTOOLCHAIN=local`, so a module ahead
+          of the runner's Go cannot be extracted at all -- reading the module's own directive
+          means the analysis can never be older than the code it analyses.
+      codeql_upload:
+        type: 'string'
+        required: false
+        default: 'always'
+        description: "CodeQL SARIF upload mode ('always', 'failure-only' or 'never'). See go.yaml."
+      database_image:
+        type: 'string'
+        required: false
+        default: ''
+        description: 'Database image to run the tests against (e.g. ''postgres:18-alpine''). See go.yaml.'
+      database_url_env:
+        type: 'string'
+        required: false
+        default: ''
+        description: 'Environment variable the composed connection URL is exported into. See go.yaml.'
+      coverage_threshold:
+        type: 'number'
+        required: false
+        default: 0
+        description: 'Minimum total coverage percentage; 0 disables the gate. See go.yaml.'
+      integration_parallel:
+        type: 'number'
+        required: false
+        default: 1
+        description: 'How many integration test binaries run concurrently (`go test -p`). See go.yaml.'
+      openapi_sync_path:
+        type: 'string'
+        required: false
+        default: ''
+        description: 'Committed OpenAPI document to regenerate and diff. See go.yaml.'
+      openapi_sync_command:
+        type: 'string'
+        required: false
+        default: 'make swagger'
+        description: 'Command that regenerates the document named by `openapi_sync_path`.'
+      fly_app_name:
+        type: 'string'
+        required: false
+        default: ''
+        description: |
+          Fly application name the deploy targets. Optional when the committed `fly.toml` already
+          declares `app`, but prefer passing it DERIVED from the ref when one repository deploys
+          two apps (`api-staging` on a branch, `api-production` on a tag):
+
+            fly_app_name: "api-${{ github.ref_type == 'tag' && 'production' || 'staging' }}"
+
+          Named, never identified by a stored id: the name is a value the workflow already knows,
+          while a stored id is one more secret to rotate — and a stale id is the worse failure of
+          the two, because it deploys the WRONG app and reports success. This is the same contract
+          `render_service_name` carries in `go-render.yaml`.
+      fly_config:
+        type: 'string'
+        required: false
+        default: 'fly.toml'
+        description: 'Path to the Fly configuration file the deploy reads.'
+      fly_strategy:
+        type: 'string'
+        required: false
+        default: ''
+        description: |
+          Deployment strategy (`rolling`, `immediate`, `canary`, `bluegreen`). Left unset, Fly
+          picks its own default for the app's layout.
+      deployment_environment:
+        type: 'string'
+        required: false
+        default: ''
+        description: |
+          GitHub environment the deploy runs under, which is what scopes the credentials and what
+          can restrict the refs allowed to deploy. Defaults to `production` on a tag and `staging`
+          otherwise.
+      deployment_required_checks:
+        type: 'string'
+        required: false
+        default: ''
+        description: |
+          Newline-separated check names that must have SUCCEEDED before deploying.
+
+          Needed for TAG builds and not much else: `go.yaml` skips lint, the suite and the whole
+          security stage on a tag — they already ran when the commit landed on the default branch —
+          so the `needs:` edge below is satisfied by a run that verified nothing. On a branch the
+          dependency is real and this can stay empty.
+
+          Write the names bare (`tests > test:all`). The gate matches a whole trailing ` / `
+          segment, so it does not matter that GitHub records them prefixed with the calling jobs.
+    secrets:
+      sonar_token:
+        required: false
+        description: 'SonarQube/SonarCloud token. See go.yaml.'
+      fly_api_token:
+        required: false
+        description: |
+          Fly.io API token. Prefer an APP-SCOPED deploy token, one per app/environment
+          (`flyctl tokens create deploy --app <app>`), over an org-scoped `flyctl auth token`:
+          the deploy needs to manage one app, and a token for `api-staging` cannot touch
+          `api-production` even though every workflow in the calling repository can read it.
+
+          Hold it as a REPOSITORY secret in the caller and pass it explicitly. Environment-scoped
+          secrets cannot reach a reusable workflow in another repository — not with
+          `secrets: inherit`, not explicitly, and not via the `environment:` the job below
+          declares — and the failure is silent: the credential arrives empty and surfaces as a
+          rejected token rather than as a scoping problem. Declared `required: false` so the
+          runtime check below can name that cause instead of failing workflow validation.
+
+jobs:
+  go-docker:
+    uses: 'rios0rios0/pipelines/.github/workflows/go-docker.yaml@main'
+    with:
+      go_version_file: '${{ inputs.go_version_file }}'
+      sonar_host: ${{ inputs.sonar_host }}
+      runs_on: ${{ inputs.runs_on }}
+      codeql_upload: ${{ inputs.codeql_upload }}
+      database_image: ${{ inputs.database_image }}
+      database_url_env: ${{ inputs.database_url_env }}
+      coverage_threshold: ${{ inputs.coverage_threshold }}
+      integration_parallel: ${{ inputs.integration_parallel }}
+      openapi_sync_path: ${{ inputs.openapi_sync_path }}
+      openapi_sync_command: ${{ inputs.openapi_sync_command }}
+    secrets:
+      sonar_token: ${{ secrets.sonar_token }}
+
+  # fifth stage
+  deployment-flyio:
+    name: 'deployment > flyio'
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    # The ref picks the environment, which is what keeps two environments' credentials apart: a run
+    # not entitled to `production` cannot read its secrets, and `production` can refuse every ref
+    # that is not a tag.
+    environment: ${{ inputs.deployment_environment != '' && inputs.deployment_environment || (github.ref_type == 'tag' && 'production' || 'staging') }}
+    # Only what is used, and only read. A called workflow can never hold more than its caller
+    # grants, so requesting anything spare turns a working consumer into a permissions error --
+    # `deployments: write` is the one to resist here, since nothing in the Fly path touches that
+    # API. `checks: read` IS required and is not in the restricted default set.
+    permissions:
+      contents: 'read'
+      checks: 'read'
+    steps:
+      # Skipped entirely when the caller passes nothing, so a branch deploy pays nothing for a gate
+      # whose guarantee `needs:` already carries.
+      - if: "inputs.deployment_required_checks != ''"
+        uses: 'rios0rios0/pipelines/github/global/stages/50-deployment/require-checks@main'
+        with:
+          required_checks: '${{ inputs.deployment_required_checks }}'
+
+      # Refused here rather than by the deploy script, whose message is about a missing token and
+      # not about why it is missing.
+      #
+      # Empty almost always means one thing: the credential is an ENVIRONMENT secret in the calling
+      # repository. Those cannot reach this workflow by any route -- not `secrets: inherit` (which
+      # only carries secrets within one organization, and this library is a different owner), not an
+      # explicit `${{ secrets.X }}` (evaluated in the caller's `uses:` job, which cannot declare an
+      # environment), and not the `environment:` on the job below, which applies for protection
+      # rules and the deployment record but brings no secrets across a repository boundary.
+      # Environment VARIABLES do cross, which is what makes this so easy to misread.
+      - run: |
+          if [ -z "$FLY_API_TOKEN" ]; then
+            echo "::error::fly_api_token did not reach this job. Hold the token as a REPOSITORY secret and pass it explicitly. Environment-scoped secrets cannot reach a reusable workflow in another repository -- not with 'secrets: inherit', not explicitly, and not via the environment declared on this job."
+            exit 1
+          fi
+        shell: 'bash'
+        env:
+          FLY_API_TOKEN: '${{ secrets.fly_api_token }}'
+
+      - uses: 'rios0rios0/pipelines/github/global/stages/50-deployment/flyio@main'
+        with:
+          fly_api_token: '${{ secrets.fly_api_token }}'
+          app_name: '${{ inputs.fly_app_name }}'
+          config: '${{ inputs.fly_config }}'
+          strategy: '${{ inputs.fly_strategy }}'
+          environment: ${{ inputs.deployment_environment != '' && inputs.deployment_environment || (github.ref_type == 'tag' && 'production' || 'staging') }}
+    needs: [ 'go-docker' ]
+    # `!failure()` rather than `success()` so a skipped upstream job does not take the deploy with
+    # it, matching how `delivery-docker` gates itself one level down. A pull request never deploys.
+    if: "!failure() && github.event_name != 'pull_request' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/'))"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ pipelines/
 ├── .github/workflows/          # GitHub Actions reusable workflows
 │   ├── go-docker.yaml         # Go with Docker delivery
 │   ├── go-render.yaml         # Go with Docker delivery + Render deployment
+│   ├── go-flyio.yaml          # Go with Docker delivery + Fly.io deployment
 │   ├── go-binary.yaml         # Go binary compilation
 │   ├── pdm-docker.yaml        # Python/PDM with Docker
 │   ├── gradle-docker.yaml     # Java/Gradle with Docker delivery
@@ -177,6 +178,7 @@ GitHub Actions workflows are located in `.github/workflows/` and can be used as 
 | `go.yaml`                    | Go testing and quality checks              | Go            |
 | `go-docker.yaml`             | Go with Docker image delivery              | Go            |
 | `go-render.yaml`             | Go with Docker delivery + Render deployment | Go            |
+| `go-flyio.yaml`              | Go with Docker delivery + Fly.io deployment | Go            |
 | `go-library.yaml`            | Go module tagged for the proxy             | Go            |
 | `go-binary.yaml`             | Go binary compilation and release          | Go            |
 | `pdm.yaml`                   | Python/PDM testing and quality checks      | Python        |


### PR DESCRIPTION
## What

Adds `.github/workflows/go-flyio.yaml`: the GitHub convenience layer for deploying a Go service to Fly.io. It mirrors `go-render.yaml` line for line — `go-docker.yaml` plus one `deployment > flyio` fifth-stage job — and the deployment itself is the existing `github/global/stages/50-deployment/flyio` composite action, so the behaviour stays the one shared script (`global/scripts/deploy/flyio/run.sh`) GitLab and Azure DevOps already reach through their own templates. Only the GitHub layer was missing.

Needed by medhub-life/backend#53 (the Brazil migration: Render → Fly.io).

## Naming: `go-flyio.yaml`, not `go-fly.yaml`

The issue calls it `go-fly.yaml`, but this repository's own Workflow Composition Standard (Test 9 of `test-workflow-composition.sh`) requires a deployment suffix to name a directory that exists under `github/global/stages/50-deployment/` — and that directory is `flyio`. `go-fly.yaml` fails the gate; `go-flyio.yaml` passes it and matches the `deploy-flyio` report name and the GitLab/Azure template names.

## The four constraints from medhub-life/backend#53, preserved

1. **The deploy credential is an explicit workflow secret** (`fly_api_token`), documented as repository-scope in the caller. Declared `required: false` per this repo's standard, with the same runtime check `go-render.yaml` carries: an empty token fails with an error naming the actual cause (environment-scoped secrets cannot cross a repository boundary into a reusable workflow — not via `secrets: inherit`, not explicitly, not through the job's `environment:`). The description also steers callers to app-scoped deploy tokens (`flyctl tokens create deploy`), one per environment, so the repository-scope trade is partially recovered: a token for `api-staging` cannot touch `api-production`.
2. **The target app is named by ref, never a stored id**: `fly_app_name` carries the same contract as `render_service_name`, with the `api-${{ github.ref_type == 'tag' && 'production' || 'staging' }}` pattern documented in its description. A stale stored id is the worse failure — it deploys the wrong app and reports success.
3. **`deployment_required_checks` carried over verbatim** — same input, same description, same conditional `require-checks` step, because on a tag the internal `needs:` edge is satisfied by a run that skipped lint, tests and security.
4. **Pinning**: consumers pin this workflow at a full 40-character commit SHA (stated in the header comment); internal `rios0rios0/pipelines/...@main` references deliberately follow the latest first-party implementation, exactly as `go-render.yaml` does and as Test 7 of the composition suite asserts. The third-party actions in the execution chain (`actions/checkout`, `actions/upload-artifact` inside the flyio composite) are already SHA-pinned with `# vX.Y.Z` trailers.

The deployment job itself declares all four required properties of the standard: `needs: [ 'go-docker' ]`, `environment:` derived from the ref, an `if:` that excludes pull requests, and the `# fifth stage` comment.

## Gates run

- `make test-workflow-composition` — 9/9 passed
- `make test-deploy-providers` — 158/158 passed
- `make test-supply-chain` — 27/27 passed
- chlog fragment added under `.changes/unreleased/` (`CHANGELOG.md` untouched, as generated)

## Docs

README updated in both places that list GitHub reusable workflows (project-structure tree and the available-workflows table), which Test 8 of the composition suite requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxhRL93tQeaL3y6bjeJPqG
