### PR TITLE
feat(claude): added the `runs_on` input to the mention and review reusable workflows

### DIFF
--- a/.changes/unreleased/1787869178053588526-ccc5.yaml
+++ b/.changes/unreleased/1787869178053588526-ccc5.yaml
@@ -1,0 +1,3 @@
+kind: 'Added'
+body: 'added the `runs_on` input to the Claude mention and review reusable workflows so consumers can route both onto self-hosted runners'
+time: '2026-08-27T22:19:38.053532291Z'

--- a/.github/workflows/reusable-claude-mention.yaml
+++ b/.github/workflows/reusable-claude-mention.yaml
@@ -2,6 +2,12 @@ name: 'Claude Mention'
 
 on:
   workflow_call:
+    inputs:
+      runs_on:
+        type: 'string'
+        required: false
+        default: '["ubuntu-latest"]'
+        description: 'JSON array of runner labels (e.g. ''["self-hosted"]''). See go.yaml.'
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: true
@@ -19,7 +25,7 @@ jobs:
       (github.event.issue != null &&
         (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
     permissions:
       contents: 'write'
       pull-requests: 'write'

--- a/.github/workflows/reusable-claude-review.yaml
+++ b/.github/workflows/reusable-claude-review.yaml
@@ -2,6 +2,12 @@ name: 'Claude Review'
 
 on:
   workflow_call:
+    inputs:
+      runs_on:
+        type: 'string'
+        required: false
+        default: '["ubuntu-latest"]'
+        description: 'JSON array of runner labels (e.g. ''["self-hosted"]''). See go.yaml.'
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: true
@@ -10,7 +16,7 @@ on:
 jobs:
   claude-review:
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
     permissions:
       contents: 'read'
       pull-requests: 'write'


### PR DESCRIPTION
## What

Exposed a `runs_on` input on `reusable-claude-mention.yaml` and `reusable-claude-review.yaml`, following the existing `go.yaml` convention: a JSON array of runner labels, `required: false`, defaulting to `["ubuntu-latest"]`, consumed via `fromJSON`.

This repository's own caller workflows (`claude-mention.yaml`, `claude-review.yaml`) deliberately pass nothing — the default keeps them on GitHub-hosted runners, which is the right choice for a public project. Consumers that run self-hosted (the medhub-life repositories) pass the input from their `RUNNER_LABELS` repository variable.

## Compatibility

Backward compatible: the input is optional and defaults to the current hardcoded value, so every existing consumer is unaffected until it passes the input.

## Gates

- `make test-workflow-composition` — 9/9 pass
- `make test-supply-chain` — pinning contract holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxhRL93tQeaL3y6bjeJPqG