### PR TITLE
fix(flyio): moved the `fly_app_name` example out of the evaluated input description

### DIFF
--- a/.changes/unreleased/1787877436562841322-f217.yaml
+++ b/.changes/unreleased/1787877436562841322-f217.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'fixed `go-flyio.yaml` failing to compile on every push because the `fly_app_name` usage example sat in the input `description:`, where GitHub evaluates `${{ }}` with no context available'
+time: '2026-08-28T00:37:16.562795953Z'

--- a/.changes/unreleased/1787877436564756238-15ee.yaml
+++ b/.changes/unreleased/1787877436564756238-15ee.yaml
@@ -1,0 +1,3 @@
+kind: 'Added'
+body: 'added a workflow-composition assertion that no `workflow_call` input or secret description contains an evaluated expression'
+time: '2026-08-28T00:37:16.564722548Z'

--- a/.changes/unreleased/1787879387962998284-9b83.yaml
+++ b/.changes/unreleased/1787879387962998284-9b83.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'broadened the trigger-block expression guard to every workflow file and to `default:` and `outputs`, and made it fail by name instead of aborting the suite when PyYAML is absent'
+time: '2026-08-28T01:09:47.962946359Z'

--- a/.github/tests/test-workflow-composition.sh
+++ b/.github/tests/test-workflow-composition.sh
@@ -39,11 +39,12 @@ set -e
 # flow style would slip past them; none is, and one would fail review long
 # before this.
 #
-# Tests 10 and 11 are the exceptions and do need PyYAML. Test 10 asserts under a
+# Tests 10, 11 and 12 are the exceptions and do need PyYAML. Test 10 asserts under a
 # key YAML 1.1 RESOLVES -- `on:` parses as the boolean `true`, so `runs_on` sits
 # under no key spelled `on` at all and no indentation rule can reach it -- and
 # Test 11 needs the `if:` as ONE expression, which a block scalar spreads over
-# ten physical lines. Both are written so that a host without PyYAML sees the
+# ten physical lines, and Test 12 walks the whole trigger block for evaluated
+# expressions. All three are written so that a host without PyYAML sees the
 # assertion FAIL BY NAME rather than a traceback -- see the comments there. CI
 # installs `python3-yaml` (`.github/workflows/ci.yaml`), and `make test` already
 # requires it for `test-azure-step-names.sh` and `test-lambda-templates.sh`.
@@ -663,30 +664,71 @@ PY
 assert_empty "every trigger clause checks the association of whoever wrote what it matched" "$BAD_TRIGGER"
 echo ""
 
-# A `${{ }}` sequence inside a `workflow_call` input or secret DESCRIPTION is evaluated
-# by GitHub, not treated as documentation -- and the `on:` block has no context, so an
+echo "Test 12: no trigger-block description or default carries an evaluated expression"
+
+# A `${{ }}` sequence in a `description:` or `default:` under `on:` is EVALUATED by
+# GitHub, not treated as documentation -- and the trigger block has no context, so an
 # example naming `github` makes the whole file fail to compile. It fails in the shape
 # that is hardest to read: the workflow is never triggered, yet every push produces a
 # failed run with no jobs, no logs, and the file PATH where the workflow name belongs.
 # `go-flyio.yaml` shipped exactly that in its `fly_app_name` example. Usage examples
 # belong in a `#` comment, which is never evaluated.
-EVALUATED_DESC=''
-while IFS= read -r file; do
-  result="$(python3 -c "
-import yaml, re
-d = yaml.safe_load(open('$SCRIPTS_DIR/.github/workflows/$file'))
-trigger = d.get('on', d.get(True))
-wc = (trigger or {}).get('workflow_call') or {}
-bad = []
-for kind in ('inputs', 'secrets'):
-    for name, spec in (wc.get(kind) or {}).items():
-        if '\${{' in ((spec or {}).get('description') or ''):
-            bad.append(f'{kind}.{name}')
-print(' '.join(bad))
-")"
-  [[ -n "$result" ]] && EVALUATED_DESC="${EVALUATED_DESC}${file}: expression in the description of ${result}"$'\n'
-done < <(reusable_workflows)
-assert_empty "no workflow_call description contains an evaluated expression" "$EVALUATED_DESC"
+#
+# Scoped to the CLASS, not the instance that was found: every file under `on:` (not
+# only reusable ones -- `workflow_dispatch` inputs evaluate identically), and every
+# `description` AND `default` (a `default:` is the likelier place to write
+# `${{ github.ref_name }}` believing it resolves), including nested `outputs`.
+BAD_ON_EXPRESSION="$(python3 - "$WORKFLOWS_DIR" <<'PY'
+import glob
+import os
+import sys
+
+try:
+    import yaml
+except ImportError:
+    print('PyYAML is required for this assertion '
+          '(CI installs python3-yaml; locally: pip install pyyaml)')
+    sys.exit(0)
+
+workflows_dir = sys.argv[1]
+
+# Only `description` and `default` are documentation-shaped keys a human writes prose
+# into. Every other scalar under `on:` (branch globs, paths, types) is data GitHub
+# reads literally, and none of it would contain `${{` except by the same mistake --
+# so flagging the two keys names the defect precisely instead of pattern-matching text.
+EVALUATED_KEYS = ('description', 'default')
+
+
+def walk(node, path):
+    """Yield (dotted-path, value) for every EVALUATED_KEYS scalar under the trigger block."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            child = f'{path}.{key}' if path else str(key)
+            if key in EVALUATED_KEYS and isinstance(value, str):
+                yield child, value
+            else:
+                yield from walk(value, child)
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            yield from walk(value, f'{path}[{index}]')
+
+
+for workflow in sorted(glob.glob(os.path.join(workflows_dir, '*.yaml'))):
+    name = os.path.basename(workflow)
+    try:
+        document = yaml.safe_load(open(workflow)) or {}
+        # YAML 1.1 resolves `on:` to the boolean True -- the same quirk Test 10 documents.
+        trigger = document.get('on', document.get(True)) or {}
+        for location, value in walk(trigger, ''):
+            if '${{' in value:
+                print(f'{name}: on.{location} contains an evaluated expression')
+    except (OSError, yaml.YAMLError) as error:
+        print(f'{name}: unreadable ({error})')
+    except Exception as error:                      # noqa: BLE001 -- see Test 10's note
+        print(f'{name}: {type(error).__name__}: {error}')
+PY
+)"
+assert_empty "no trigger-block description or default carries an evaluated expression" "$BAD_ON_EXPRESSION"
 echo ""
 
 echo "================================"

--- a/.github/tests/test-workflow-composition.sh
+++ b/.github/tests/test-workflow-composition.sh
@@ -663,6 +663,32 @@ PY
 assert_empty "every trigger clause checks the association of whoever wrote what it matched" "$BAD_TRIGGER"
 echo ""
 
+# A `${{ }}` sequence inside a `workflow_call` input or secret DESCRIPTION is evaluated
+# by GitHub, not treated as documentation -- and the `on:` block has no context, so an
+# example naming `github` makes the whole file fail to compile. It fails in the shape
+# that is hardest to read: the workflow is never triggered, yet every push produces a
+# failed run with no jobs, no logs, and the file PATH where the workflow name belongs.
+# `go-flyio.yaml` shipped exactly that in its `fly_app_name` example. Usage examples
+# belong in a `#` comment, which is never evaluated.
+EVALUATED_DESC=''
+while IFS= read -r file; do
+  result="$(python3 -c "
+import yaml, re
+d = yaml.safe_load(open('$SCRIPTS_DIR/.github/workflows/$file'))
+trigger = d.get('on', d.get(True))
+wc = (trigger or {}).get('workflow_call') or {}
+bad = []
+for kind in ('inputs', 'secrets'):
+    for name, spec in (wc.get(kind) or {}).items():
+        if '\${{' in ((spec or {}).get('description') or ''):
+            bad.append(f'{kind}.{name}')
+print(' '.join(bad))
+")"
+  [[ -n "$result" ]] && EVALUATED_DESC="${EVALUATED_DESC}${file}: expression in the description of ${result}"$'\n'
+done < <(reusable_workflows)
+assert_empty "no workflow_call description contains an evaluated expression" "$EVALUATED_DESC"
+echo ""
+
 echo "================================"
 echo -e "Tests passed: ${GREEN}${TESTS_PASSED}${NC}"
 if [[ $TESTS_FAILED -gt 0 ]]; then

--- a/.github/workflows/go-flyio.yaml
+++ b/.github/workflows/go-flyio.yaml
@@ -82,16 +82,23 @@ on:
         required: false
         default: 'make swagger'
         description: 'Command that regenerates the document named by `openapi_sync_path`.'
+      # A caller derives this from the ref, which is what keeps one repository's two apps apart
+      # and what stops a stale app id from deploying the wrong one. The example lives in this
+      # comment rather than in `description:` below because GitHub EVALUATES a `${{ }}` sequence
+      # inside an input description, where no context is available -- an expression naming
+      # `github` there does not document the input, it makes the whole file fail to compile, on
+      # every push, as a run with no jobs named after the file path:
+      #
+      #     fly_app_name: "api-${{ github.ref_type == 'tag' && 'production' || 'staging' }}"
       fly_app_name:
         type: 'string'
         required: false
         default: ''
         description: |
           Fly application name the deploy targets. Optional when the committed `fly.toml` already
-          declares `app`, but prefer passing it DERIVED from the ref when one repository deploys
-          two apps (`api-staging` on a branch, `api-production` on a tag):
-
-            fly_app_name: "api-${{ github.ref_type == 'tag' && 'production' || 'staging' }}"
+          declares `app`, but prefer passing it derived from the ref when one repository deploys
+          two apps (`api-staging` on a branch, `api-production` on a tag); see the comment above
+          for the shape.
 
           Named, never identified by a stored id: the name is a value the workflow already knows,
           while a stored id is one more secret to rotate — and a stale id is the worse failure of

--- a/.github/workflows/go-flyio.yaml
+++ b/.github/workflows/go-flyio.yaml
@@ -83,8 +83,8 @@ on:
         default: 'make swagger'
         description: 'Command that regenerates the document named by `openapi_sync_path`.'
       # A caller derives this from the ref, which is what keeps one repository's two apps apart
-      # and what stops a stale app id from deploying the wrong one. The example lives in this
-      # comment rather than in `description:` below because GitHub EVALUATES a `${{ }}` sequence
+      # and what stops a stale hardcoded name from deploying the wrong app. The example lives in
+      # this comment rather than in `description:` below because GitHub EVALUATES a `${{ }}` sequence
       # inside an input description, where no context is available -- an expression naming
       # `github` there does not document the input, it makes the whole file fail to compile, on
       # every push, as a run with no jobs named after the file path:
@@ -97,8 +97,11 @@ on:
         description: |
           Fly application name the deploy targets. Optional when the committed `fly.toml` already
           declares `app`, but prefer passing it derived from the ref when one repository deploys
-          two apps (`api-staging` on a branch, `api-production` on a tag); see the comment above
-          for the shape.
+          two apps: concatenate a fixed prefix with `production` on a tag and `staging` otherwise,
+          so the value reads `api-staging` on a branch and `api-production` on a tag. Deriving it
+          beats hardcoding, because a stale name deploys the WRONG app and reports success. The
+          literal expression cannot appear here — GitHub evaluates this field in the trigger block,
+          where no context exists — so it is written out in the comment above the input.
 
           Named, never identified by a stored id: the name is a value the workflow already knows,
           while a stored id is one more secret to rotate — and a stale id is the worse failure of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,7 +231,7 @@ is a large part of why the rule is a test rather than a review habit.
 
 ### Workflow Composition Standard
 
-**Enforced by `.github/tests/test-workflow-composition.sh` (`make test-workflow-composition`), eleven
+**Enforced by `.github/tests/test-workflow-composition.sh` (`make test-workflow-composition`), twelve
 assertions, every one of them proven to fire against a deliberate violation.** Read this section
 before writing anything under `.github/workflows/`, and before writing a pipeline in a repository
 that consumes this one.
@@ -349,6 +349,21 @@ clause reads is only half the boundary, so the allowlist is pinned too: every cl
 `contains(fromJSON(…))` must be exactly `OWNER`, `MEMBER`, `COLLABORATOR`. Adding `CONTRIBUTOR` or
 `NONE` is one token in the same free-text block and opens the job to anyone, with every pairing check
 still passing.
+
+The twelfth forbids an **evaluated expression in a trigger-block `description:` or `default:`**.
+GitHub evaluates `${{ }}` in those fields rather than treating them as documentation, and the `on:`
+block has no context — so a usage example naming `github` does not document the input, it stops the
+whole file compiling. The failure is the least legible one this repository has hit: the workflow is
+never triggered, yet every push produces a failed run with **no jobs, no logs, and the file path
+where the workflow name belongs**, which reads like a broken pin rather than a broken file.
+`go-flyio.yaml` shipped exactly that in a `fly_app_name` example and failed on `main` until it was
+found. Usage examples belong in a `#` comment, which is never evaluated. The assertion is scoped to
+the class rather than the instance: every workflow file, not only reusable ones (a
+`workflow_dispatch` input evaluates identically), and `default:` as well as `description:` — a
+`default:` being the likelier place to write `${{ github.ref_name }}` believing it resolves —
+including nested `outputs`. Note the linter cannot be relied on here: `actionlint` catches the
+`workflow_call` description case but the repository's own CI passed the broken file for its entire
+life on `main`.
 
 **Secrets reach a build as secrets.** A value passed into a reusable workflow as an *input* loses
 the caller's masking; passed as a *secret* it keeps it. That is why the deployment workflows take


### PR DESCRIPTION
## The failure

Every push to `main` produces a failed run named `.github/workflows/go-flyio.yaml` — the raw path, not a workflow name — even though the workflow only declares `on: workflow_call` and is never triggered.

It is not a run. It is GitHub failing to **compile** the file, reported as a failed run. Three tells, all from the API: the run has **zero jobs**, **zero check-runs** and no logs, and GitHub falls back to the file path when it cannot read the workflow definition.

## The cause — one line

`go-flyio.yaml:71`, inside the `description:` of the `fly_app_name` input:

```yaml
      fly_app_name:
        description: |
          … prefer passing it DERIVED from the ref …:

            fly_app_name: "api-${{ github.ref_type == 'tag' && 'production' || 'staging' }}"
```

Written as documentation, but GitHub **evaluates `${{ }}` inside input descriptions too**, and the `on:` block has no context available — so `github.*` is unresolvable there. actionlint states it exactly:

```
go-flyio.yaml:89:288: context "github" is not allowed here. no context is available here.
```

`go-render.yaml` is unaffected because it gives the same advice as prose, with no expression.

**This is not only noise:** an invalid workflow file cannot be *called* either, so any consumer pinning `go-flyio.yaml` would fail at its first `uses:`. medhub-life/backend has that switch queued behind the Fly cutover.

## The fix

The example moves into a `#` comment — never evaluated — keeping the guidance where a reader looks for it, with a note recording why it cannot live in `description:`.

## The guard

`test-workflow-composition.sh` now asserts that no `workflow_call` input or secret description contains an evaluated expression. Nothing caught this class before: the repo's own validation job passed the broken file for its entire life on `main`.

Proven to fire against the original file before landing:

```
FAIL: no workflow_call description contains an evaluated expression
      go-flyio.yaml: expression in the description of inputs.fly_app_name
```
exit 1.

## Gates

- `make test-workflow-composition` — **12/12** (baseline on `main` is 11; this adds one)
- `make test-supply-chain` — pinning contract holds
- `make test-runner-cache-gating` — all pass
- `actionlint .github/workflows/go-flyio.yaml` — clean

## Investigated and NOT a bug: `yarn.yaml:214`

An earlier note here flagged `uses: '$/github/global/stages/20-security/semgrep'` as an invalid
reference, on actionlint's say-so. That was wrong, and the note is withdrawn.

`$/` is a real self-repository reference the runner resolves to the same repo **at the same commit
the workflow was pinned to**. From a successful production run of that exact line:

```
##[group]Run rios0rios0/pipelines/github/global/stages/20-security/semgrep@7adcf43253717b2d974613c22b4d6a01ab98dbab
##[start-action display=Get Scripts;id=__self.__selfRepository]
##[group]Run rios0rios0/pipelines/github/global/abstracts/scripts-repo@7adcf43253717b2d974613c22b4d6a01ab98dbab
```

It resolved to the caller's SHA, not `@main` — exactly what the comment beside it claims, and
stricter than the `@main` form used elsewhere. Both `$/` sites (this one and
`github/global/stages/20-security/semgrep/action.yaml:19`) pass in production today. actionlint
v1.7.12 has no rule for the form; the finding is a false positive and no change is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxhRL93tQeaL3y6bjeJPqG
