### PR TITLE
feat(claude): pinned Claude Opus 5 through `ANTHROPIC_MODEL`

### DIFF
--- a/.changes/unreleased/1787880000000000001-5a9d.yaml
+++ b/.changes/unreleased/1787880000000000001-5a9d.yaml
@@ -1,0 +1,3 @@
+kind: 'Changed'
+body: 'changed the Claude reusable workflows to run on Claude Opus 5, set through the `ANTHROPIC_MODEL` environment variable rather than a `--model` flag. `parse-sdk-options.ts` resolves the model as `options.model || modelFromClaudeArgs`, where `options.model` is `process.env.ANTHROPIC_MODEL`, so the variable takes precedence and the workflows keep passing no `claude_args` -- which is what lets `track_progress` tag mode wire its own tools. Left unset, the CLI default applies, and in CI that resolved to Claude Sonnet 5 with Claude Haiku 4.5 for comment classification.'
+time: '2026-08-27T23:00:00.000000000Z'

--- a/.github/workflows/reusable-claude-mention.yaml
+++ b/.github/workflows/reusable-claude-mention.yaml
@@ -39,3 +39,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
+        env:
+          # Sets the model without touching `claude_args`: parse-sdk-options.ts resolves
+          # `model: options.model || modelFromClaudeArgs`, where `options.model` is this
+          # variable -- so it wins over `--model` and leaves the tool wiring alone.
+          ANTHROPIC_MODEL: 'claude-opus-5'

--- a/.github/workflows/reusable-claude-review.yaml
+++ b/.github/workflows/reusable-claude-review.yaml
@@ -38,3 +38,8 @@ jobs:
           prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           show_full_output: true
           display_report: true
+        env:
+          # Sets the model without touching `claude_args`: parse-sdk-options.ts resolves
+          # `model: options.model || modelFromClaudeArgs`, where `options.model` is this
+          # variable -- so it wins over `--model` and leaves the tool wiring alone.
+          ANTHROPIC_MODEL: 'claude-opus-5'

--- a/README.md
+++ b/README.md
@@ -253,10 +253,13 @@ Pass the secret explicitly rather than with `secrets: inherit` — Semgrep's
 `yaml.github-actions.security.secrets-inherit` rule fails `make sast` on the inherited form.
 
 The caller's `permissions:` is a **ceiling** for the workflow it calls, so it must grant at
-least what the definition declares — `id-token: write` included. Neither definition pins a
-model or an `--allowedTools` list: the review runs with `track_progress: true`, which puts
-the action in tag mode, where it wires its own posting tool and takes the Claude Code CLI's
-default model.
+least what the definition declares — `id-token: write` included. Neither definition passes
+`claude_args`: the review runs with `track_progress: true`, which puts the action in tag mode,
+where it wires its own posting tool. The model is pinned with the `ANTHROPIC_MODEL`
+environment variable rather than `--model`, because `parse-sdk-options.ts` resolves
+`model: options.model || modelFromClaudeArgs` — the variable wins, and setting it leaves the
+tool wiring untouched. Without it the CLI default applies, which in CI resolves to
+Claude Sonnet, not Opus.
 
 **`id-token: write` is required.** Unless a `github_token` is passed explicitly, the action's
 `setupGitHubToken()` always requests a GitHub OIDC token and exchanges it for a GitHub App


### PR DESCRIPTION
## Problem

After `claude_args` was removed, the workflows fell back to the Claude Code CLI default. Measured on the smoke-test run (`jetbrains-golden-sync#28`), that default is **not Opus**:

| Model | Cost on that run |
|---|---|
| `claude-sonnet-5` | $0.180 |
| `claude-haiku-4-5` | $0.004 |

(The Haiku slice is the action's `classify_inline_comments`, which is unrelated to the main model.)

I previously reported the default as `claude-opus-5`. That measurement was taken against the **local** CLI with an account config present, not a clean CI environment — the caveat I flagged at the time, and it was wrong for CI. The CI default is Sonnet 5.

## Fix — without reintroducing `claude_args`

`ANTHROPIC_MODEL` is an **environment variable**, not an action input, and it outranks `--model`:

```ts
// base-action/src/index.ts
model: process.env.ANTHROPIC_MODEL,

// base-action/src/parse-sdk-options.ts
model: options.model || modelFromClaudeArgs,
```

So:

```yaml
        env:
          ANTHROPIC_MODEL: 'claude-opus-5'
```

`claude_args` stays absent, which is what keeps `track_progress` tag mode wiring its own posting tool. Pinning the model no longer costs the tools — the exact trade-off that made this awkward before.

## Cost

Opus 5 is `$5 / $25` per MTok against Sonnet 5's `$2 / $10`, so expect roughly **2.5×** per review. The smoke test's $0.18 would land near $0.45.

## Verification

`make test-workflow-composition` 9/9, `make test-supply-chain` 27/27, and both steps parse with the expected `env` block. The real proof is the next run's `modelUsage` reporting `claude-opus-5` — I will re-run the smoke test once this merges rather than assume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6B21LbgQKbpL1JzDdBXDe