### PR TITLE
fix(claude): allowed the tools the review workflow needs to post

### DIFF
--- a/.changes/unreleased/1787876000000000001-9f2a.yaml
+++ b/.changes/unreleased/1787876000000000001-9f2a.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'fixed the Claude review workflow never posting its findings. It ran, reviewed the pull request and produced a report, then had nowhere to put it: the run ended with `The inline-comment MCP tool isn''t available in this environment` and the action logged `No buffered inline comments`. A `prompt:` puts the action in agent mode, where the allowed-tool list comes only from `claude_args`, and the inline-comment MCP server is installed only when that list names it. `claude_args` now passes `--allowedTools` with `mcp__github_inline_comment__create_inline_comment` and the `gh pr` commands, matching the action''s own documented PR-review example.'
+time: '2026-08-27T22:00:00.000000000Z'

--- a/.github/workflows/reusable-claude-review.yaml
+++ b/.github/workflows/reusable-claude-review.yaml
@@ -27,7 +27,13 @@ jobs:
         uses: 'anthropics/claude-code-action@70fec183852c4f82f3f1969faed7dd60c5149ca7' # v1.0.207
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model claude-opus-4-8'
+          # `--allowedTools` is what installs the inline-comment MCP server: agent mode derives
+          # its tool list from claude_args alone, and the server is only wired when the list
+          # names it (see install-mcp-server.ts). Without this Claude reviews the PR but has
+          # no way to post, and falls back to a `gh` call that headless CI cannot approve.
+          claude_args: >-
+            --model claude-opus-4-8
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Symptom

The review workflow runs, succeeds, and posts nothing. On #629 it spent 7½ minutes, produced a genuine finding, and ended with:

```
No buffered inline comments
```

The run's own result explains it:

> The inline-comment MCP tool isn't available in this environment, and the fallback `gh api` POST is gated behind an approval that wasn't granted (I attempted it twice).

## Cause

Passing a `prompt:` makes the action auto-detect **agent mode**. In that mode the allowed-tool list comes *only* from `claude_args`:

```ts
// src/modes/agent/index.ts
const allowedTools = parseAllowedTools(userClaudeArgs);
```

and the inline-comment MCP server is installed *only* when that list names it:

```ts
// src/mcp/install-mcp-server.ts
if (isEntityContext(context) && context.isPR && (hasGitHubMcpTools || hasInlineCommentTools)) {
  baseMcpConfig.mcpServers.github_inline_comment = { ... };
}
```

`claude_args` was `--model claude-opus-4-8`, so the list was empty, the server was never installed, and Claude had no way to post. Its fallback — a `gh api` POST — is a `Bash` call that was likewise not allowlisted, so headless CI denied it. Read-only tools are permitted by default, which is why the *review itself* worked.

## Fix

Matches the action's own documented PR-review example (`docs/solutions.md`):

```yaml
claude_args: >-
  --model claude-opus-4-8
  --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
```

## Scope

One file. `reusable-claude-review.yaml` is referenced `@main` by all 75 repositories, so this fixes the fleet in a single merge.

`reusable-claude-mention.yaml` is **not** affected and is unchanged: it passes no `prompt:`, so it runs in **tag mode**, which builds its own tool list including `mcp__github_comment__update_claude_comment`.

## Verification

`make test-workflow-composition` 9/9 and `make test-supply-chain` 27/27. The real proof is the next pull request after this merges — the review should post its findings instead of discarding them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6B21LbgQKbpL1JzDdBXDe