### PR TITLE
fix(claude): restored the required `id-token: write` permission

### DIFF
--- a/.changes/unreleased/1787874000000000001-6d3f.yaml
+++ b/.changes/unreleased/1787874000000000001-6d3f.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'restored the `id-token: write` permission on the Claude reusable workflows and callers. Removing it broke every Claude run with `Could not fetch an OIDC token`: unless a `github_token` is passed explicitly, `anthropics/claude-code-action`''s `setupGitHubToken()` always requests a GitHub OIDC token and exchanges it for a GitHub App token, which is how it posts reviews and comments. That is GitHub authentication and is independent of `claude_code_oauth_token`, which authenticates to Anthropic. The scope is required, not vestigial, and the README now says so.'
+time: '2026-08-27T21:40:00.000000000Z'

--- a/.github/workflows/claude-mention.yaml
+++ b/.github/workflows/claude-mention.yaml
@@ -19,4 +19,5 @@ jobs:
       contents: 'write'
       pull-requests: 'write'
       issues: 'write'
+      id-token: 'write'
       actions: 'read'

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -13,3 +13,4 @@ jobs:
       contents: 'read'
       pull-requests: 'write'
       issues: 'write'
+      id-token: 'write'

--- a/.github/workflows/reusable-claude-mention.yaml
+++ b/.github/workflows/reusable-claude-mention.yaml
@@ -24,6 +24,7 @@ jobs:
       contents: 'write'
       pull-requests: 'write'
       issues: 'write'
+      id-token: 'write'
       actions: 'read'
     steps:
       - name: 'Checkout repository'

--- a/.github/workflows/reusable-claude-review.yaml
+++ b/.github/workflows/reusable-claude-review.yaml
@@ -15,6 +15,7 @@ jobs:
       contents: 'read'
       pull-requests: 'write'
       issues: 'write'
+      id-token: 'write'
     steps:
       - name: 'Checkout repository'
         uses: 'actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803' # v6.1.0

--- a/README.md
+++ b/README.md
@@ -251,10 +251,13 @@ Pass the secret explicitly rather than with `secrets: inherit` — Semgrep's
 `yaml.github-actions.security.secrets-inherit` rule fails `make sast` on the inherited form.
 
 The caller's `permissions:` is a **ceiling** for the workflow it calls, so it must grant at
-least what the definition declares. Neither needs `id-token: write`:
-`anthropics/claude-code-action` documents that scope as required only for workload identity
-federation, or the Bedrock / Vertex / Foundry OIDC paths, and these authenticate with
-`claude_code_oauth_token`.
+least what the definition declares — `id-token: write` included.
+
+**`id-token: write` is required.** Unless a `github_token` is passed explicitly, the action's
+`setupGitHubToken()` always requests a GitHub OIDC token and exchanges it for a GitHub App
+token, which is how it posts reviews and comments. That is GitHub authentication and is
+separate from `claude_code_oauth_token`, which authenticates to Anthropic. Removing the scope
+fails every run with `Could not fetch an OIDC token`.
 
 `.github/workflows/claude-review.yaml`:
 
@@ -274,6 +277,7 @@ jobs:
       contents: 'read'
       pull-requests: 'write'
       issues: 'write'
+      id-token: 'write'
 ```
 
 `.github/workflows/claude-mention.yaml`:
@@ -300,6 +304,7 @@ jobs:
       contents: 'write'
       pull-requests: 'write'
       issues: 'write'
+      id-token: 'write'
       actions: 'read'
 ```
 


### PR DESCRIPTION
## 🚨 This reverts a regression I introduced — merge first

#627 removed `id-token: write` on my analysis that it was unused. **That analysis was wrong**, and every Claude run across the fleet now fails:

```
Attempt 3 failed: Could not fetch an OIDC token.
Did you remember to add `id-token: write` to your workflow permissions?
Error: Action failed with error: Could not fetch an OIDC token.
```

Already visible on unrelated work — the Claude review on #629 is failing for this reason.

## Why the scope is required

`anthropics/claude-code-action`'s `src/github/token.ts`:

```ts
export async function setupGitHubToken(): Promise<string> {
  const providedToken = process.env.OVERRIDE_GITHUB_TOKEN;
  if (providedToken) { return providedToken; }

  console.log("Requesting OIDC token...");
  const oidcToken = await retryWithBackoff(() => getOidcToken());   // <-- needs id-token: write
  const appToken = await retryWithBackoff(() => exchangeForAppToken(oidcToken, permissions));
  return appToken;
}
```

Unless `github_token` is passed explicitly, the action **always** requests a GitHub OIDC token and exchanges it for a **GitHub App token** — that is how it posts reviews and comments.

**Two independent authentications, which is what I conflated:**

| Credential | Authenticates to | Needs `id-token: write` |
|---|---|---|
| `claude_code_oauth_token` | Anthropic | no |
| OIDC → GitHub App token | GitHub | **yes** |

I read only `action.yml`'s input descriptions, which mention `id-token: write` under the *Anthropic* workload-identity-federation input, and concluded the scope was unused. I never checked how the action authenticates to *GitHub*. The `action.yml` docs are about a different OIDC use entirely.

The README now states why the scope is required, so it does not get "cleaned up" again.

## Follow-up

The 74 caller PRs that removed the same scope are being corrected to keep it; they retain only the `Claude Review` rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6B21LbgQKbpL1JzDdBXDe