### PR TITLE
fix(claude): documented the self-hosted runner requirements and asserted the `runs_on` wiring

### DIFF
--- a/.changes/unreleased/1787870069299689828-1076.yaml
+++ b/.changes/unreleased/1787870069299689828-1076.yaml
@@ -1,0 +1,3 @@
+kind: 'Changed'
+body: 'documented the self-hosted provisioning requirements on the Claude reusable workflows (runner Node runtime, writable `$HOME`, egress to `api.anthropic.com` and `github.com`) and recorded the fork-guard asymmetry of the mention responder in its `runs_on` description'
+time: '2026-08-27T22:34:29.299648138Z'

--- a/.changes/unreleased/1787870069299689828-1076.yaml
+++ b/.changes/unreleased/1787870069299689828-1076.yaml
@@ -1,3 +1,3 @@
 kind: 'Changed'
-body: 'documented the self-hosted provisioning requirements on the Claude reusable workflows (runner Node runtime, writable `$HOME`, egress to `api.anthropic.com` and `github.com`) and recorded the fork-guard asymmetry of the mention responder in its `runs_on` description'
+body: 'documented the self-hosted provisioning requirements on the Claude reusable workflows (`bash`, `git` and `unzip`, a writable `$HOME`, and egress to `github.com`, `registry.npmjs.org`, `api.github.com` and `api.anthropic.com` -- the runner supplies its own Node) and recorded the fork-guard asymmetry of the mention responder where a consumer reads it, in `README.md` and above `jobs:`'
 time: '2026-08-27T22:34:29.299648138Z'

--- a/.changes/unreleased/1787870069301649227-a752.yaml
+++ b/.changes/unreleased/1787870069301649227-a752.yaml
@@ -1,0 +1,3 @@
+kind: 'Added'
+body: 'added a workflow-composition assertion that the Claude reusable workflows declare an optional `runs_on` input defaulting to GitHub-hosted and consume it via `fromJSON`'
+time: '2026-08-27T22:34:29.301610358Z'

--- a/.changes/unreleased/1787872153562936378-32a3.yaml
+++ b/.changes/unreleased/1787872153562936378-32a3.yaml
@@ -1,0 +1,3 @@
+kind: 'Security'
+body: 'fixed the `@claude` mention responder starting on any comment to a maintainer-opened thread whose body or title contained `@claude`: an `issue_comment` payload carries both `comment` and `issue`, so the third `if:` clause evaluated on comment events too and read the THREAD AUTHOR''s association instead of the commenter''s. It is now gated on `github.event.comment == null`. Not an escalation -- the action re-checks the actor''s write permission and refuses to act -- but the job started on the runner'
+time: '2026-08-27T23:09:13.562841943Z'

--- a/.changes/unreleased/1787872763568572664-dfec.yaml
+++ b/.changes/unreleased/1787872763568572664-dfec.yaml
@@ -1,0 +1,3 @@
+kind: 'Added'
+body: 'added a workflow-composition assertion that the mention responder''s `if:` reads the association of whoever wrote the text each clause matched on -- structural, so the guard survives a reformat -- and generalised the `runs_on` assertion from the two Claude reusables to every workflow declaring the input (19 today), while keeping a separate check that the Claude pair declares one at all'
+time: '2026-08-27T23:19:23.568487356Z'

--- a/.changes/unreleased/1787873405084463172-c9da.yaml
+++ b/.changes/unreleased/1787873405084463172-c9da.yaml
@@ -1,0 +1,3 @@
+kind: 'Changed'
+body: 'widened the workflow `runs_on` contract from "resolves from `inputs.runs_on`" to "resolves from a declared input", so a job with a hard platform requirement (the documented Flutter `ipa` build needing macOS) can take a second input instead of a pinned runner, and demanded a `with:` forward only when the called workflow declares `runs_on` -- GitHub rejects an undeclared input key outright'
+time: '2026-08-27T23:30:05.084392594Z'

--- a/.changes/unreleased/1787874077082310408-eb1b.yaml
+++ b/.changes/unreleased/1787874077082310408-eb1b.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'fixed `yarn-docker.yaml` and `yarn-library.yaml` stranding every consumer on GitHub-hosted runners: both call `yarn.yaml`, which takes `runs_on`, but neither declared nor forwarded it and both hardcoded `ubuntu-latest` on their delivery jobs -- their npm twins with the input deleted. `yarn-docker.yaml` had dropped `codeql_upload` the same way'
+time: '2026-08-27T23:41:17.082225792Z'

--- a/.changes/unreleased/1787874077084692869-178a.yaml
+++ b/.changes/unreleased/1787874077084692869-178a.yaml
@@ -1,0 +1,3 @@
+kind: 'Added'
+body: 'added the converse of the callee lookup to the workflow `runs_on` assertion -- a reusable workflow calling one that takes `runs_on` must declare and forward it, which is what caught the `yarn` children -- plus checks that a declared `runs_on` reaches at least one job and that the mention responder''s trigger allowlist is exactly `OWNER`, `MEMBER`, `COLLABORATOR`'
+time: '2026-08-27T23:41:17.084648027Z'

--- a/.github/tests/test-workflow-composition.sh
+++ b/.github/tests/test-workflow-composition.sh
@@ -361,11 +361,15 @@ echo "Test 10: the Claude reusables declare and consume runs_on"
 #     in a list here it would be unchecked by this one too, and a hardcoded runner
 #     in it would go green. A glob matching nothing is itself reported, so a
 #     rename fails here rather than passing by having nothing left to check.
-#   - Every path through the Python exits 0 and speaks through stdout, including
-#     a missing PyYAML and an unreadable file. This script runs under `set -e`, so
-#     a non-zero exit inside the command substitution would kill the suite after
-#     nine PASS lines with no FAIL line and no summary -- which reads as a crash
-#     rather than as a verdict.
+#   - Every path through the Python exits 0 and speaks through stdout. This script
+#     runs under `set -e`, so a non-zero exit inside the command substitution would
+#     kill the suite after nine PASS lines with no FAIL line and no summary --
+#     which reads as a crash rather than as a verdict. `except Exception` around
+#     the per-file body is deliberately that broad: `OSError`/`YAMLError` cover an
+#     unreadable file, but an EMPTY workflow (`safe_load` returns `None`), a scalar
+#     `runs_on:` or a job with an empty body are all well-formed YAML that raise
+#     `AttributeError` on the lookups below -- which would abort the suite for the
+#     shapes it exists to report.
 BAD_RUNS_ON="$(python3 - "$WORKFLOWS_DIR" <<'PY'
 import glob
 import os
@@ -385,27 +389,41 @@ if not paths:
 
 for path in paths:
     name = os.path.basename(path)
+    problems = []
     try:
         with open(path, encoding='utf-8') as handle:
-            document = yaml.safe_load(handle)
-    except (OSError, yaml.YAMLError) as error:
-        print(f'{name}: unreadable ({error})')
-        continue
+            document = yaml.safe_load(handle) or {}
 
-    problems = []
-    # YAML 1.1 reads the `on:` key as the boolean `true`.
-    trigger = document.get('on', document.get(True)) or {}
-    spec = ((trigger.get('workflow_call') or {}).get('inputs') or {}).get('runs_on')
-    if spec is None:
-        problems.append('declares no runs_on workflow_call input')
-    else:
-        if spec.get('required') is not False:
-            problems.append('runs_on is not optional')
-        if spec.get('default') != '["ubuntu-latest"]':
-            problems.append('runs_on does not default to ["ubuntu-latest"]')
-    for job, body in (document.get('jobs') or {}).items():
-        if body.get('runs-on') != '${{ fromJSON(inputs.runs_on) }}':
-            problems.append(f'job {job} does not consume fromJSON(inputs.runs_on)')
+        # YAML 1.1 reads the `on:` key as the boolean `true`.
+        trigger = document.get('on', document.get(True)) or {}
+        spec = ((trigger.get('workflow_call') or {}).get('inputs') or {}).get('runs_on')
+        if spec is None:
+            problems.append('declares no runs_on workflow_call input')
+        elif not isinstance(spec, dict):
+            problems.append(f'runs_on is not an input declaration ({spec!r})')
+        else:
+            if spec.get('required') is not False:
+                problems.append('runs_on is not optional')
+            if spec.get('default') != '["ubuntu-latest"]':
+                problems.append('runs_on does not default to ["ubuntu-latest"]')
+
+        for job, body in (document.get('jobs') or {}).items():
+            body = body or {}
+            # A job that CALLS another workflow cannot declare `runs-on` -- GitHub
+            # rejects the key there -- so it forwards the input instead. Demanding
+            # `runs-on` of every job would fail such a job for being correct; not
+            # asserting anything about it would let half a migration through, the
+            # shape `test-dart-pipeline.sh` calls out on the Dart children.
+            if 'uses' in body:
+                if (body.get('with') or {}).get('runs_on') != '${{ inputs.runs_on }}':
+                    problems.append(f'job {job} calls a workflow without forwarding runs_on')
+            elif body.get('runs-on') != '${{ fromJSON(inputs.runs_on) }}':
+                problems.append(f'job {job} does not consume fromJSON(inputs.runs_on)')
+    except (OSError, yaml.YAMLError) as error:
+        problems.append(f'unreadable ({error})')
+    except Exception as error:                      # noqa: BLE001 -- see the note above
+        problems.append(f'{type(error).__name__}: {error}')
+
     if problems:
         print(f'{name}: ' + '; '.join(problems))
 PY

--- a/.github/tests/test-workflow-composition.sh
+++ b/.github/tests/test-workflow-composition.sh
@@ -32,12 +32,20 @@ set -e
 #
 # WHAT IT DOES NOT DO
 #
-# It does not parse YAML with a library -- PyYAML is not assumed present here,
-# the same constraint `order-check` and `var-catalog` work under. It reads the
-# files as indented text, which is sufficient because every assertion below is
-# about a line shape (a job key at two spaces, a `name:` at four) rather than
-# about a resolved document. A workflow written in flow style would slip past
-# it; none is, and one would fail review long before this.
+# Tests 1-9 do not parse YAML with a library -- the same constraint `order-check`
+# and `var-catalog` work under. They read the files as indented text, which is
+# sufficient because each is about a line shape (a job key at two spaces, a
+# `name:` at four) rather than about a resolved document. A workflow written in
+# flow style would slip past them; none is, and one would fail review long
+# before this.
+#
+# Test 10 is the one exception and does need PyYAML, because the key it asserts
+# under is one YAML 1.1 RESOLVES: `on:` parses as the boolean `true`, so
+# `runs_on` sits under no key spelled `on` at all and no indentation rule can
+# reach it. It is written so that a host without PyYAML sees that assertion FAIL
+# BY NAME rather than a traceback -- see the comment there. CI installs
+# `python3-yaml` (`.github/workflows/ci.yaml`), and `make test` already requires
+# it for `test-azure-step-names.sh` and `test-lambda-templates.sh`.
 
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 export SCRIPTS_DIR
@@ -336,34 +344,72 @@ done < <(reusable_workflows)
 assert_empty "every deployment suffix names a 50-deployment provider that exists" "$NO_ACTION"
 echo ""
 
-# The Claude reusables are STANDALONE, so every rule above deliberately skips them --
-# and nothing else asserts their `runs_on` wiring. Consumers route these onto
-# self-hosted runners through that input (#635), so a refactor that drops it or
-# re-hardcodes the runner goes green while breaking every such consumer. Asserted on
-# the PARSED document, same as the Dart suite: YAML 1.1 reads `on:` as the boolean
-# `true`, and a grep would pass on a file that only mentions the name in a comment.
-BAD_RUNS_ON=''
-for file in reusable-claude-review.yaml reusable-claude-mention.yaml; do
-  result="$(python3 -c "
-import yaml
-d = yaml.safe_load(open('$SCRIPTS_DIR/.github/workflows/$file'))
-trigger = d.get('on', d.get(True))
-spec = ((trigger.get('workflow_call') or {}).get('inputs') or {}).get('runs_on')
-problems = []
-if spec is None:
-    problems.append('declares no runs_on workflow_call input')
-else:
-    if spec.get('required') is not False:
-        problems.append('runs_on is not optional')
-    if spec.get('default') != '[\"ubuntu-latest\"]':
-        problems.append('runs_on does not default to [\"ubuntu-latest\"]')
-for name, job in (d.get('jobs') or {}).items():
-    if job.get('runs-on') != '\${{ fromJSON(inputs.runs_on) }}':
-        problems.append(f'job {name} does not consume fromJSON(inputs.runs_on)')
-print('; '.join(problems))
-")"
-  [[ -n "$result" ]] && BAD_RUNS_ON="${BAD_RUNS_ON}${file}: ${result}"$'\n'
-done
+echo "Test 10: the Claude reusables declare and consume runs_on"
+# The Claude reusables are STANDALONE, so every rule above deliberately skips
+# them -- and nothing else asserts their `runs_on` wiring. Consumers route these
+# onto self-hosted runners through that input (#635), so a refactor that drops it
+# or re-hardcodes the runner goes green while quietly pinning every such consumer
+# back onto a hosted runner.
+#
+# Three things about the shape below are deliberate:
+#
+#   - It reads the PARSED document, the only assertion here that does, and the
+#     file header says why. Same shape as `test-dart-pipeline.sh`, which asserts
+#     this same wiring on the Dart workflows.
+#   - The files come from a GLOB, not a list. A third `reusable-claude-*.yaml`
+#     added to STANDALONE is already skipped by Tests 1, 2 and 9 by design; named
+#     in a list here it would be unchecked by this one too, and a hardcoded runner
+#     in it would go green. A glob matching nothing is itself reported, so a
+#     rename fails here rather than passing by having nothing left to check.
+#   - Every path through the Python exits 0 and speaks through stdout, including
+#     a missing PyYAML and an unreadable file. This script runs under `set -e`, so
+#     a non-zero exit inside the command substitution would kill the suite after
+#     nine PASS lines with no FAIL line and no summary -- which reads as a crash
+#     rather than as a verdict.
+BAD_RUNS_ON="$(python3 - "$WORKFLOWS_DIR" <<'PY'
+import glob
+import os
+import sys
+
+try:
+    import yaml
+except ImportError:
+    print('PyYAML is required for this assertion '
+          '(CI installs python3-yaml; locally: pip install pyyaml)')
+    sys.exit(0)
+
+workflows_dir = sys.argv[1]
+paths = sorted(glob.glob(os.path.join(workflows_dir, 'reusable-claude-*.yaml')))
+if not paths:
+    print('no reusable-claude-*.yaml in .github/workflows/ -- renamed, or removed')
+
+for path in paths:
+    name = os.path.basename(path)
+    try:
+        with open(path, encoding='utf-8') as handle:
+            document = yaml.safe_load(handle)
+    except (OSError, yaml.YAMLError) as error:
+        print(f'{name}: unreadable ({error})')
+        continue
+
+    problems = []
+    # YAML 1.1 reads the `on:` key as the boolean `true`.
+    trigger = document.get('on', document.get(True)) or {}
+    spec = ((trigger.get('workflow_call') or {}).get('inputs') or {}).get('runs_on')
+    if spec is None:
+        problems.append('declares no runs_on workflow_call input')
+    else:
+        if spec.get('required') is not False:
+            problems.append('runs_on is not optional')
+        if spec.get('default') != '["ubuntu-latest"]':
+            problems.append('runs_on does not default to ["ubuntu-latest"]')
+    for job, body in (document.get('jobs') or {}).items():
+        if body.get('runs-on') != '${{ fromJSON(inputs.runs_on) }}':
+            problems.append(f'job {job} does not consume fromJSON(inputs.runs_on)')
+    if problems:
+        print(f'{name}: ' + '; '.join(problems))
+PY
+)"
 assert_empty "the Claude reusables declare and consume the runs_on input" "$BAD_RUNS_ON"
 echo ""
 

--- a/.github/tests/test-workflow-composition.sh
+++ b/.github/tests/test-workflow-composition.sh
@@ -344,35 +344,42 @@ done < <(reusable_workflows)
 assert_empty "every deployment suffix names a 50-deployment provider that exists" "$NO_ACTION"
 echo ""
 
-echo "Test 10: the Claude reusables declare and consume runs_on"
-# The Claude reusables are STANDALONE, so every rule above deliberately skips
-# them -- and nothing else asserts their `runs_on` wiring. Consumers route these
-# onto self-hosted runners through that input (#635), so a refactor that drops it
-# or re-hardcodes the runner goes green while quietly pinning every such consumer
-# back onto a hosted runner.
+echo "Test 10: every workflow declaring runs_on declares and consumes it the same way"
+# Two halves, because either alone is defeatable.
 #
-# Three things about the shape below are deliberate:
+# The CONTRACT half runs over every workflow that declares a `runs_on` input --
+# 19 of them today, not just the two this test was written for. The shape is not
+# Claude-specific: `go.yaml`, `yarn.yaml`, `npm.yaml`, `dart.yaml` and their
+# children all declare the byte-identical input, and only the Dart ones were
+# asserted anywhere (`test-dart-pipeline.sh`). Running the same body over all of
+# them costs nothing and closes the gap a `reusable-claude-*` glob leaves: a
+# future Claude workflow named outside that pattern.
 #
-#   - It reads the PARSED document, the only assertion here that does, and the
-#     file header says why. Same shape as `test-dart-pipeline.sh`, which asserts
-#     this same wiring on the Dart workflows.
-#   - The files come from a GLOB, not a list. A third `reusable-claude-*.yaml`
-#     added to STANDALONE is already skipped by Tests 1, 2 and 9 by design; named
-#     in a list here it would be unchecked by this one too, and a hardcoded runner
-#     in it would go green. A glob matching nothing is itself reported, so a
-#     rename fails here rather than passing by having nothing left to check.
+# The DECLARATION half keeps the glob, because generalising alone would invert
+# the assertion -- a workflow that DROPS the input stops being iterated and
+# passes by not being looked at. The Claude reusables are STANDALONE, so Tests 1,
+# 2 and 9 skip them by design and nothing else names them; the glob, rather than
+# a list of two filenames, is what stops a third one from being invisible here as
+# well. A glob matching nothing is itself reported, so a rename fails rather than
+# passing with nothing left to check.
+#
+# Two more things about the shape below are deliberate:
+#
+#   - It reads the PARSED document, one of the two assertions here that does, and
+#     the file header says why. Same shape as `test-dart-pipeline.sh`.
 #   - Every path through the Python exits 0 and speaks through stdout. This script
 #     runs under `set -e`, so a non-zero exit inside the command substitution would
-#     kill the suite after nine PASS lines with no FAIL line and no summary --
-#     which reads as a crash rather than as a verdict. `except Exception` around
-#     the per-file body is deliberately that broad: `OSError`/`YAMLError` cover an
-#     unreadable file, but an EMPTY workflow (`safe_load` returns `None`), a scalar
-#     `runs_on:` or a job with an empty body are all well-formed YAML that raise
-#     `AttributeError` on the lookups below -- which would abort the suite for the
-#     shapes it exists to report.
+#     kill the suite mid-run with no FAIL line and no summary -- which reads as a
+#     crash rather than as a verdict. `except Exception` around the per-file body
+#     is deliberately that broad: `OSError`/`YAMLError` cover an unreadable file,
+#     but an EMPTY workflow (`safe_load` returns `None`), a scalar `runs_on:` or a
+#     job with an empty body are all well-formed YAML that raise `AttributeError`
+#     on the lookups below -- which would abort the suite for the shapes it exists
+#     to report.
 BAD_RUNS_ON="$(python3 - "$WORKFLOWS_DIR" <<'PY'
 import glob
 import os
+import re
 import sys
 
 try:
@@ -383,23 +390,45 @@ except ImportError:
     sys.exit(0)
 
 workflows_dir = sys.argv[1]
-paths = sorted(glob.glob(os.path.join(workflows_dir, 'reusable-claude-*.yaml')))
-if not paths:
+
+# `${{inputs.runs_on}}` and `${{ inputs.runs_on }}` are the same forward. Comparing
+# the raw string would report the correct one as "not forwarding runs_on", which
+# points a reader at the wrong defect -- `test-dart-pipeline.sh` checks presence for
+# the same reason. Normalising keeps the stricter check without the false positive.
+EXPRESSION = re.compile(r'\$\{\{\s*(.*?)\s*\}\}')
+
+
+def normalized(value):
+    return EXPRESSION.sub(r'${{ \1 }}', value) if isinstance(value, str) else value
+
+
+def runs_on_input(document):
+    # YAML 1.1 reads the `on:` key as the boolean `true`.
+    trigger = document.get('on', document.get(True)) or {}
+    return ((trigger.get('workflow_call') or {}).get('inputs') or {}).get('runs_on')
+
+
+# DECLARATION half: these must offer the input at all.
+must_declare = sorted(glob.glob(os.path.join(workflows_dir, 'reusable-claude-*.yaml')))
+if not must_declare:
     print('no reusable-claude-*.yaml in .github/workflows/ -- renamed, or removed')
 
-for path in paths:
+for path in sorted(glob.glob(os.path.join(workflows_dir, '*.yaml'))):
     name = os.path.basename(path)
     problems = []
     try:
         with open(path, encoding='utf-8') as handle:
             document = yaml.safe_load(handle) or {}
 
-        # YAML 1.1 reads the `on:` key as the boolean `true`.
-        trigger = document.get('on', document.get(True)) or {}
-        spec = ((trigger.get('workflow_call') or {}).get('inputs') or {}).get('runs_on')
+        spec = runs_on_input(document)
         if spec is None:
-            problems.append('declares no runs_on workflow_call input')
-        elif not isinstance(spec, dict):
+            # CONTRACT half applies only to workflows that offer the input; the
+            # declaration half is what makes its absence a finding where it matters.
+            if path in must_declare:
+                print(f'{name}: declares no runs_on workflow_call input')
+            continue
+
+        if not isinstance(spec, dict):
             problems.append(f'runs_on is not an input declaration ({spec!r})')
         else:
             if spec.get('required') is not False:
@@ -415,9 +444,9 @@ for path in paths:
             # asserting anything about it would let half a migration through, the
             # shape `test-dart-pipeline.sh` calls out on the Dart children.
             if 'uses' in body:
-                if (body.get('with') or {}).get('runs_on') != '${{ inputs.runs_on }}':
+                if normalized((body.get('with') or {}).get('runs_on')) != '${{ inputs.runs_on }}':
                     problems.append(f'job {job} calls a workflow without forwarding runs_on')
-            elif body.get('runs-on') != '${{ fromJSON(inputs.runs_on) }}':
+            elif normalized(body.get('runs-on')) != '${{ fromJSON(inputs.runs_on) }}':
                 problems.append(f'job {job} does not consume fromJSON(inputs.runs_on)')
     except (OSError, yaml.YAMLError) as error:
         problems.append(f'unreadable ({error})')
@@ -428,7 +457,98 @@ for path in paths:
         print(f'{name}: ' + '; '.join(problems))
 PY
 )"
-assert_empty "the Claude reusables declare and consume the runs_on input" "$BAD_RUNS_ON"
+assert_empty "every runs_on input is optional, defaults to hosted, and reaches every job" "$BAD_RUNS_ON"
+echo ""
+
+echo "Test 11: the mention responder's trigger guard reads the right author"
+# The `@claude` responder runs with `contents: write` and this repository's secrets,
+# so its `if:` is the authorization boundary. It shipped with a hole: an
+# `issue_comment` payload carries BOTH `comment` and `issue`, so the clause reading
+# `github.event.issue.author_association` -- the THREAD AUTHOR's -- also evaluated on
+# every comment, and any comment by anyone on a maintainer-opened `@claude` thread
+# started the job.
+#
+# That guard now lives in a free-text `if:` block, which is the shape a reformat or a
+# "simplify these conditions" pass eats first, defended only by a comment saying not
+# to. This whole suite exists because a review habit is not an assertion, so the guard
+# gets one too.
+#
+# It is asserted STRUCTURALLY, not as a string match: the expression is split into its
+# top-level `||` clauses, and each clause that reads an `author_association` must also
+# carry the null-check selecting the payload it belongs to. The `issue` clause must
+# additionally exclude comment events -- by `github.event.comment == null` or by
+# `github.event_name == 'issues'`, either spelling, because the invariant is what
+# matters and not the idiom. A clause reading no association at all is an unguarded
+# trigger and is reported as one.
+BAD_TRIGGER="$(python3 - "$WORKFLOWS_DIR" <<'PY'
+import os
+import re
+import sys
+
+try:
+    import yaml
+except ImportError:
+    print('PyYAML is required for this assertion '
+          '(CI installs python3-yaml; locally: pip install pyyaml)')
+    sys.exit(0)
+
+WORKFLOW = 'reusable-claude-mention.yaml'
+ASSOCIATION = re.compile(r'github\.event\.(\w+)\.author_association')
+# Either spelling excludes an `issue_comment` payload, which carries both objects.
+COMMENT_EXCLUSIONS = ("github.event.comment == null", "github.event_name == 'issues'")
+
+
+def or_clauses(expression):
+    """Split on `||` at parenthesis depth 0 -- the clauses are themselves parenthesised."""
+    clauses, depth, current = [], 0, ''
+    index = 0
+    while index < len(expression):
+        character = expression[index]
+        if character == '(':
+            depth += 1
+        elif character == ')':
+            depth -= 1
+        elif depth == 0 and expression[index:index + 2] == '||':
+            clauses.append(current)
+            current = ''
+            index += 2
+            continue
+        current += character
+        index += 1
+    clauses.append(current)
+    return [clause.strip() for clause in clauses if clause.strip()]
+
+
+path = os.path.join(sys.argv[1], WORKFLOW)
+try:
+    with open(path, encoding='utf-8') as handle:
+        document = yaml.safe_load(handle) or {}
+
+    for job, body in (document.get('jobs') or {}).items():
+        condition = ' '.join(str((body or {}).get('if', '')).split())
+        if not condition:
+            print(f'{WORKFLOW}: job {job} has no `if:` -- the trigger is unguarded')
+            continue
+        for clause in or_clauses(condition):
+            authors = set(ASSOCIATION.findall(clause))
+            if not authors:
+                print(f'{WORKFLOW}: job {job} has a clause reading no author_association: {clause}')
+                continue
+            for author in sorted(authors):
+                if f'github.event.{author} != null' not in clause:
+                    print(f'{WORKFLOW}: job {job} reads {author}.author_association '
+                          f'without requiring github.event.{author} != null')
+                if author == 'issue' and not any(x in clause for x in COMMENT_EXCLUSIONS):
+                    print(f'{WORKFLOW}: job {job} reads the THREAD AUTHOR association on a clause '
+                          f'that an issue_comment payload also reaches -- it carries both '
+                          f'`comment` and `issue`')
+except (OSError, yaml.YAMLError) as error:
+    print(f'{WORKFLOW}: unreadable ({error})')
+except Exception as error:                          # noqa: BLE001 -- see Test 10's note
+    print(f'{WORKFLOW}: {type(error).__name__}: {error}')
+PY
+)"
+assert_empty "every trigger clause checks the association of whoever wrote what it matched" "$BAD_TRIGGER"
 echo ""
 
 echo "================================"

--- a/.github/tests/test-workflow-composition.sh
+++ b/.github/tests/test-workflow-composition.sh
@@ -336,6 +336,37 @@ done < <(reusable_workflows)
 assert_empty "every deployment suffix names a 50-deployment provider that exists" "$NO_ACTION"
 echo ""
 
+# The Claude reusables are STANDALONE, so every rule above deliberately skips them --
+# and nothing else asserts their `runs_on` wiring. Consumers route these onto
+# self-hosted runners through that input (#635), so a refactor that drops it or
+# re-hardcodes the runner goes green while breaking every such consumer. Asserted on
+# the PARSED document, same as the Dart suite: YAML 1.1 reads `on:` as the boolean
+# `true`, and a grep would pass on a file that only mentions the name in a comment.
+BAD_RUNS_ON=''
+for file in reusable-claude-review.yaml reusable-claude-mention.yaml; do
+  result="$(python3 -c "
+import yaml
+d = yaml.safe_load(open('$SCRIPTS_DIR/.github/workflows/$file'))
+trigger = d.get('on', d.get(True))
+spec = ((trigger.get('workflow_call') or {}).get('inputs') or {}).get('runs_on')
+problems = []
+if spec is None:
+    problems.append('declares no runs_on workflow_call input')
+else:
+    if spec.get('required') is not False:
+        problems.append('runs_on is not optional')
+    if spec.get('default') != '[\"ubuntu-latest\"]':
+        problems.append('runs_on does not default to [\"ubuntu-latest\"]')
+for name, job in (d.get('jobs') or {}).items():
+    if job.get('runs-on') != '\${{ fromJSON(inputs.runs_on) }}':
+        problems.append(f'job {name} does not consume fromJSON(inputs.runs_on)')
+print('; '.join(problems))
+")"
+  [[ -n "$result" ]] && BAD_RUNS_ON="${BAD_RUNS_ON}${file}: ${result}"$'\n'
+done
+assert_empty "the Claude reusables declare and consume the runs_on input" "$BAD_RUNS_ON"
+echo ""
+
 echo "================================"
 echo -e "Tests passed: ${GREEN}${TESTS_PASSED}${NC}"
 if [[ $TESTS_FAILED -gt 0 ]]; then

--- a/.github/tests/test-workflow-composition.sh
+++ b/.github/tests/test-workflow-composition.sh
@@ -409,7 +409,11 @@ def normalized(value):
 # input (`flutter-artifacts.yaml` documents an `ipa` job needing macOS). So the rule
 # is "resolves from a DECLARED input", which rejects every hardcoded runner while
 # leaving a second input available for a hard platform requirement.
-RUNNER = re.compile(r'^\$\{\{ fromJSON\(inputs\.(\w+)\) \}\}$')
+# `\s*` inside, not just around: `normalized()` collapses the whitespace bordering
+# `${{ … }}` and a reformat may equally produce `fromJSON( inputs.runs_on )`. Anchoring
+# on exact interior spacing would report that correct job as PINNING A RUNNER -- the
+# wrong-defect message the `with:` compare was already fixed for.
+RUNNER = re.compile(r'^\$\{\{\s*fromJSON\(\s*inputs\.(\w+)\s*\)\s*\}\}$')
 
 
 def declared_inputs(document):
@@ -432,7 +436,15 @@ def takes_runs_on(workflows_dir, uses):
     this directory can be resolved; anything else is assumed to take it, which is
     the status quo rather than a new silence.
     """
-    path = os.path.join(workflows_dir, os.path.basename(str(uses).split('@')[0]))
+    reference = str(uses).split('@')[0]
+    # By basename alone, `someorg/theirrepo/.github/workflows/go.yaml@v1` would resolve
+    # to THIS repository's `go.yaml` and the forward would be demanded of a callee that
+    # does not declare it -- the same trap this function exists to avoid, from the other
+    # side. Only a local path or this repository's own workflows are resolvable.
+    if not (reference.startswith('./')
+            or reference.startswith('rios0rios0/pipelines/.github/workflows/')):
+        return True
+    path = os.path.join(workflows_dir, os.path.basename(reference))
     if not os.path.isfile(path):
         return True
     try:
@@ -456,10 +468,25 @@ for path in sorted(glob.glob(os.path.join(workflows_dir, '*.yaml'))):
 
         spec = runs_on_input(document)
         if spec is None:
-            # CONTRACT half applies only to workflows that offer the input; the
-            # declaration half is what makes its absence a finding where it matters.
+            # CONTRACT half applies only to workflows that offer the input, so its
+            # ABSENCE has to be a finding in its own right or the whole assertion
+            # inverts -- a workflow that drops the input stops being iterated and
+            # passes by not being looked at. Two ways it becomes one:
             if path in must_declare:
                 print(f'{name}: declares no runs_on workflow_call input')
+            elif 'workflow_call' in (document.get('on', document.get(True)) or {}):
+                # A REUSABLE workflow that composes one taking `runs_on` must pass the
+                # choice through; otherwise its consumers cannot reach a self-hosted
+                # runner at all, for the composed pipeline OR its own jobs. `yarn-docker`
+                # and `yarn-library` were exactly this -- their npm twins with the input
+                # dropped. A LEAF caller (this repository's own `claude-review.yaml`) is
+                # not reusable and is entitled to take the default, so it is not asked.
+                for job, body in (document.get('jobs') or {}).items():
+                    body = body or {}
+                    if 'uses' in body and takes_runs_on(workflows_dir, body['uses']):
+                        print(f'{name}: job {job} calls a workflow that takes runs_on, but '
+                              f'{name} declares no runs_on of its own to forward -- its '
+                              f'consumers cannot reach another runner')
             continue
 
         if not isinstance(spec, dict):
@@ -470,6 +497,7 @@ for path in sorted(glob.glob(os.path.join(workflows_dir, '*.yaml'))):
             if spec.get('default') != '["ubuntu-latest"]':
                 problems.append('runs_on does not default to ["ubuntu-latest"]')
 
+        reaches_a_job = False
         for job, body in (document.get('jobs') or {}).items():
             body = body or {}
             # A job that CALLS another workflow cannot declare `runs-on` -- GitHub
@@ -482,14 +510,27 @@ for path in sorted(glob.glob(os.path.join(workflows_dir, '*.yaml'))):
                     continue
                 if normalized((body.get('with') or {}).get('runs_on')) != '${{ inputs.runs_on }}':
                     problems.append(f'job {job} calls a workflow without forwarding runs_on')
+                else:
+                    reaches_a_job = True
                 continue
-            selector = RUNNER.match(normalized(body.get('runs-on')) or '')
+            selected = normalized(body.get('runs-on'))
+            selector = RUNNER.match(selected) if isinstance(selected, str) else None
             if not selector:
                 problems.append(f'job {job} pins a runner instead of resolving one from an '
                                 f'input ({body.get("runs-on")!r})')
             elif selector.group(1) not in declared_inputs(document):
                 problems.append(f'job {job} resolves its runner from inputs.{selector.group(1)}, '
                                 f'which the workflow does not declare')
+            elif selector.group(1) == 'runs_on':
+                reaches_a_job = True
+
+        # The runner rule accepts ANY declared input, which is what lets a job with a hard
+        # platform requirement take a second one. Without this, a workflow could declare
+        # `runs_on` and route every job through something else: the consumer sets it, GitHub
+        # accepts it because it is declared, and nobody reads it. A silently ignored input is
+        # worse than a rejected one, and the assertion's label promises it reaches a job.
+        if not problems and not reaches_a_job:
+            problems.append('declares runs_on that no job resolves from or forwards')
     except (OSError, yaml.YAMLError) as error:
         problems.append(f'unreadable ({error})')
     except Exception as error:                      # noqa: BLE001 -- see the note above
@@ -523,6 +564,7 @@ echo "Test 11: the mention responder's trigger guard reads the right author"
 # matters and not the idiom. A clause reading no association at all is an unguarded
 # trigger and is reported as one.
 BAD_TRIGGER="$(python3 - "$WORKFLOWS_DIR" <<'PY'
+import json
 import os
 import re
 import sys
@@ -538,6 +580,12 @@ WORKFLOW = 'reusable-claude-mention.yaml'
 ASSOCIATION = re.compile(r'github\.event\.(\w+)\.author_association')
 # Either spelling excludes an `issue_comment` payload, which carries both objects.
 COMMENT_EXCLUSIONS = ("github.event.comment == null", "github.event_name == 'issues'")
+# WHICH association a clause reads is only half the boundary; the other half is what it
+# is read AGAINST. Adding `CONTRIBUTOR` or `NONE` is one token inside the same free-text
+# block, and it opens the job to anyone who has ever landed a commit -- or to anyone at
+# all -- while every pairing check above still passes.
+PRIVILEGED = ['COLLABORATOR', 'MEMBER', 'OWNER']
+ALLOWLIST = re.compile(r'contains\(\s*fromJSON\(\s*\'(\[[^\']*\])\'\s*\)')
 
 
 def or_clauses(expression):
@@ -589,6 +637,15 @@ try:
                       f'associations {sorted(authors)} -- the top-level `||` split did not '
                       f'separate them, so the null-check pairing is unverified')
                 continue
+            for raw in ALLOWLIST.findall(clause):
+                try:
+                    allowed = sorted(json.loads(raw))
+                except ValueError:
+                    print(f'{WORKFLOW}: job {job} has an association list that is not JSON: {raw}')
+                    continue
+                if allowed != PRIVILEGED:
+                    print(f'{WORKFLOW}: job {job} admits {allowed} -- the trigger allowlist must '
+                          f'be exactly {PRIVILEGED}')
             for author in sorted(authors):
                 if f'github.event.{author} != null' not in clause:
                     print(f'{WORKFLOW}: job {job} reads {author}.author_association '

--- a/.github/tests/test-workflow-composition.sh
+++ b/.github/tests/test-workflow-composition.sh
@@ -39,13 +39,14 @@ set -e
 # flow style would slip past them; none is, and one would fail review long
 # before this.
 #
-# Test 10 is the one exception and does need PyYAML, because the key it asserts
-# under is one YAML 1.1 RESOLVES: `on:` parses as the boolean `true`, so
-# `runs_on` sits under no key spelled `on` at all and no indentation rule can
-# reach it. It is written so that a host without PyYAML sees that assertion FAIL
-# BY NAME rather than a traceback -- see the comment there. CI installs
-# `python3-yaml` (`.github/workflows/ci.yaml`), and `make test` already requires
-# it for `test-azure-step-names.sh` and `test-lambda-templates.sh`.
+# Tests 10 and 11 are the exceptions and do need PyYAML. Test 10 asserts under a
+# key YAML 1.1 RESOLVES -- `on:` parses as the boolean `true`, so `runs_on` sits
+# under no key spelled `on` at all and no indentation rule can reach it -- and
+# Test 11 needs the `if:` as ONE expression, which a block scalar spreads over
+# ten physical lines. Both are written so that a host without PyYAML sees the
+# assertion FAIL BY NAME rather than a traceback -- see the comments there. CI
+# installs `python3-yaml` (`.github/workflows/ci.yaml`), and `make test` already
+# requires it for `test-azure-step-names.sh` and `test-lambda-templates.sh`.
 
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 export SCRIPTS_DIR
@@ -402,10 +403,43 @@ def normalized(value):
     return EXPRESSION.sub(r'${{ \1 }}', value) if isinstance(value, str) else value
 
 
-def runs_on_input(document):
+# A job's runner must be CALLER-SELECTABLE; it need not be this exact input.
+# `runs-on` is a hard selector, so a hardcoded runner is what strands a consumer --
+# and a workflow spanning two platforms genuinely cannot express both through one
+# input (`flutter-artifacts.yaml` documents an `ipa` job needing macOS). So the rule
+# is "resolves from a DECLARED input", which rejects every hardcoded runner while
+# leaving a second input available for a hard platform requirement.
+RUNNER = re.compile(r'^\$\{\{ fromJSON\(inputs\.(\w+)\) \}\}$')
+
+
+def declared_inputs(document):
     # YAML 1.1 reads the `on:` key as the boolean `true`.
     trigger = document.get('on', document.get(True)) or {}
-    return ((trigger.get('workflow_call') or {}).get('inputs') or {}).get('runs_on')
+    return (trigger.get('workflow_call') or {}).get('inputs') or {}
+
+
+def runs_on_input(document):
+    return declared_inputs(document).get('runs_on')
+
+
+def takes_runs_on(workflows_dir, uses):
+    """Does the workflow this job CALLS declare a `runs_on` input?
+
+    A `with:` key the callee does not declare is rejected by GitHub outright, so
+    demanding the forward unconditionally would be a trap the day a `runs_on`-
+    declaring workflow calls one without it (`update-major-version-tag.yaml` is the
+    callable example here, and `release.yaml` already calls it). Only a sibling in
+    this directory can be resolved; anything else is assumed to take it, which is
+    the status quo rather than a new silence.
+    """
+    path = os.path.join(workflows_dir, os.path.basename(str(uses).split('@')[0]))
+    if not os.path.isfile(path):
+        return True
+    try:
+        with open(path, encoding='utf-8') as handle:
+            return runs_on_input(yaml.safe_load(handle) or {}) is not None
+    except (OSError, yaml.YAMLError):
+        return True
 
 
 # DECLARATION half: these must offer the input at all.
@@ -444,10 +478,18 @@ for path in sorted(glob.glob(os.path.join(workflows_dir, '*.yaml'))):
             # asserting anything about it would let half a migration through, the
             # shape `test-dart-pipeline.sh` calls out on the Dart children.
             if 'uses' in body:
+                if not takes_runs_on(workflows_dir, body['uses']):
+                    continue
                 if normalized((body.get('with') or {}).get('runs_on')) != '${{ inputs.runs_on }}':
                     problems.append(f'job {job} calls a workflow without forwarding runs_on')
-            elif normalized(body.get('runs-on')) != '${{ fromJSON(inputs.runs_on) }}':
-                problems.append(f'job {job} does not consume fromJSON(inputs.runs_on)')
+                continue
+            selector = RUNNER.match(normalized(body.get('runs-on')) or '')
+            if not selector:
+                problems.append(f'job {job} pins a runner instead of resolving one from an '
+                                f'input ({body.get("runs-on")!r})')
+            elif selector.group(1) not in declared_inputs(document):
+                problems.append(f'job {job} resolves its runner from inputs.{selector.group(1)}, '
+                                f'which the workflow does not declare')
     except (OSError, yaml.YAMLError) as error:
         problems.append(f'unreadable ({error})')
     except Exception as error:                      # noqa: BLE001 -- see the note above
@@ -533,6 +575,19 @@ try:
             authors = set(ASSOCIATION.findall(clause))
             if not authors:
                 print(f'{WORKFLOW}: job {job} has a clause reading no author_association: {clause}')
+                continue
+            if len(authors) > 1:
+                # `or_clauses` splits at parenthesis depth 0, which only separates the
+                # clauses while each is itself parenthesised. Wrap the expression --
+                # `github.event_name != 'x' && ( (A) || (B) || (C) )`, or anything a
+                # "tidy these conditions" pass produces -- and every `||` sits at depth
+                # 1, the split returns ONE clause, and every check below degrades from
+                # `paired within a clause` to `present somewhere in the expression`
+                # while still printing PASS. That is this assertion's own threat model,
+                # so the assumption is checked rather than documented.
+                print(f'{WORKFLOW}: job {job} has one clause reading {len(authors)} payload '
+                      f'associations {sorted(authors)} -- the top-level `||` split did not '
+                      f'separate them, so the null-check pairing is unverified')
                 continue
             for author in sorted(authors):
                 if f'github.event.{author} != null' not in clause:

--- a/.github/workflows/flutter-artifacts.yaml
+++ b/.github/workflows/flutter-artifacts.yaml
@@ -8,7 +8,13 @@
 # `ipa` is not built here: it needs a `macos-latest` runner and, to be
 # installable, a signing identity and provisioning profile that belong to the
 # consuming project rather than to a shared template. Add a job with
-# `runs-on: macos-latest` and `targets: ipa` when you have them.
+# `targets: ipa` when you have them -- and give it a SECOND input,
+# `runs_on_macos`, defaulting to `'["macos-latest"]'`, rather than hardcoding the
+# runner. `runs_on` carries one value for the whole workflow, so a job on another
+# platform cannot share it; and `test-workflow-composition.sh` rejects a pinned
+# runner outright, because a hard `runs-on` is what strands a consumer whose
+# hosted minutes are gone. Resolving from a declared input is the contract, not
+# resolving from that particular input.
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/reusable-claude-mention.yaml
+++ b/.github/workflows/reusable-claude-mention.yaml
@@ -31,17 +31,27 @@ on:
 #
 # Unlike `reusable-claude-review.yaml`, this responder carries no same-repository guard, and that
 # is deliberate -- answering `@claude` under a fork's pull request is the point of a mention
-# responder. Know what it puts on the host before naming a persistent one. Only an OWNER, MEMBER
-# or COLLABORATOR can trigger it (the `if:` below) and the action re-checks the actor's write
-# permission, so an outside contributor cannot start it; but a maintainer's `@claude` on a fork
-# PR then runs holding `contents: write` and this repository's secrets, and tag mode fetches
-# `refs/pull/<n>/head` and checks the FORK's branch out into the workspace
-# (`src/github/operations/branch.ts`). The action restores `.claude/` and `.mcp.json` from the
-# base branch before the CLI reads them, so that injection path is closed -- the fork's code
-# itself is still on the runner, and a hosted runner discards it with the VM where a self-hosted
-# one does not.
+# responder. Know what it puts on the host before naming a persistent one. Two independent things
+# keep an outside contributor out: the `if:` below admits only an OWNER, MEMBER or COLLABORATOR,
+# reading the association of whoever wrote the text it matched on (see the note there -- the third
+# clause needed a guard to make that true), and the action re-checks the actor's write permission
+# itself. But a maintainer's `@claude` on a fork PR runs holding `contents: write` and this
+# repository's secrets, and tag mode then fetches `refs/pull/<n>/head` and checks the FORK's branch
+# out into the workspace (`src/github/operations/branch.ts`). The action restores `.claude/` and
+# `.mcp.json` from the base branch before the CLI reads them, so that injection path is closed --
+# the fork's code itself is still on the runner, and a hosted runner discards it with the VM where
+# a persistent self-hosted one does not.
 jobs:
   claude:
+    # Each clause admits ONE event shape and reads the association of whoever wrote the text it
+    # matched on. The third clause's `github.event.comment == null` is what keeps that true and
+    # must not be "simplified" away: an `issue_comment` payload carries BOTH `comment` and
+    # `issue`, so without it the third clause also evaluates on every comment -- and it consults
+    # `github.event.issue.author_association`, the THREAD AUTHOR's. Any comment by anyone on a
+    # maintainer-opened thread whose body or title says `@claude` would then start this job. The
+    # action re-checks the actor's write permission and refuses to act, so it is not an
+    # escalation, but the job still starts on the runner -- which on a self-hosted host is the
+    # whole exposure this workflow's comment above is about.
     if: |
       (github.event.comment != null &&
         contains(github.event.comment.body, '@claude') &&
@@ -49,7 +59,7 @@ jobs:
       (github.event.review != null &&
         contains(github.event.review.body, '@claude') &&
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
-      (github.event.issue != null &&
+      (github.event.issue != null && github.event.comment == null &&
         (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ${{ fromJSON(inputs.runs_on) }}
@@ -67,6 +77,10 @@ jobs:
 
       - name: 'Run Claude Code'
         id: 'claude'
+        # The provisioning list in the comment above `jobs:` (and README.md's "Claude Review and
+        # Claude Mention" section) describes THIS pin's install chain -- `oven-sh/setup-bun`,
+        # `@actions/tool-cache` resolving `unzip`, `$HOME/.bun/bin`, `bun install --production`.
+        # `dependency-updates.yaml` exists to make this SHA move; re-read both when it does.
         uses: 'anthropics/claude-code-action@70fec183852c4f82f3f1969faed7dd60c5149ca7' # v1.0.207
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/reusable-claude-mention.yaml
+++ b/.github/workflows/reusable-claude-mention.yaml
@@ -40,7 +40,11 @@ on:
 # out into the workspace (`src/github/operations/branch.ts`). The action restores `.claude/` and
 # `.mcp.json` from the base branch before the CLI reads them, so that injection path is closed --
 # the fork's code itself is still on the runner, and a hosted runner discards it with the VM where
-# a persistent self-hosted one does not.
+# a persistent self-hosted one does not. The restored set is wider than those two: `SENSITIVE_PATHS`
+# is `.claude`, `.mcp.json`, `.claude.json`, `.gitmodules`, `.ripgreprc`, `CLAUDE.md`,
+# `CLAUDE.local.md` and `.husky`. `CLAUDE.md` being in it has a consequence worth knowing here --
+# a reviewing agent's working tree carries the BASE branch's instructions, so a pull request that
+# edits `CLAUDE.md` is invisible to the review of that same pull request.
 jobs:
   claude:
     # Each clause admits ONE event shape and reads the association of whoever wrote the text it

--- a/.github/workflows/reusable-claude-mention.yaml
+++ b/.github/workflows/reusable-claude-mention.yaml
@@ -9,20 +9,37 @@ on:
         default: '["ubuntu-latest"]'
         description: |
           JSON array of runner labels (e.g. '["self-hosted"]'); see the `runs_on` input in
-          go.yaml for the shape's rationale. Unlike the review workflow, this responder has no
-          same-repository guard -- a trusted `@claude` mention under a fork's pull request runs
-          here holding `contents: write`, so on a persistent self-hosted host the fork's code
-          can share the machine. Weigh that before routing this workflow off hosted runners.
+          go.yaml for the shape's rationale, and the comment above `jobs:` for what this
+          workflow in particular puts on the runner it names.
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: true
         description: 'OAuth token used by the Claude Code action'
 
-# `ubuntu-latest` carries the Node runtime `anthropics/claude-code-action` runs on; a bare
-# self-hosted runner selected through `runs_on` needs that runtime, a writable `$HOME` for the
-# Bun and Claude CLI install the action performs, and network egress to `api.anthropic.com` and
-# `github.com`. A missing one does not fail at job selection -- it fails minutes in, inside the
-# action, with an error that never names the runner.
+# A bare self-hosted runner selected through `runs_on` must be provisioned before these jobs pass
+# -- and NOT with host Node: the Actions runner ships its own (`externals/node*`) and executes
+# every JavaScript action with it, on self-hosted hosts too. What a minimal host lacks is what
+# `anthropics/claude-code-action` shells OUT to. Every step of that composite declares
+# `shell: bash`; `oven-sh/setup-bun` unpacks Bun through `@actions/tool-cache`, which resolves
+# `unzip` and throws when it is absent; Bun installs into `$HOME/.bun/bin`, so `$HOME` must be
+# writable; `bun install --production` then resolves the action's dependencies from the npm
+# registry; and the checkout -- plus the PR branch tag mode fetches below -- needs `git`. So:
+# `bash`, `git` and `unzip` on `PATH`, a writable `$HOME`, and egress to `github.com`,
+# `registry.npmjs.org`, `api.github.com` and `api.anthropic.com`. A missing one does not fail at
+# job selection -- it fails minutes in, inside the action, with an error that never names the
+# runner.
+#
+# Unlike `reusable-claude-review.yaml`, this responder carries no same-repository guard, and that
+# is deliberate -- answering `@claude` under a fork's pull request is the point of a mention
+# responder. Know what it puts on the host before naming a persistent one. Only an OWNER, MEMBER
+# or COLLABORATOR can trigger it (the `if:` below) and the action re-checks the actor's write
+# permission, so an outside contributor cannot start it; but a maintainer's `@claude` on a fork
+# PR then runs holding `contents: write` and this repository's secrets, and tag mode fetches
+# `refs/pull/<n>/head` and checks the FORK's branch out into the workspace
+# (`src/github/operations/branch.ts`). The action restores `.claude/` and `.mcp.json` from the
+# base branch before the CLI reads them, so that injection path is closed -- the fork's code
+# itself is still on the runner, and a hosted runner discards it with the VM where a self-hosted
+# one does not.
 jobs:
   claude:
     if: |

--- a/.github/workflows/reusable-claude-mention.yaml
+++ b/.github/workflows/reusable-claude-mention.yaml
@@ -7,12 +7,22 @@ on:
         type: 'string'
         required: false
         default: '["ubuntu-latest"]'
-        description: 'JSON array of runner labels (e.g. ''["self-hosted"]''). See go.yaml.'
+        description: |
+          JSON array of runner labels (e.g. '["self-hosted"]'); see the `runs_on` input in
+          go.yaml for the shape's rationale. Unlike the review workflow, this responder has no
+          same-repository guard -- a trusted `@claude` mention under a fork's pull request runs
+          here holding `contents: write`, so on a persistent self-hosted host the fork's code
+          can share the machine. Weigh that before routing this workflow off hosted runners.
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: true
         description: 'OAuth token used by the Claude Code action'
 
+# `ubuntu-latest` carries the Node runtime `anthropics/claude-code-action` runs on; a bare
+# self-hosted runner selected through `runs_on` needs that runtime, a writable `$HOME` for the
+# Bun and Claude CLI install the action performs, and network egress to `api.anthropic.com` and
+# `github.com`. A missing one does not fail at job selection -- it fails minutes in, inside the
+# action, with an error that never names the runner.
 jobs:
   claude:
     if: |

--- a/.github/workflows/reusable-claude-review.yaml
+++ b/.github/workflows/reusable-claude-review.yaml
@@ -44,6 +44,10 @@ jobs:
 
       - name: 'Run Claude Code Review'
         id: 'claude-review'
+        # The provisioning list in the comment above `jobs:` (and README.md's "Claude Review and
+        # Claude Mention" section) describes THIS pin's install chain -- `oven-sh/setup-bun`,
+        # `@actions/tool-cache` resolving `unzip`, `$HOME/.bun/bin`, `bun install --production`.
+        # `dependency-updates.yaml` exists to make this SHA move; re-read both when it does.
         uses: 'anthropics/claude-code-action@70fec183852c4f82f3f1969faed7dd60c5149ca7' # v1.0.207
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/reusable-claude-review.yaml
+++ b/.github/workflows/reusable-claude-review.yaml
@@ -15,11 +15,18 @@ on:
         required: true
         description: 'OAuth token used by the Claude Code action'
 
-# `ubuntu-latest` carries the Node runtime `anthropics/claude-code-action` runs on; a bare
-# self-hosted runner selected through `runs_on` needs that runtime, a writable `$HOME` for the
-# Bun and Claude CLI install the action performs, and network egress to `api.anthropic.com` and
-# `github.com`. A missing one does not fail at job selection -- it fails minutes in, inside the
-# action, with an error that never names the runner.
+# A bare self-hosted runner selected through `runs_on` must be provisioned before these jobs pass
+# -- and NOT with host Node: the Actions runner ships its own (`externals/node*`) and executes
+# every JavaScript action with it, on self-hosted hosts too. What a minimal host lacks is what
+# `anthropics/claude-code-action` shells OUT to. Every step of that composite declares
+# `shell: bash`; `oven-sh/setup-bun` unpacks Bun through `@actions/tool-cache`, which resolves
+# `unzip` and throws when it is absent; Bun installs into `$HOME/.bun/bin`, so `$HOME` must be
+# writable; `bun install --production` then resolves the action's dependencies from the npm
+# registry; and the checkout -- plus the plugin marketplace cloned below -- needs `git`. So:
+# `bash`, `git` and `unzip` on `PATH`, a writable `$HOME`, and egress to `github.com`,
+# `registry.npmjs.org`, `api.github.com` and `api.anthropic.com`. A missing one does not fail at
+# job selection -- it fails minutes in, inside the action, with an error that never names the
+# runner.
 jobs:
   claude-review:
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/reusable-claude-review.yaml
+++ b/.github/workflows/reusable-claude-review.yaml
@@ -7,12 +7,19 @@ on:
         type: 'string'
         required: false
         default: '["ubuntu-latest"]'
-        description: 'JSON array of runner labels (e.g. ''["self-hosted"]''). See go.yaml.'
+        description: |
+          JSON array of runner labels (e.g. '["self-hosted"]'); see the `runs_on` input in
+          go.yaml for the shape's rationale.
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: true
         description: 'OAuth token used by the Claude Code action'
 
+# `ubuntu-latest` carries the Node runtime `anthropics/claude-code-action` runs on; a bare
+# self-hosted runner selected through `runs_on` needs that runtime, a writable `$HOME` for the
+# Bun and Claude CLI install the action performs, and network egress to `api.anthropic.com` and
+# `github.com`. A missing one does not fail at job selection -- it fails minutes in, inside the
+# action, with an error that never names the runner.
 jobs:
   claude-review:
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/yarn-docker.yaml
+++ b/.github/workflows/yarn-docker.yaml
@@ -1,6 +1,16 @@
 on:
   workflow_call:
     inputs:
+      runs_on:
+        type: 'string'
+        required: false
+        default: '["ubuntu-latest"]'
+        description: 'JSON array of runner labels (e.g. ''["self-hosted"]''). See yarn.yaml.'
+      codeql_upload:
+        type: 'string'
+        required: false
+        default: 'always'
+        description: "CodeQL SARIF upload mode ('always', 'failure-only' or 'never'). See yarn.yaml."
       install_run_scripts:
         type: 'boolean'
         required: false
@@ -20,6 +30,8 @@ jobs:
   yarn:
     uses: 'rios0rios0/pipelines/.github/workflows/yarn.yaml@main'
     with:
+      runs_on: ${{ inputs.runs_on }}
+      codeql_upload: ${{ inputs.codeql_upload }}
       install_run_scripts: ${{ inputs.install_run_scripts }}
       sonar_host: ${{ inputs.sonar_host }}
     secrets:
@@ -28,7 +40,7 @@ jobs:
   # fourth stage
   delivery-release:
     name: 'delivery > release'
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
     outputs:
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
@@ -39,7 +51,7 @@ jobs:
 
   delivery-docker:
     name: 'delivery > docker'
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
     steps:
       - uses: 'rios0rios0/pipelines/github/global/stages/40-delivery/docker@main'
         with:

--- a/.github/workflows/yarn-library.yaml
+++ b/.github/workflows/yarn-library.yaml
@@ -3,6 +3,11 @@
 on:
   workflow_call:
     inputs:
+      runs_on:
+        type: 'string'
+        required: false
+        default: '["ubuntu-latest"]'
+        description: 'JSON array of runner labels (e.g. ''["self-hosted"]''). See yarn.yaml.'
       codeql_upload:
         description: |
           Whether sast:codeql uploads its SARIF results ('always', 'failure-only' or 'never').
@@ -35,6 +40,7 @@ jobs:
   yarn:
     uses: 'rios0rios0/pipelines/.github/workflows/yarn.yaml@main'
     with:
+      runs_on: ${{ inputs.runs_on }}
       codeql_upload: '${{ inputs.codeql_upload }}'
       install_run_scripts: ${{ inputs.install_run_scripts }}
       sonar_host: '${{ inputs.sonar_host }}'
@@ -44,7 +50,7 @@ jobs:
   # fourth stage
   delivery-release:
     name: 'delivery > release'
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
     outputs:
       tag_name: '${{ steps.release.outputs.tag_name }}'
     strategy:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,7 +231,7 @@ is a large part of why the rule is a test rather than a review habit.
 
 ### Workflow Composition Standard
 
-**Enforced by `.github/tests/test-workflow-composition.sh` (`make test-workflow-composition`), ten
+**Enforced by `.github/tests/test-workflow-composition.sh` (`make test-workflow-composition`), eleven
 assertions, every one of them proven to fire against a deliberate violation.** Read this section
 before writing anything under `.github/workflows/`, and before writing a pipeline in a repository
 that consumes this one.
@@ -297,13 +297,32 @@ job and the called workflow's job. Renaming a job renames a check for everyone d
 
 **A `STANDALONE` workflow is exempt from the composition rules, not from every rule.** The two Claude
 reusables are listed there, so the naming, delegation and suffix assertions skip them by design —
-which left their `runs_on` wiring asserted by nothing at all. The tenth assertion covers it: both must
-declare an optional `runs_on` defaulting to `'["ubuntu-latest"]'`, and every job in them must consume
-`${{ fromJSON(inputs.runs_on) }}`, so a refactor that re-hardcodes the runner fails here instead of
-silently pinning every consumer back onto a hosted one. It reads the PARSED document — YAML 1.1
-resolves `on:` to the boolean `true`, so no indentation rule can reach under it — which makes it the
-one assertion in that suite needing PyYAML, and it says so by name rather than dying when it is
-absent.
+which left their wiring asserted by nothing at all. The last two assertions cover what that exemption
+leaves behind, and both read the PARSED document (YAML 1.1 resolves `on:` to the boolean `true`, so no
+indentation rule can reach under it) — which is why this suite needs PyYAML at all, and why it says so
+by name rather than dying when it is absent.
+
+The tenth is the **`runs_on` contract**, and it has two halves because either alone is defeatable. The
+contract half runs over *every* workflow declaring the input — 19 today, not just the Claude pair,
+since `go.yaml`, `yarn.yaml`, `npm.yaml` and `dart.yaml` declare the byte-identical shape: optional,
+defaulting to `'["ubuntu-latest"]'`, and reaching every job — as `runs-on: ${{ fromJSON(inputs.runs_on) }}`
+for a normal job, or forwarded in `with:` for a job that `uses:` another workflow, where GitHub rejects
+the `runs-on` key outright. The declaration half keeps a `reusable-claude-*.yaml` glob, because
+generalising alone would invert the assertion: a workflow that *drops* the input stops being iterated
+and would pass by not being looked at.
+
+The eleventh is the **mention responder's trigger guard**, which is an authorization boundary rather
+than a style rule — that job runs with `contents: write` and the repository's secrets. It shipped with
+a hole worth remembering: an `issue_comment` payload carries **both** `comment` and `issue`, so a
+clause reading `github.event.issue.author_association` — the *thread author's* — also evaluated on
+every comment, and any comment by anyone on a maintainer-opened `@claude` thread started the job. (Not
+an escalation: the action re-checks the actor's write permission and refuses to act. But the job
+started, which on a self-hosted runner is the whole exposure.) The assertion is structural, not a
+string match: the `if:` is split into its top-level `||` clauses, and each clause reading an
+`author_association` must carry the null-check selecting the payload it belongs to, with the `issue`
+clause additionally excluding comment events — by `github.event.comment == null` or
+`github.event_name == 'issues'`, either spelling, because the invariant is what matters and not the
+idiom.
 
 **Secrets reach a build as secrets.** A value passed into a reusable workflow as an *input* loses
 the caller's masking; passed as a *secret* it keeps it. That is why the deployment workflows take

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,6 +320,16 @@ runner, which is what the check enforces. And the forward is demanded only when 
 unconditionally would be a trap the first time one of these calls something like
 `update-major-version-tag.yaml`.
 
+That callee lookup has a **converse**, and it is the rule that catches the most consequential shape:
+a *reusable* workflow whose job calls one that takes `runs_on` must declare and forward it. Without it
+the inversion returns one level up — a composed workflow that drops the input stops being iterated and
+passes by not being looked at, while its consumers cannot reach another runner at all, for the composed
+pipeline *or* its own delivery jobs. `yarn-docker.yaml` and `yarn-library.yaml` were exactly that: their
+npm twins with the input deleted, hardcoded to `ubuntu-latest`, green the whole time. A **leaf** caller
+is deliberately not asked, since taking the default is what a caller is for. And because the runner rule
+accepts any declared input, a workflow declaring `runs_on` must have at least one job resolve from or
+forward *it* — otherwise a consumer sets an input that GitHub accepts and nobody reads.
+
 The eleventh is the **mention responder's trigger guard**, which is an authorization boundary rather
 than a style rule — that job runs with `contents: write` and the repository's secrets. It shipped with
 a hole worth remembering: an `issue_comment` payload carries **both** `comment` and `issue`, so a
@@ -334,7 +344,11 @@ clause additionally excluding comment events — by `github.event.comment == nul
 idiom. The split assumes each clause is itself parenthesised, and checks that assumption rather than
 documenting it: one clause reading more than one payload's association means a wrapping reformat
 collapsed them, at which point the pairing degrades to "present somewhere in the expression" — a PASS
-that verifies nothing, which is the failure this assertion exists to prevent.
+that verifies nothing, which is the failure this assertion exists to prevent. *Which* association a
+clause reads is only half the boundary, so the allowlist is pinned too: every clause's
+`contains(fromJSON(…))` must be exactly `OWNER`, `MEMBER`, `COLLABORATOR`. Adding `CONTRIBUTOR` or
+`NONE` is one token in the same free-text block and opens the job to anyone, with every pairing check
+still passing.
 
 **Secrets reach a build as secrets.** A value passed into a reusable workflow as an *input* loses
 the caller's masking; passed as a *secret* it keeps it. That is why the deployment workflows take

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,7 +231,7 @@ is a large part of why the rule is a test rather than a review habit.
 
 ### Workflow Composition Standard
 
-**Enforced by `.github/tests/test-workflow-composition.sh` (`make test-workflow-composition`), nine
+**Enforced by `.github/tests/test-workflow-composition.sh` (`make test-workflow-composition`), ten
 assertions, every one of them proven to fire against a deliberate violation.** Read this section
 before writing anything under `.github/workflows/`, and before writing a pipeline in a repository
 that consumes this one.
@@ -294,6 +294,16 @@ Every deployment job therefore declares, and the test asserts, all four of:
 **Job names are an API, not a label.** `delivery > <target>` and `deployment > <provider>` are the
 strings consumers pass to `require-checks`, because GitHub composes a check's name from the calling
 job and the called workflow's job. Renaming a job renames a check for everyone downstream.
+
+**A `STANDALONE` workflow is exempt from the composition rules, not from every rule.** The two Claude
+reusables are listed there, so the naming, delegation and suffix assertions skip them by design —
+which left their `runs_on` wiring asserted by nothing at all. The tenth assertion covers it: both must
+declare an optional `runs_on` defaulting to `'["ubuntu-latest"]'`, and every job in them must consume
+`${{ fromJSON(inputs.runs_on) }}`, so a refactor that re-hardcodes the runner fails here instead of
+silently pinning every consumer back onto a hosted one. It reads the PARSED document — YAML 1.1
+resolves `on:` to the boolean `true`, so no indentation rule can reach under it — which makes it the
+one assertion in that suite needing PyYAML, and it says so by name rather than dying when it is
+absent.
 
 **Secrets reach a build as secrets.** A value passed into a reusable workflow as an *input* loses
 the caller's masking; passed as a *secret* it keeps it. That is why the deployment workflows take

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,11 +305,20 @@ by name rather than dying when it is absent.
 The tenth is the **`runs_on` contract**, and it has two halves because either alone is defeatable. The
 contract half runs over *every* workflow declaring the input — 19 today, not just the Claude pair,
 since `go.yaml`, `yarn.yaml`, `npm.yaml` and `dart.yaml` declare the byte-identical shape: optional,
-defaulting to `'["ubuntu-latest"]'`, and reaching every job — as `runs-on: ${{ fromJSON(inputs.runs_on) }}`
-for a normal job, or forwarded in `with:` for a job that `uses:` another workflow, where GitHub rejects
-the `runs-on` key outright. The declaration half keeps a `reusable-claude-*.yaml` glob, because
-generalising alone would invert the assertion: a workflow that *drops* the input stops being iterated
-and would pass by not being looked at.
+defaulting to `'["ubuntu-latest"]'`, and reaching every job — resolved from a **declared input** for a
+normal job, or forwarded in `with:` for a job that `uses:` another workflow, where GitHub rejects the
+`runs-on` key outright. The declaration half keeps a `reusable-claude-*.yaml` glob, because generalising
+alone would invert the assertion: a workflow that *drops* the input stops being iterated and would pass
+by not being looked at.
+
+Two edges of that rule are worth stating, because the obvious stricter version of each is wrong. The
+runner must be **caller-selectable**, not literally `inputs.runs_on`: `runs_on` carries one value for
+the whole workflow, so a job on another platform cannot share it, and `flutter-artifacts.yaml` documents
+exactly such a job (an `ipa` build needing macOS) — it must take a second input rather than a pinned
+runner, which is what the check enforces. And the forward is demanded only when the **callee** declares
+`runs_on`: a `with:` key the callee does not declare is rejected by GitHub outright, so demanding it
+unconditionally would be a trap the first time one of these calls something like
+`update-major-version-tag.yaml`.
 
 The eleventh is the **mention responder's trigger guard**, which is an authorization boundary rather
 than a style rule — that job runs with `contents: write` and the repository's secrets. It shipped with
@@ -322,7 +331,10 @@ string match: the `if:` is split into its top-level `||` clauses, and each claus
 `author_association` must carry the null-check selecting the payload it belongs to, with the `issue`
 clause additionally excluding comment events — by `github.event.comment == null` or
 `github.event_name == 'issues'`, either spelling, because the invariant is what matters and not the
-idiom.
+idiom. The split assumes each clause is itself parenthesised, and checks that assumption rather than
+documenting it: one clause reading more than one payload's association means a wrapping reformat
+collapsed them, at which point the pairing degrades to "present somewhere in the expression" — a PASS
+that verifies nothing, which is the failure this assertion exists to prevent.
 
 **Secrets reach a build as secrets.** A value passed into a reusable workflow as an *input* loses
 the caller's masking; passed as a *secret* it keeps it. That is why the deployment workflows take

--- a/README.md
+++ b/README.md
@@ -267,6 +267,30 @@ token, which is how it posts reviews and comments. That is GitHub authentication
 separate from `claude_code_oauth_token`, which authenticates to Anthropic. Removing the scope
 fails every run with `Could not fetch an OIDC token`.
 
+Both take an optional `runs_on` — a JSON array of runner labels, `'["ubuntu-latest"]'` by
+default — for moving the pair onto self-hosted runners. Two things are worth knowing before
+using it.
+
+**A bare self-hosted host needs provisioning, and not the part most people reach for first.**
+The Actions runner ships its own Node and runs every JavaScript action with it, self-hosted
+included, so host Node is not the gap. What `anthropics/claude-code-action` shells out to is:
+`bash` (every step of that composite declares it), `unzip` (the Bun install unpacks through
+`@actions/tool-cache`, which resolves it and throws when it is absent), `git`, a writable
+`$HOME` (Bun lands in `$HOME/.bun/bin`), and egress to `github.com`, `registry.npmjs.org`,
+`api.github.com` and `api.anthropic.com`. A missing one does not fail at job selection — it
+fails minutes in, inside the action, with an error that never names the runner.
+
+**The two workflows differ in what they let onto that host.** `reusable-claude-review.yaml`
+runs only for pull requests opened from the repository itself. `reusable-claude-mention.yaml`
+deliberately does not, because answering `@claude` under a fork's pull request is the point of a
+mention responder. Only an OWNER, MEMBER or COLLABORATOR can trigger it and the action re-checks
+the actor's write permission, so an outside contributor cannot start it — but a maintainer's
+`@claude` on a fork PR then runs holding `contents: write` and this repository's secrets, and
+checks the fork's branch out into the workspace. The action restores `.claude/` and `.mcp.json`
+from the base branch first, so that injection path is closed; the fork's code itself is still on
+the runner, and a hosted runner discards it with the VM where a persistent self-hosted one does
+not.
+
 `.github/workflows/claude-review.yaml`:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -287,10 +287,13 @@ mention responder. An outside contributor is kept out twice over — the job's `
 OWNER, MEMBER or COLLABORATOR, reading the association of whoever wrote the text that matched, and
 the action independently re-checks the actor's write permission — but a maintainer's `@claude` on
 a fork PR then runs holding `contents: write` and this repository's secrets, and
-checks the fork's branch out into the workspace. The action restores `.claude/` and `.mcp.json`
-from the base branch first, so that injection path is closed; the fork's code itself is still on
+checks the fork's branch out into the workspace. The action restores its `SENSITIVE_PATHS` from the
+base branch first — `.claude`, `.mcp.json`, `.claude.json`, `.gitmodules`, `.ripgreprc`, `CLAUDE.md`,
+`CLAUDE.local.md`, `.husky` — so that injection path is closed; the fork's code itself is still on
 the runner, and a hosted runner discards it with the VM where a persistent self-hosted one does
-not.
+not. One consequence of `CLAUDE.md` being in that set is worth knowing before you rely on a review:
+a pull request that edits `CLAUDE.md` is reviewed against the **base** branch's copy, so the
+instructions it changes are not the ones the reviewing agent read.
 
 `.github/workflows/claude-review.yaml`:
 
@@ -304,6 +307,10 @@ on:
 jobs:
   claude-review:
     uses: 'rios0rios0/pipelines/.github/workflows/reusable-claude-review.yaml@main'
+    # Read the two paragraphs above before uncommenting: a bare self-hosted host
+    # needs provisioning, and it fails inside the action rather than at selection.
+    # with:
+    #   runs_on: '["self-hosted"]'
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     permissions:
@@ -331,6 +338,10 @@ on:
 jobs:
   claude-mention:
     uses: 'rios0rios0/pipelines/.github/workflows/reusable-claude-mention.yaml@main'
+    # Read the two paragraphs above before uncommenting: this one also puts a
+    # fork's checked-out branch on whatever host you name here.
+    # with:
+    #   runs_on: '["self-hosted"]'
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     permissions:

--- a/README.md
+++ b/README.md
@@ -283,9 +283,10 @@ fails minutes in, inside the action, with an error that never names the runner.
 **The two workflows differ in what they let onto that host.** `reusable-claude-review.yaml`
 runs only for pull requests opened from the repository itself. `reusable-claude-mention.yaml`
 deliberately does not, because answering `@claude` under a fork's pull request is the point of a
-mention responder. Only an OWNER, MEMBER or COLLABORATOR can trigger it and the action re-checks
-the actor's write permission, so an outside contributor cannot start it — but a maintainer's
-`@claude` on a fork PR then runs holding `contents: write` and this repository's secrets, and
+mention responder. An outside contributor is kept out twice over — the job's `if:` admits only an
+OWNER, MEMBER or COLLABORATOR, reading the association of whoever wrote the text that matched, and
+the action independently re-checks the actor's write permission — but a maintainer's `@claude` on
+a fork PR then runs holding `contents: write` and this repository's secrets, and
 checks the fork's branch out into the workspace. The action restores `.claude/` and `.mcp.json`
 from the base branch first, so that injection path is closed; the fork's code itself is still on
 the runner, and a hosted runner discards it with the VM where a persistent self-hosted one does


### PR DESCRIPTION
Follow-up to the review on #635 (https://github.com/rios0rios0/pipelines/pull/635#issuecomment-5445936521), addressing all four findings:

## 1. Runner-provisioning note (medium)

Both reusables gained the `go.yaml`-style comment above `jobs:`: a bare self-hosted runner selected through `runs_on` needs the runner's Node runtime, a writable `$HOME` for the Bun and Claude CLI install `anthropics/claude-code-action` performs, and egress to `api.anthropic.com` and `github.com` — and a missing one fails minutes in, inside the action, never naming the runner.

## 2. Fork-guard asymmetry of the mention responder (medium)

Recorded in the mention reusable's `runs_on` input description: unlike the review workflow, it carries no same-repository guard, so a trusted `@claude` mention under a fork's PR runs holding `contents: write` — on a persistent self-hosted host, fork code shares the machine. Per the review's own framing, the **guard itself is deliberately not added here**: what `claude-code-action` checks out for a fork PR in tag mode should be confirmed before deciding whether a guard belongs alongside the sentence.

## 3. Thin cross-reference (low)

`See go.yaml.` → the descriptions now name the `runs_on` input in go.yaml as the rationale being pointed at.

## 4. Nothing asserted the input exists (low)

`test-workflow-composition.sh` now asserts — on the parsed document, following the `test-dart-pipeline.sh` precedent — that both Claude reusables declare an optional `runs_on` defaulting to `["ubuntu-latest"]` and consume it as `runs-on: ${{ fromJSON(inputs.runs_on) }}`.

Proven to fire on both violation shapes before landing:
- re-hardcoding the runner → `FAIL: … job claude does not consume fromJSON(inputs.runs_on)`, exit 1
- dropping the input → `FAIL: … declares no runs_on workflow_call input`, exit 1

## Gates

- `make test-workflow-composition` — **10/10** pass (was 9)
- `make test-supply-chain` — pinning contract holds
- `make test-runner-cache-gating` — all pass

## Not done, deliberately

The README `runs_on` line — the review itself judged its absence consistent (no workflow's `runs_on` is in the README, `go.yaml` included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxhRL93tQeaL3y6bjeJPqG