### PR TITLE
fix(terra): removed the CodeQL job the Terraform workflow could never run

### DIFF
--- a/.changes/unreleased/1788499657967532408-b7be.yaml
+++ b/.changes/unreleased/1788499657967532408-b7be.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'removed the `sast:codeql` job from the GitHub Terraform workflow (`terra.yaml`): CodeQL ships no HCL extractor, so the job failed at `codeql resolve languages` ("Did not recognize the following languages: hcl") on every run and `continue-on-error` hid it as a red-but-ignored job on every consumer''s pull request. The gap is handled as the Dart pipeline handles its own: by a deliberate absence, with Semgrep''s Terraform rules as the static analysis for HCL, pinned by the new `test-terra-pipeline` suite on every platform and in `terraform.mk`'
+time: '2026-09-04T05:27:37.96742121Z'

--- a/.github/tests/test-terra-pipeline.sh
+++ b/.github/tests/test-terra-pipeline.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# The assertion helper takes its condition as a STRING and `eval`s it, so ShellCheck cannot
+# see that every variable it reads is used. A file-wide directive is only honoured before the
+# first command, which is why it sits here.
+# shellcheck disable=SC2034
+set -e
+# Validation for the Terraform (terra) pipeline's tool gap.
+#
+# CodeQL ships no HCL extractor. `.github/workflows/terra.yaml` used to carry a
+# `sast:codeql` job with `codeql_language: 'hcl'`, and it failed on every run at
+# `codeql resolve languages` ("Did not recognize the following languages: hcl");
+# `continue-on-error` turned that into a red-but-ignored job on every pull request of
+# every consumer. The gap is handled the way the Dart pipeline handles the same gap: by
+# a deliberate ABSENCE, with Semgrep's Terraform rules as the static analysis for HCL.
+# An absence is exactly what a later "make the languages consistent" edit silently
+# undoes, so this suite defends it on every platform and in the Makefile include.
+#
+# Runs OFFLINE with nothing but bash and grep.
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_SKIPPED=0
+
+assert_true() {
+  local description="$1"
+  local condition="$2"
+  if eval "$condition"; then
+    echo -e "${GREEN}  PASS: $description${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}  FAIL: $description${NC}"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+skip() {
+  echo -e "${YELLOW}  SKIP: $1${NC}"
+  TESTS_SKIPPED=$((TESTS_SKIPPED + 1))
+}
+
+echo "=========================================="
+echo "Terraform pipeline validation"
+echo "=========================================="
+
+echo ""
+echo "--- 1. Tool gap: CodeQL is absent on every platform ---"
+
+GITHUB_WORKFLOW="$SCRIPTS_DIR/.github/workflows/terra.yaml"
+assert_true "GitHub: the Terraform workflow exists" "[ -f '$GITHUB_WORKFLOW' ]"
+assert_true "GitHub: no CodeQL job is wired in the Terraform workflow" \
+  "! grep -E '^[^#]*20-security/codeql' '$GITHUB_WORKFLOW'"
+assert_true "GitHub: no job asks CodeQL for the hcl language" \
+  "! grep -qE \"^[^#]*codeql_language: *'?hcl\" '$GITHUB_WORKFLOW'"
+assert_true "GitHub: the absence is explained where the job used to be, so it survives review" \
+  "grep -q 'no HCL extractor' '$GITHUB_WORKFLOW'"
+
+found_template=0
+for template in "$SCRIPTS_DIR"/gitlab/terraform/*.yaml "$SCRIPTS_DIR"/azure-devops/terraform/*.yaml \
+                "$SCRIPTS_DIR"/gitlab/terraform/**/*.yaml "$SCRIPTS_DIR"/azure-devops/terraform/**/*.yaml; do
+  [ -f "$template" ] || continue
+  found_template=1
+  assert_true "$(echo "$template" | sed "s|$SCRIPTS_DIR/||"): no CodeQL job is wired for Terraform" \
+    "! grep -E '^[^#]*codeql' '$template'"
+done
+[ "$found_template" -eq 1 ] || skip "no GitLab/Azure DevOps Terraform template found to inspect"
+
+echo ""
+echo "--- 2. The Makefile include skips CodeQL for the same reason ---"
+assert_true "terraform.mk leaves CODEQL_LANGUAGE unset so 'make sast' skips CodeQL" \
+  "! grep -qE '^CODEQL_LANGUAGE' '$SCRIPTS_DIR/makefiles/terraform.mk'"
+assert_true "terraform.mk says why, so the omission reads as a decision" \
+  "grep -qi 'CodeQL does not support Terraform' '$SCRIPTS_DIR/makefiles/terraform.mk'"
+
+echo ""
+echo "=========================================="
+echo -e "Passed:  ${GREEN}$TESTS_PASSED${NC}"
+echo -e "Failed:  ${RED}$TESTS_FAILED${NC}"
+[[ $TESTS_SKIPPED -gt 0 ]] && echo -e "Skipped: ${YELLOW}$TESTS_SKIPPED${NC}"
+echo "=========================================="
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+  echo -e "${RED}Terraform pipeline validation FAILED${NC}"
+  exit 1
+fi
+echo -e "${GREEN}Terraform pipeline validation passed${NC}"
+exit 0

--- a/.github/tests/test-terra-pipeline.sh
+++ b/.github/tests/test-terra-pipeline.sh
@@ -13,7 +13,8 @@ set -e
 # every consumer. The gap is handled the way the Dart pipeline handles the same gap: by
 # a deliberate ABSENCE, with Semgrep's Terraform rules as the static analysis for HCL.
 # An absence is exactly what a later "make the languages consistent" edit silently
-# undoes, so this suite defends it on every platform and in the Makefile include.
+# undoes, so this suite defends it on every platform and in both Makefile includes
+# (`terra.mk` pairs with this workflow, `terraform.mk` with the raw Terraform one).
 #
 # Runs OFFLINE with nothing but bash and grep.
 
@@ -75,11 +76,13 @@ done
 [ "$found_template" -eq 1 ] || skip "no GitLab/Azure DevOps Terraform template found to inspect"
 
 echo ""
-echo "--- 2. The Makefile include skips CodeQL for the same reason ---"
-assert_true "terraform.mk leaves CODEQL_LANGUAGE unset so 'make sast' skips CodeQL" \
-  "! grep -qE '^CODEQL_LANGUAGE' '$SCRIPTS_DIR/makefiles/terraform.mk'"
-assert_true "terraform.mk says why, so the omission reads as a decision" \
-  "grep -qi 'CodeQL does not support Terraform' '$SCRIPTS_DIR/makefiles/terraform.mk'"
+echo "--- 2. Both Makefile includes skip CodeQL for the same reason ---"
+for mk in terra terraform; do
+  assert_true "$mk.mk leaves CODEQL_LANGUAGE unset so 'make sast' skips CodeQL" \
+    "! grep -qE '^CODEQL_LANGUAGE' '$SCRIPTS_DIR/makefiles/$mk.mk'"
+  assert_true "$mk.mk says why, so the omission reads as a decision" \
+    "grep -qi 'CodeQL does not support Terraform' '$SCRIPTS_DIR/makefiles/$mk.mk'"
+done
 
 echo ""
 echo "=========================================="

--- a/.github/tests/test-terra-pipeline.sh
+++ b/.github/tests/test-terra-pipeline.sh
@@ -60,9 +60,13 @@ assert_true "GitHub: no job asks CodeQL for the hcl language" \
 assert_true "GitHub: the absence is explained where the job used to be, so it survives review" \
   "grep -q 'no HCL extractor' '$GITHUB_WORKFLOW'"
 
+# `**` only recurses with globstar; without it the pattern silently means one level, which
+# is exactly how a stage file two levels down would escape the assertion. Both the raw
+# Terraform trees and the Terra CLI trees are inspected on both platforms, at every depth.
+shopt -s globstar
 found_template=0
-for template in "$SCRIPTS_DIR"/gitlab/terraform/*.yaml "$SCRIPTS_DIR"/azure-devops/terraform/*.yaml \
-                "$SCRIPTS_DIR"/gitlab/terraform/**/*.yaml "$SCRIPTS_DIR"/azure-devops/terraform/**/*.yaml; do
+for template in "$SCRIPTS_DIR"/gitlab/terra/**/*.yaml "$SCRIPTS_DIR"/gitlab/terraform/**/*.yaml \
+                "$SCRIPTS_DIR"/azure-devops/terra/**/*.yaml "$SCRIPTS_DIR"/azure-devops/terraform/**/*.yaml; do
   [ -f "$template" ] || continue
   found_template=1
   assert_true "$(echo "$template" | sed "s|$SCRIPTS_DIR/||"): no CodeQL job is wired for Terraform" \

--- a/.github/workflows/terra.yaml
+++ b/.github/workflows/terra.yaml
@@ -204,17 +204,14 @@ jobs:
 
 
   # second stage
-  security-sast_codeql:
-    name: 'security > sast:codeql'
-    runs-on: 'ubuntu-latest'
-    steps:
-      - uses: 'rios0rios0/pipelines/github/global/stages/20-security/codeql@main'
-        with:
-          codeql_language: 'hcl'
-    needs: [ 'code_check-style_terra_format' ]
-    continue-on-error: true
-    if: "!startsWith(github.ref, 'refs/tags/')"
-
+  #
+  # There is deliberately NO `sast:codeql` job here, on any platform. CodeQL ships no HCL extractor,
+  # so the job this workflow used to carry (`codeql_language: 'hcl'`) failed on every run at
+  # `codeql resolve languages` ("Did not recognize the following languages: hcl") and
+  # `continue-on-error` turned that into a red-but-ignored job on every pull request -- a check
+  # that can only ever be wrong is worse than no check. Semgrep's Terraform rules are the static
+  # analysis for HCL, as with Dart (dart.yaml). `.github/tests/test-terra-pipeline.sh` fails if a
+  # CodeQL job reappears.
   security-sast_semgrep:
     name: 'security > sast:semgrep'
     runs-on: 'ubuntu-latest'
@@ -562,5 +559,7 @@ jobs:
 #     workflow_dispatch:
 #
 #   permissions:
-#     security-events: 'write' # security-sast_codeql
-#     actions: 'read' # security-sast_codeql (required only on a private repository)
+#     checks: 'write'         # JUnit publication of the test tiers
+#     pull-requests: 'write'  # basic-checks comments on the pull request
+#     # No `security-events` or `actions` permission: there is no CodeQL job (see the second
+#     # stage above), so nothing here uploads SARIF or reads the Actions API.

--- a/.github/workflows/terra.yaml
+++ b/.github/workflows/terra.yaml
@@ -559,6 +559,8 @@ jobs:
 #     workflow_dispatch:
 #
 #   permissions:
+#     contents: 'read'        # actions/checkout -- naming `permissions:` at all resets every
+#                             # unlisted scope to none, so this one is never implied
 #     checks: 'write'         # JUnit publication of the test tiers
 #     pull-requests: 'write'  # basic-checks comments on the pull request
 #     # No `security-events` or `actions` permission: there is no CodeQL job (see the second

--- a/.github/workflows/terra.yaml
+++ b/.github/workflows/terra.yaml
@@ -559,9 +559,10 @@ jobs:
 #     workflow_dispatch:
 #
 #   permissions:
-#     contents: 'read'        # actions/checkout -- naming `permissions:` at all resets every
-#                             # unlisted scope to none, so this one is never implied
-#     checks: 'write'         # JUnit publication of the test tiers
-#     pull-requests: 'write'  # basic-checks comments on the pull request
+#     contents: 'read' # actions/checkout -- naming `permissions:` at all resets every unlisted
+#                      # scope to none, so this one is never implied
 #     # No `security-events` or `actions` permission: there is no CodeQL job (see the second
-#     # stage above), so nothing here uploads SARIF or reads the Actions API.
+#     # stage above), so nothing here uploads SARIF or reads the Actions API. Nothing needs
+#     # `checks` or `pull-requests` either -- every publication step is
+#     # `actions/upload-artifact`, which requires no additional scope, and basic-checks
+#     # posts nothing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -631,6 +631,14 @@ written with it loads cleanly and then matches nothing. When editing that file,
 re-run `make test-dart-pipeline` with Semgrep installed; the suite asserts every
 rule still matches its vulnerable sample and none matches the safe counterpart.
 
+**Terraform has the same CodeQL gap, handled the same way.** CodeQL ships no HCL extractor,
+so `terra.yaml` carries no `sast:codeql` job: the one it used to carry
+(`codeql_language: 'hcl'`) failed at `codeql resolve languages` on every run and
+`continue-on-error` hid it as a red-but-ignored job on every consumer's pull request.
+Semgrep's Terraform rules are the static analysis for HCL, and `terraform.mk` leaves
+`CODEQL_LANGUAGE` unset so `make sast` skips CodeQL. `.github/tests/test-terra-pipeline.sh`
+fails if the job reappears on any platform. Do not "restore consistency" here either.
+
 ### Terra Test Tiers
 
 The Terra CLI pipeline test stage exposes three parallel jobs on every platform (Azure DevOps, GitLab CI, GitHub Actions) — two always on, one opt-in:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ A CI/CD pipeline templates library providing reusable workflows for **GitHub Act
 ## Commands
 
 ```bash
-make test              # Run all validation tests (Go, go-module-toolchain, CycloneDX main detection, Go cache trim, Lambda, YAML merge, SonarQube, release tag, tftest-gen, order-check, var-catalog, terraform-validate, terraform-provider-mirror, docker-multi-arch, basic-checks, gitignore, dependency-check, dependency-track, goreleaser-prepare, release-version-extraction, release-reconcile, deploy-providers, memory-detection, dart-pipeline, javascript-pipeline, workflow-composition, supply-chain, runner-cache-gating, azure-step-names, dependency-updates)
+make test              # Run all validation tests (Go, go-module-toolchain, CycloneDX main detection, Go cache trim, Lambda, YAML merge, SonarQube, release tag, tftest-gen, order-check, var-catalog, terraform-validate, terraform-provider-mirror, docker-multi-arch, basic-checks, gitignore, dependency-check, dependency-track, goreleaser-prepare, release-version-extraction, release-reconcile, deploy-providers, memory-detection, dart-pipeline, javascript-pipeline, terra-pipeline, workflow-composition, supply-chain, runner-cache-gating, azure-step-names, dependency-updates)
 make test-go-script    # Test Go validation script only
 make test-go-module-toolchain  # Test that every go.mod toolchain directive is readable by the images/analysers that consume it only
 make test-go-tool-staleness    # Test that a source-built Go tool (govulncheck) is rebuilt when its toolchain/pin moves only
@@ -35,6 +35,7 @@ make test-release-reconcile  # Test release reconciliation gap detection only
 make test-deploy-providers   # Test the MVP hosting deployment providers (Cloudflare, Vercel, Render, Netlify, Fly.io) only
 make test-memory-detection  # Test the cgroup-aware memory ceiling detection only
 make test-dart-pipeline # Test the Dart/Flutter pipeline (scripts, Semgrep rules, cross-platform wiring) only
+make test-terra-pipeline # Test the Terraform/terra pipeline's CodeQL tool gap (GitHub, GitLab, Azure, terra.mk, terraform.mk) only
 make test-javascript-pipeline  # Test the JavaScript formatting gate (Prettier runner + cross-platform wiring) only
 make test-workflow-composition  # Test the GitHub Actions workflow composition standard only
 make test-supply-chain # Test the supply-chain pinning contract (actions, images, binaries, packages) only

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TAG := latest
 ROOT := global/containers
 CONTAINER_REGISTRY = ghcr.io/rios0rios0/pipelines
 
-.PHONY: login setup-buildx build-and-push test-dependency-track test-go-script test-cyclonedx-main test-go-cache-trim test-go-tmpdir-modcache test-go-integration-scope test-lambda test-yaml-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-var-catalog test-terraform-validate test-terraform-provider-mirror test-docker-multi-arch test-basic-checks test-gitignore test-dependency-check test-goreleaser-prepare test-release-version-extraction test-release-reconcile test-deploy-providers test-memory-detection test-dart-pipeline test-javascript-pipeline test-workflow-composition test-supply-chain test-runner-cache-gating test-azure-step-names test-dependency-updates test-go-module-toolchain check-dependency-updates test
+.PHONY: login setup-buildx build-and-push test-dependency-track test-go-script test-cyclonedx-main test-go-cache-trim test-go-tmpdir-modcache test-go-integration-scope test-lambda test-yaml-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-var-catalog test-terraform-validate test-terraform-provider-mirror test-docker-multi-arch test-basic-checks test-gitignore test-dependency-check test-goreleaser-prepare test-release-version-extraction test-release-reconcile test-deploy-providers test-memory-detection test-dart-pipeline test-javascript-pipeline test-terra-pipeline test-workflow-composition test-supply-chain test-runner-cache-gating test-azure-step-names test-dependency-updates test-go-module-toolchain check-dependency-updates test
 
 login:
 	docker login $(CONTAINER_REGISTRY)
@@ -122,6 +122,10 @@ test-dart-pipeline:
 	@echo "Running Dart/Flutter pipeline validation..."
 	@./.github/tests/test-dart-pipeline.sh
 
+test-terra-pipeline:
+	@echo "Running Terraform pipeline validation..."
+	@./.github/tests/test-terra-pipeline.sh
+
 test-javascript-pipeline:
 	@echo "Running JavaScript formatting-gate validation..."
 	@./.github/tests/test-javascript-pipeline.sh
@@ -156,5 +160,5 @@ test-go-module-toolchain:
 	@echo "Running Go module/builder toolchain agreement validation..."
 	@./.github/tests/test-go-module-toolchain.sh
 
-test: test-dependency-track test-go-module-toolchain test-go-script test-cyclonedx-main test-go-cache-trim test-go-tmpdir-modcache test-go-integration-scope test-go-tool-staleness test-lambda test-yaml-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-var-catalog test-terraform-validate test-terraform-provider-mirror test-docker-multi-arch test-basic-checks test-gitignore test-dependency-check test-goreleaser-prepare test-release-version-extraction test-release-reconcile test-deploy-providers test-memory-detection test-dart-pipeline test-javascript-pipeline test-workflow-composition test-supply-chain test-runner-cache-gating test-azure-step-names test-dependency-updates
+test: test-dependency-track test-go-module-toolchain test-go-script test-cyclonedx-main test-go-cache-trim test-go-tmpdir-modcache test-go-integration-scope test-go-tool-staleness test-lambda test-yaml-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-var-catalog test-terraform-validate test-terraform-provider-mirror test-docker-multi-arch test-basic-checks test-gitignore test-dependency-check test-goreleaser-prepare test-release-version-extraction test-release-reconcile test-deploy-providers test-memory-detection test-dart-pipeline test-javascript-pipeline test-terra-pipeline test-workflow-composition test-supply-chain test-runner-cache-gating test-azure-step-names test-dependency-updates
 	@echo "All tests completed successfully!"


### PR DESCRIPTION
Found on the first runs of a new consumer, [medhub-life/iac#1](https://github.com/medhub-life/iac/pull/1): `security > sast:codeql` in `terra.yaml` fails on every run.

```
codeql resolve languages ...
##[error]Did not recognize the following languages: hcl
CodeQL job status was configuration error.
```

CodeQL ships no HCL extractor, so the job can only ever fail; `continue-on-error: true` keeps the run green but paints a red, ignored job onto every consumer's pull request, which is a check that trains people to ignore red.

## Change

- **`terra.yaml`**: the job is removed, with a comment where it stood explaining the absence, and the usage example's commented `permissions:` block no longer asks for `security-events`/`actions` on its account. The GitLab and Azure DevOps Terraform templates already carried no CodeQL job, so GitHub was the one platform that drifted.
- **`.github/tests/test-terra-pipeline.sh`** (new, wired into `make test` as `test-terra-pipeline`): the same tool-gap assertion `test-dart-pipeline.sh` makes for Dart — no CodeQL job in the GitHub workflow, none in any GitLab/Azure Terraform template, `terraform.mk` leaving `CODEQL_LANGUAGE` unset — so a later "make the languages consistent" edit cannot quietly put it back. Runs offline with bash and grep.
- **`CLAUDE.md`**: the decision recorded beside the Dart one, with the same "do not restore consistency" instruction.
- chlog fragment (`Fixed`).

## Gates

`make test-terra-pipeline` passes (10 assertions), `make test-workflow-composition` passes. Semgrep's Terraform rules remain the static analysis for HCL; nothing else in the workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Maj44fMdekCDvHtLPbfpg4