### PR TITLE
feat(claude): removed `claude_args` and let the action wire itself

### DIFF
--- a/.changes/unreleased/1787878000000000001-7c4e.yaml
+++ b/.changes/unreleased/1787878000000000001-7c4e.yaml
@@ -1,0 +1,3 @@
+kind: 'Changed'
+body: 'removed `claude_args` from both Claude reusable workflows. Neither pins a model any more -- they take the Claude Code CLI default, which is `claude-opus-5` as of CLI `2.1.247` -- and the review no longer hands Claude an `--allowedTools` list. Instead it sets `track_progress: true`, which forces tag mode; tag mode builds its own tool list including `mcp__github_comment__update_claude_comment`, so Claude can publish its review without being told which tools exist. The review is now delivered as a tracking comment that Claude updates as it works, rather than line-anchored inline comments.'
+time: '2026-08-27T22:45:00.000000000Z'

--- a/.github/workflows/reusable-claude-mention.yaml
+++ b/.github/workflows/reusable-claude-mention.yaml
@@ -37,6 +37,5 @@ jobs:
         uses: 'anthropics/claude-code-action@70fec183852c4f82f3f1969faed7dd60c5149ca7' # v1.0.207
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model claude-opus-4-8'
           additional_permissions: |
             actions: read

--- a/.github/workflows/reusable-claude-review.yaml
+++ b/.github/workflows/reusable-claude-review.yaml
@@ -27,13 +27,12 @@ jobs:
         uses: 'anthropics/claude-code-action@70fec183852c4f82f3f1969faed7dd60c5149ca7' # v1.0.207
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # `--allowedTools` is what installs the inline-comment MCP server: agent mode derives
-          # its tool list from claude_args alone, and the server is only wired when the list
-          # names it (see install-mcp-server.ts). Without this Claude reviews the PR but has
-          # no way to post, and falls back to a `gh` call that headless CI cannot approve.
-          claude_args: >-
-            --model claude-opus-4-8
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+          # `track_progress` forces tag mode (detector.ts checks it before the prompt check),
+          # and tag mode builds its own tool list including `mcp__github_comment__update_claude_comment`,
+          # so Claude can post without being handed an `--allowedTools` list. Agent mode -- what a
+          # bare `prompt:` selects -- derives its tools from `claude_args` alone and would leave
+          # Claude with no way to publish the review.
+          track_progress: true
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/README.md
+++ b/README.md
@@ -253,7 +253,10 @@ Pass the secret explicitly rather than with `secrets: inherit` — Semgrep's
 `yaml.github-actions.security.secrets-inherit` rule fails `make sast` on the inherited form.
 
 The caller's `permissions:` is a **ceiling** for the workflow it calls, so it must grant at
-least what the definition declares — `id-token: write` included.
+least what the definition declares — `id-token: write` included. Neither definition pins a
+model or an `--allowedTools` list: the review runs with `track_progress: true`, which puts
+the action in tag mode, where it wires its own posting tool and takes the Claude Code CLI's
+default model.
 
 **`id-token: write` is required.** Unless a `github_token` is passed explicitly, the action's
 `setupGitHubToken()` always requests a GitHub OIDC token and exchanges it for a GitHub App


### PR DESCRIPTION
## What

`claude_args` is gone from both reusable workflows.

```diff
-          claude_args: >-
-            --model claude-opus-4-8
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),..."
+          track_progress: true
```

```diff
   # reusable-claude-mention.yaml
-          claude_args: '--model claude-opus-4-8'
```

## No pinned model

Both now take the **Claude Code CLI default**. I measured it rather than assuming: CLI `2.1.247` — the same build the action installs — with no `--model`, no config pin, no `ANTHROPIC_MODEL`, resolves to:

```
modelUsage: claude-opus-5[1m]  canonical=claude-opus-5  ctx=1000000  maxOut=64000
```

Opus 5 and Opus 4.8 are both `$5 / $25` per MTok, so this is the newer model at the same rate, and it tracks future CLI defaults automatically.

## Why `track_progress: true` replaces `--allowedTools`

Dropping `claude_args` on its own would have silently broken posting again. A bare `prompt:` selects **agent mode**, whose tool list comes only from `claude_args`:

```ts
const allowedTools = parseAllowedTools(userClaudeArgs);          // src/modes/agent/index.ts
```

An empty list means the posting tool is never wired, and Claude reviews the PR and then discards the result — the `No buffered inline comments` failure seen on #629.

`track_progress: true` avoids that without naming any tool, because the detector checks it **before** the prompt check:

```ts
if (context.inputs.trackProgress && isEntityContext(context)) {
  if (isPullRequestEvent(context) || ...) return "tag";          // src/modes/detector.ts
}
```

and tag mode builds its own list — `Glob`, `Grep`, `LS`, `Read`, `mcp__github_comment__update_claude_comment`, the CI tools — so the action wires itself.

## Trade-off, stated plainly

The review arrives as a **tracking comment Claude updates as it works**, not line-anchored inline comments. `tagModeTools` includes `update_claude_comment` but **not** `mcp__github_inline_comment__create_inline_comment`, so per-line annotations need an explicit `--allowedTools` — which is exactly what this PR removes. That was an accepted trade in choosing this option.

## Verification

`make test-workflow-composition` 9/9, `make test-supply-chain` 27/27. The real proof is the first PR after this merges: the review should post a tracking comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6B21LbgQKbpL1JzDdBXDe