### PR TITLE
fix(security): removed user-controlled data from azure script blocks and restricted downloads

### DIFF
--- a/.changes/unreleased/1788655045486597299-cc81.yaml
+++ b/.changes/unreleased/1788655045486597299-cc81.yaml
@@ -1,0 +1,3 @@
+kind: 'Security'
+body: 'stopped the Azure DevOps Go Lambda deployment template from substituting `${{ parameters.* }}` straight into its inline shell, passing every value through `env:` instead'
+time: '2026-09-06T00:37:25.486517716Z'

--- a/.changes/unreleased/1788655045497405685-9e41.yaml
+++ b/.changes/unreleased/1788655045497405685-9e41.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'fixed the Azure DevOps Go Lambda `Deploy Lambda Function via ZIP (Environment Variables)` step, whose shell was missing a `fi` and could never have run'
+time: '2026-09-06T00:37:25.497346205Z'

--- a/.changes/unreleased/1788655045512270424-f40e.yaml
+++ b/.changes/unreleased/1788655045512270424-f40e.yaml
@@ -1,0 +1,3 @@
+kind: 'Security'
+body: 'pinned the ProGuard, BFG, AWS CLI and AWS SAM CLI downloads to HTTPS on every redirect hop with `curl --proto ''=https'' --proto-redir ''=https''`'
+time: '2026-09-06T00:37:25.512195893Z'

--- a/.changes/unreleased/1788655045529539330-0699.yaml
+++ b/.changes/unreleased/1788655045529539330-0699.yaml
@@ -1,0 +1,3 @@
+kind: 'Security'
+body: 'confined the report directory of the Terragrunt `order-check` tool to the repository it checks, and the Dart analyze reporter''s to the working directory, so a directory named on the command line can no longer be created outside them (an absolute `REPORT_PATH` pointing outside now fails loudly)'
+time: '2026-09-06T00:37:25.529446362Z'

--- a/.changes/unreleased/1788655045546739174-653e.yaml
+++ b/.changes/unreleased/1788655045546739174-653e.yaml
@@ -1,0 +1,3 @@
+kind: 'Added'
+body: 'added `sonar-project.properties` recording the SonarCloud findings accepted for this repository, each scoped to a single rule and file with the reason a fix would remove required behaviour'
+time: '2026-09-06T00:37:25.54666433Z'

--- a/.changes/unreleased/1788658789834097590-7c65.yaml
+++ b/.changes/unreleased/1788658789834097590-7c65.yaml
@@ -1,0 +1,3 @@
+kind: 'Security'
+body: 'removed the `eval` from both Azure DevOps Go Lambda SAM deployment steps: `sam deploy` is now assembled as positional arguments and run directly, with `$(STACK_NAME)` and `$(PARAMETER_OVERRIDES)` delivered through `env:`, so no consumer-controlled value is handed back to the shell parser a second time'
+time: '2026-09-06T01:39:49.834097590Z'

--- a/.changes/unreleased/1788658789844567069-bfb1.yaml
+++ b/.changes/unreleased/1788658789844567069-bfb1.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'fixed the Azure DevOps Go Lambda ZIP deployment steps breaking an argument in two whenever a value held a space (a `Build.SourcesDirectory` such as `/build/my sources` reached `aws` as two arguments), by quoting every expansion in both the service-connection and the environment-variable step'
+time: '2026-09-06T01:39:49.844567069Z'

--- a/.changes/unreleased/1788658789855210819-3bc5.yaml
+++ b/.changes/unreleased/1788658789855210819-3bc5.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'fixed the Azure DevOps Go Lambda SAM deployment steps failing when `STACK_NAME` or `PARAMETER_OVERRIDES` is not defined: an Azure macro that arrives unexpanded is now read as unset, so `go-lambda-sam.yaml` deploys with the stack name from `samconfig.toml` as its comment promises, and parameter overrides stay optional'
+time: '2026-09-06T01:39:49.855210819Z'

--- a/.github/tests/test-dart-pipeline.sh
+++ b/.github/tests/test-dart-pipeline.sh
@@ -554,8 +554,10 @@ INFO|LINT|PREFER_CONST|lib/widgets/card.dart|7|5|9|Use 'a \| b' instead of a pip
 Analyzing project...
 EOF
 
+# Run from inside $WORK_DIR: the helper confines its report directory to the working
+# directory, so the argument is a path relative to it rather than an absolute one.
 STATUS=0
-python3 "$DART_DIR/analyze/dart_analyze_report.py" "$WORK_DIR/an" < "$WORK_DIR/machine.txt" > /dev/null 2>&1 || STATUS=$?
+(cd "$WORK_DIR" && python3 "$DART_DIR/analyze/dart_analyze_report.py" "an" < "machine.txt") > /dev/null 2>&1 || STATUS=$?
 assert_true "the default gate fails on an ERROR" "[[ $STATUS -eq 1 ]]"
 assert_true "the JUnit report is well-formed XML" \
   "python3 -c \"import xml.dom.minidom as m; m.parse('$WORK_DIR/an/junit-analyze.xml')\""
@@ -578,16 +580,16 @@ assert_true "non-fatal findings stay visible as JUnit skips" \
 
 head -1 "$WORK_DIR/machine.txt" > "$WORK_DIR/infos.txt"
 STATUS=0
-python3 "$DART_DIR/analyze/dart_analyze_report.py" "$WORK_DIR/an2" < "$WORK_DIR/infos.txt" > /dev/null 2>&1 || STATUS=$?
+(cd "$WORK_DIR" && python3 "$DART_DIR/analyze/dart_analyze_report.py" "an2" < "infos.txt") > /dev/null 2>&1 || STATUS=$?
 assert_true "INFO findings alone do not fail by default" "[[ $STATUS -eq 0 ]]"
 
 STATUS=0
-DART_FATAL_INFOS=true python3 "$DART_DIR/analyze/dart_analyze_report.py" "$WORK_DIR/an3" \
-  < "$WORK_DIR/infos.txt" > /dev/null 2>&1 || STATUS=$?
+(cd "$WORK_DIR" && DART_FATAL_INFOS=true python3 "$DART_DIR/analyze/dart_analyze_report.py" "an3" \
+  < "infos.txt") > /dev/null 2>&1 || STATUS=$?
 assert_true "DART_FATAL_INFOS=true makes INFO findings fatal" "[[ $STATUS -eq 1 ]]"
 
 STATUS=0
-python3 "$DART_DIR/analyze/dart_analyze_report.py" "$WORK_DIR/an4" < /dev/null > /dev/null 2>&1 || STATUS=$?
+(cd "$WORK_DIR" && python3 "$DART_DIR/analyze/dart_analyze_report.py" "an4" < /dev/null) > /dev/null 2>&1 || STATUS=$?
 assert_true "a clean analysis passes and still writes a valid JUnit report" \
   "[[ $STATUS -eq 0 ]] && python3 -c \"import xml.dom.minidom as m; m.parse('$WORK_DIR/an4/junit-analyze.xml')\""
 

--- a/.github/tests/test-order-check.sh
+++ b/.github/tests/test-order-check.sh
@@ -37,7 +37,10 @@ assert_true() {
 cleanup() { rm -rf "$TEST_DIR"; }
 trap cleanup EXIT
 
-oc() { REPORT_PATH="$(mktemp -d)/reports" python3 "$OC" "$@"; }
+# A RELATIVE REPORT_PATH, because the checker confines its report directory to the
+# repository it was pointed at: `build/reports` resolves under `--repo-dir`, which is a
+# throwaway tree per test, and is also what every runner in this repo passes.
+oc() { REPORT_PATH="build/reports" python3 "$OC" "$@"; }
 
 # Build a correct, in-standard repo at $1.
 make_clean_repo() {

--- a/azure-devops/golang/stages/50-deployment/lambda.yaml
+++ b/azure-devops/golang/stages/50-deployment/lambda.yaml
@@ -75,27 +75,27 @@ stages:
                     echo "Deploying Lambda function via AWS CLI..."
 
                     # Check if function exists
-                    if aws lambda get-function --function-name $LAMBDA_FUNCTION_NAME --region $AWS_REGION_NAME 2>/dev/null; then
+                    if aws lambda get-function --function-name "$LAMBDA_FUNCTION_NAME" --region "$AWS_REGION_NAME" 2>/dev/null; then
                       echo "Updating existing Lambda function: $LAMBDA_FUNCTION_NAME"
                       aws lambda update-function-code \
-                        --function-name $LAMBDA_FUNCTION_NAME \
-                        --zip-file fileb://$BUILD_SOURCES_DIRECTORY/lambda-function.zip \
-                        --region $AWS_REGION_NAME
+                        --function-name "$LAMBDA_FUNCTION_NAME" \
+                        --zip-file "fileb://$BUILD_SOURCES_DIRECTORY/lambda-function.zip" \
+                        --region "$AWS_REGION_NAME"
 
                       # Update configuration if environment variables are provided
                       if [ -n "$LAMBDA_ENV_VARS" ]; then
                         aws lambda update-function-configuration \
-                          --function-name $LAMBDA_FUNCTION_NAME \
-                          --timeout $LAMBDA_TIMEOUT \
-                          --memory-size $LAMBDA_MEMORY_SIZE \
+                          --function-name "$LAMBDA_FUNCTION_NAME" \
+                          --timeout "$LAMBDA_TIMEOUT" \
+                          --memory-size "$LAMBDA_MEMORY_SIZE" \
                           --environment "Variables={$LAMBDA_ENV_VARS}" \
-                          --region $AWS_REGION_NAME
+                          --region "$AWS_REGION_NAME"
                       else
                         aws lambda update-function-configuration \
-                          --function-name $LAMBDA_FUNCTION_NAME \
-                          --timeout $LAMBDA_TIMEOUT \
-                          --memory-size $LAMBDA_MEMORY_SIZE \
-                          --region $AWS_REGION_NAME
+                          --function-name "$LAMBDA_FUNCTION_NAME" \
+                          --timeout "$LAMBDA_TIMEOUT" \
+                          --memory-size "$LAMBDA_MEMORY_SIZE" \
+                          --region "$AWS_REGION_NAME"
                       fi
                     else
                       # Only create if CREATE_IF_MISSING is true
@@ -111,25 +111,25 @@ stages:
 
                         if [ -n "$LAMBDA_ENV_VARS" ]; then
                           aws lambda create-function \
-                            --function-name $LAMBDA_FUNCTION_NAME \
-                            --runtime $LAMBDA_RUNTIME \
-                            --handler $LAMBDA_HANDLER \
+                            --function-name "$LAMBDA_FUNCTION_NAME" \
+                            --runtime "$LAMBDA_RUNTIME" \
+                            --handler "$LAMBDA_HANDLER" \
                             --role "$LAMBDA_ROLE_ARN" \
-                            --zip-file fileb://$BUILD_SOURCES_DIRECTORY/lambda-function.zip \
-                            --timeout $LAMBDA_TIMEOUT \
-                            --memory-size $LAMBDA_MEMORY_SIZE \
+                            --zip-file "fileb://$BUILD_SOURCES_DIRECTORY/lambda-function.zip" \
+                            --timeout "$LAMBDA_TIMEOUT" \
+                            --memory-size "$LAMBDA_MEMORY_SIZE" \
                             --environment "Variables={$LAMBDA_ENV_VARS}" \
-                            --region $AWS_REGION_NAME
+                            --region "$AWS_REGION_NAME"
                         else
                           aws lambda create-function \
-                            --function-name $LAMBDA_FUNCTION_NAME \
-                            --runtime $LAMBDA_RUNTIME \
-                            --handler $LAMBDA_HANDLER \
+                            --function-name "$LAMBDA_FUNCTION_NAME" \
+                            --runtime "$LAMBDA_RUNTIME" \
+                            --handler "$LAMBDA_HANDLER" \
                             --role "$LAMBDA_ROLE_ARN" \
-                            --zip-file fileb://$BUILD_SOURCES_DIRECTORY/lambda-function.zip \
-                            --timeout $LAMBDA_TIMEOUT \
-                            --memory-size $LAMBDA_MEMORY_SIZE \
-                            --region $AWS_REGION_NAME
+                            --zip-file "fileb://$BUILD_SOURCES_DIRECTORY/lambda-function.zip" \
+                            --timeout "$LAMBDA_TIMEOUT" \
+                            --memory-size "$LAMBDA_MEMORY_SIZE" \
+                            --region "$AWS_REGION_NAME"
                         fi
                       else
                         echo "ERROR: Lambda function $LAMBDA_FUNCTION_NAME does not exist and CREATE_IF_MISSING is false"
@@ -171,27 +171,27 @@ stages:
               echo "Deploying Lambda function via AWS CLI..."
 
               # Check if function exists
-              if aws lambda get-function --function-name $LAMBDA_FUNCTION_NAME --region $AWS_REGION_NAME 2>/dev/null; then
+              if aws lambda get-function --function-name "$LAMBDA_FUNCTION_NAME" --region "$AWS_REGION_NAME" 2>/dev/null; then
                 echo "Updating existing Lambda function: $LAMBDA_FUNCTION_NAME"
                 aws lambda update-function-code \
-                  --function-name $LAMBDA_FUNCTION_NAME \
-                  --zip-file fileb://$BUILD_SOURCES_DIRECTORY/lambda-function.zip \
-                  --region $AWS_REGION_NAME
+                  --function-name "$LAMBDA_FUNCTION_NAME" \
+                  --zip-file "fileb://$BUILD_SOURCES_DIRECTORY/lambda-function.zip" \
+                  --region "$AWS_REGION_NAME"
 
                 # Update configuration if environment variables are provided
                 if [ -n "$LAMBDA_ENV_VARS" ]; then
                   aws lambda update-function-configuration \
-                    --function-name $LAMBDA_FUNCTION_NAME \
-                    --timeout $LAMBDA_TIMEOUT \
-                    --memory-size $LAMBDA_MEMORY_SIZE \
+                    --function-name "$LAMBDA_FUNCTION_NAME" \
+                    --timeout "$LAMBDA_TIMEOUT" \
+                    --memory-size "$LAMBDA_MEMORY_SIZE" \
                     --environment "Variables={$LAMBDA_ENV_VARS}" \
-                    --region $AWS_REGION_NAME
+                    --region "$AWS_REGION_NAME"
                 else
                   aws lambda update-function-configuration \
-                    --function-name $LAMBDA_FUNCTION_NAME \
-                    --timeout $LAMBDA_TIMEOUT \
-                    --memory-size $LAMBDA_MEMORY_SIZE \
-                    --region $AWS_REGION_NAME
+                    --function-name "$LAMBDA_FUNCTION_NAME" \
+                    --timeout "$LAMBDA_TIMEOUT" \
+                    --memory-size "$LAMBDA_MEMORY_SIZE" \
+                    --region "$AWS_REGION_NAME"
                 fi
               else
                 # Only create if CREATE_IF_MISSING is true
@@ -207,25 +207,25 @@ stages:
 
                   if [ -n "$LAMBDA_ENV_VARS" ]; then
                     aws lambda create-function \
-                      --function-name $LAMBDA_FUNCTION_NAME \
-                      --runtime $LAMBDA_RUNTIME \
-                      --handler $LAMBDA_HANDLER \
+                      --function-name "$LAMBDA_FUNCTION_NAME" \
+                      --runtime "$LAMBDA_RUNTIME" \
+                      --handler "$LAMBDA_HANDLER" \
                       --role "$LAMBDA_ROLE_ARN" \
-                      --zip-file fileb://$BUILD_SOURCES_DIRECTORY/lambda-function.zip \
-                      --timeout $LAMBDA_TIMEOUT \
-                      --memory-size $LAMBDA_MEMORY_SIZE \
+                      --zip-file "fileb://$BUILD_SOURCES_DIRECTORY/lambda-function.zip" \
+                      --timeout "$LAMBDA_TIMEOUT" \
+                      --memory-size "$LAMBDA_MEMORY_SIZE" \
                       --environment "Variables={$LAMBDA_ENV_VARS}" \
-                      --region $AWS_REGION_NAME
+                      --region "$AWS_REGION_NAME"
                   else
                     aws lambda create-function \
-                      --function-name $LAMBDA_FUNCTION_NAME \
-                      --runtime $LAMBDA_RUNTIME \
-                      --handler $LAMBDA_HANDLER \
+                      --function-name "$LAMBDA_FUNCTION_NAME" \
+                      --runtime "$LAMBDA_RUNTIME" \
+                      --handler "$LAMBDA_HANDLER" \
                       --role "$LAMBDA_ROLE_ARN" \
-                      --zip-file fileb://$BUILD_SOURCES_DIRECTORY/lambda-function.zip \
-                      --timeout $LAMBDA_TIMEOUT \
-                      --memory-size $LAMBDA_MEMORY_SIZE \
-                      --region $AWS_REGION_NAME
+                      --zip-file "fileb://$BUILD_SOURCES_DIRECTORY/lambda-function.zip" \
+                      --timeout "$LAMBDA_TIMEOUT" \
+                      --memory-size "$LAMBDA_MEMORY_SIZE" \
+                      --region "$AWS_REGION_NAME"
                   fi
                 else
                   echo "ERROR: Lambda function $LAMBDA_FUNCTION_NAME does not exist and CREATE_IF_MISSING is false"
@@ -264,20 +264,40 @@ stages:
 
                     echo "Deploying Lambda function via AWS SAM..."
 
-                    # Build sam deploy command
-                    SAM_DEPLOY_CMD="sam deploy \
-                      --template-file $BUILD_SOURCES_DIRECTORY/packaged.yaml \
-                      --config-env $PARAM_SAM_CONFIG_ENV \
-                      --stack-name $(STACK_NAME) \
-                      --no-confirm-changeset \
-                      --region $AWS_REGION_NAME"
+                    # Azure DevOps substitutes nothing for an undefined variable, so `$(STACK_NAME)`
+                    # and `$(PARAMETER_OVERRIDES)` arrive verbatim when the consumer never set them:
+                    # a value that still looks like a macro means "not set". Both are optional --
+                    # the SAM entrypoint takes the stack name from `samconfig.toml` -- so neither is
+                    # passed to `sam` unless it holds a real value.
+                    case "${STACK_NAME:-}" in
+                      '$('*) STACK_NAME='' ;;
+                    esac
+                    case "${PARAMETER_OVERRIDES:-}" in
+                      '$('*) PARAMETER_OVERRIDES='' ;;
+                    esac
 
-                    # Add parameter overrides if they exist
-                    if [ -n "$(PARAMETER_OVERRIDES)" ]; then
-                      SAM_DEPLOY_CMD="$SAM_DEPLOY_CMD --parameter-overrides $(PARAMETER_OVERRIDES)"
+                    # Build the command as positional parameters and run it directly. Assembling a
+                    # string and calling `eval` on it would hand every value back to the parser a
+                    # second time, which is the very sink the `env:` block below exists to close:
+                    # a `;` or a `$(...)` in any of them would run as a command on the agent that
+                    # holds this pipeline's AWS credentials.
+                    set -- sam deploy \
+                      --template-file "$BUILD_SOURCES_DIRECTORY/packaged.yaml" \
+                      --config-env "$PARAM_SAM_CONFIG_ENV" \
+                      --no-confirm-changeset \
+                      --region "$AWS_REGION_NAME"
+
+                    if [ -n "$STACK_NAME" ]; then
+                      set -- "$@" --stack-name "$STACK_NAME"
                     fi
 
-                    eval $SAM_DEPLOY_CMD
+                    # Add parameter overrides if they exist
+                    if [ -n "$PARAMETER_OVERRIDES" ]; then
+                      # shellcheck disable=SC2086 # word splitting is intended: one argument per Key=Value pair
+                      set -- "$@" --parameter-overrides $PARAMETER_OVERRIDES
+                    fi
+
+                    "$@"
 
             # Every parameter and predefined variable this script reads arrives through
             # `env:`. `${{ }}` is substituted into the YAML before the agent runs it, so a
@@ -287,6 +307,8 @@ stages:
               PARAM_SAM_CONFIG_ENV: ${{ parameters.SAM_CONFIG_ENV }}
               BUILD_SOURCES_DIRECTORY: $(Build.SourcesDirectory)
               AWS_REGION_NAME: $(AWS_REGION)
+              STACK_NAME: $(STACK_NAME)
+              PARAMETER_OVERRIDES: $(PARAMETER_OVERRIDES)
           - script: |
               set -e
 
@@ -298,20 +320,40 @@ stages:
 
               echo "Deploying Lambda function via AWS SAM..."
 
-              # Build sam deploy command
-              SAM_DEPLOY_CMD="sam deploy \
-                --template-file $BUILD_SOURCES_DIRECTORY/packaged.yaml \
-                --config-env $PARAM_SAM_CONFIG_ENV \
-                --stack-name $(STACK_NAME) \
-                --no-confirm-changeset \
-                --region $AWS_REGION_NAME"
+              # Azure DevOps substitutes nothing for an undefined variable, so `$(STACK_NAME)`
+              # and `$(PARAMETER_OVERRIDES)` arrive verbatim when the consumer never set them:
+              # a value that still looks like a macro means "not set". Both are optional --
+              # the SAM entrypoint takes the stack name from `samconfig.toml` -- so neither is
+              # passed to `sam` unless it holds a real value.
+              case "${STACK_NAME:-}" in
+                '$('*) STACK_NAME='' ;;
+              esac
+              case "${PARAMETER_OVERRIDES:-}" in
+                '$('*) PARAMETER_OVERRIDES='' ;;
+              esac
 
-              # Add parameter overrides if they exist
-              if [ -n "$(PARAMETER_OVERRIDES)" ]; then
-                SAM_DEPLOY_CMD="$SAM_DEPLOY_CMD --parameter-overrides $(PARAMETER_OVERRIDES)"
+              # Build the command as positional parameters and run it directly. Assembling a
+              # string and calling `eval` on it would hand every value back to the parser a
+              # second time, which is the very sink the `env:` block below exists to close:
+              # a `;` or a `$(...)` in any of them would run as a command on the agent that
+              # holds this pipeline's AWS credentials.
+              set -- sam deploy \
+                --template-file "$BUILD_SOURCES_DIRECTORY/packaged.yaml" \
+                --config-env "$PARAM_SAM_CONFIG_ENV" \
+                --no-confirm-changeset \
+                --region "$AWS_REGION_NAME"
+
+              if [ -n "$STACK_NAME" ]; then
+                set -- "$@" --stack-name "$STACK_NAME"
               fi
 
-              eval $SAM_DEPLOY_CMD
+              # Add parameter overrides if they exist
+              if [ -n "$PARAMETER_OVERRIDES" ]; then
+                # shellcheck disable=SC2086 # word splitting is intended: one argument per Key=Value pair
+                set -- "$@" --parameter-overrides $PARAMETER_OVERRIDES
+              fi
+
+              "$@"
             displayName: 'Deploy Lambda Function via SAM (Environment Variables)'
             condition: and(eq(variables['DEPLOY_STRATEGY'], 'sam'), eq(variables['AWS_SERVICE_CONNECTION'], ''))
             # Every parameter and predefined variable this script reads arrives through
@@ -322,3 +364,5 @@ stages:
               PARAM_SAM_CONFIG_ENV: ${{ parameters.SAM_CONFIG_ENV }}
               BUILD_SOURCES_DIRECTORY: $(Build.SourcesDirectory)
               AWS_REGION_NAME: $(AWS_REGION)
+              STACK_NAME: $(STACK_NAME)
+              PARAMETER_OVERRIDES: $(PARAMETER_OVERRIDES)

--- a/azure-devops/golang/stages/50-deployment/lambda.yaml
+++ b/azure-devops/golang/stages/50-deployment/lambda.yaml
@@ -163,7 +163,7 @@ stages:
               fi
 
               # Validate LAMBDA_FUNCTION_NAME is provided for ZIP deployment
-              if [ -z "${{ parameters.LAMBDA_FUNCTION_NAME }}" ]; then
+              if [ -z "$LAMBDA_FUNCTION_NAME" ]; then
                 echo "ERROR: LAMBDA_FUNCTION_NAME is required for ZIP deployment"
                 exit 1
               fi
@@ -171,70 +171,85 @@ stages:
               echo "Deploying Lambda function via AWS CLI..."
 
               # Check if function exists
-              if aws lambda get-function --function-name ${{ parameters.LAMBDA_FUNCTION_NAME }} --region $(AWS_REGION) 2>/dev/null; then
-                echo "Updating existing Lambda function: ${{ parameters.LAMBDA_FUNCTION_NAME }}"
+              if aws lambda get-function --function-name $LAMBDA_FUNCTION_NAME --region $AWS_REGION_NAME 2>/dev/null; then
+                echo "Updating existing Lambda function: $LAMBDA_FUNCTION_NAME"
                 aws lambda update-function-code \
-                  --function-name ${{ parameters.LAMBDA_FUNCTION_NAME }} \
-                  --zip-file fileb://$(Build.SourcesDirectory)/lambda-function.zip \
-                  --region $(AWS_REGION)
+                  --function-name $LAMBDA_FUNCTION_NAME \
+                  --zip-file fileb://$BUILD_SOURCES_DIRECTORY/lambda-function.zip \
+                  --region $AWS_REGION_NAME
 
-                # Update configuration if parameters are provided
                 # Update configuration if environment variables are provided
-                if [ -n "${{ parameters.LAMBDA_ENV_VARS }}" ]; then
+                if [ -n "$LAMBDA_ENV_VARS" ]; then
                   aws lambda update-function-configuration \
-                    --function-name ${{ parameters.LAMBDA_FUNCTION_NAME }} \
-                    --timeout ${{ parameters.LAMBDA_TIMEOUT }} \
-                    --memory-size ${{ parameters.LAMBDA_MEMORY_SIZE }} \
-                    --environment "Variables={${{ parameters.LAMBDA_ENV_VARS }}}" \
-                    --region $(AWS_REGION)
+                    --function-name $LAMBDA_FUNCTION_NAME \
+                    --timeout $LAMBDA_TIMEOUT \
+                    --memory-size $LAMBDA_MEMORY_SIZE \
+                    --environment "Variables={$LAMBDA_ENV_VARS}" \
+                    --region $AWS_REGION_NAME
                 else
                   aws lambda update-function-configuration \
-                    --function-name ${{ parameters.LAMBDA_FUNCTION_NAME }} \
-                    --timeout ${{ parameters.LAMBDA_TIMEOUT }} \
-                    --memory-size ${{ parameters.LAMBDA_MEMORY_SIZE }} \
-                    --region $(AWS_REGION)
+                    --function-name $LAMBDA_FUNCTION_NAME \
+                    --timeout $LAMBDA_TIMEOUT \
+                    --memory-size $LAMBDA_MEMORY_SIZE \
+                    --region $AWS_REGION_NAME
                 fi
               else
-                # If function does not exist, check if we should create it
-                if [ "${{ parameters.CREATE_IF_MISSING }}" = "true" ]; then
-                  echo "Creating new Lambda function: ${{ parameters.LAMBDA_FUNCTION_NAME }}"
+                # Only create if CREATE_IF_MISSING is true
+                if [ "$PARAM_CREATE_IF_MISSING" = "true" ]; then
+                  echo "Creating new Lambda function: $LAMBDA_FUNCTION_NAME"
 
                   # Note: Creating a Lambda function requires IAM role ARN
                   # This should be provided via environment variables or parameters
                   if [ -z "$LAMBDA_ROLE_ARN" ]; then
                     echo "ERROR: LAMBDA_ROLE_ARN environment variable is required to create a new Lambda function"
                     exit 1
-                  fi  
+                  fi
 
-                  if [ -n "${{ parameters.LAMBDA_ENV_VARS }}" ]; then
+                  if [ -n "$LAMBDA_ENV_VARS" ]; then
                     aws lambda create-function \
-                      --function-name ${{ parameters.LAMBDA_FUNCTION_NAME }} \
-                      --runtime ${{ parameters.LAMBDA_RUNTIME }} \
-                      --handler ${{ parameters.LAMBDA_HANDLER }} \
+                      --function-name $LAMBDA_FUNCTION_NAME \
+                      --runtime $LAMBDA_RUNTIME \
+                      --handler $LAMBDA_HANDLER \
                       --role "$LAMBDA_ROLE_ARN" \
-                      --zip-file fileb://$(Build.SourcesDirectory)/lambda-function.zip \
-                      --timeout ${{ parameters.LAMBDA_TIMEOUT }} \
-                      --memory-size ${{ parameters.LAMBDA_MEMORY_SIZE }} \
-                      --environment "Variables={${{ parameters.LAMBDA_ENV_VARS }}}" \
-                      --region $(AWS_REGION)
+                      --zip-file fileb://$BUILD_SOURCES_DIRECTORY/lambda-function.zip \
+                      --timeout $LAMBDA_TIMEOUT \
+                      --memory-size $LAMBDA_MEMORY_SIZE \
+                      --environment "Variables={$LAMBDA_ENV_VARS}" \
+                      --region $AWS_REGION_NAME
                   else
                     aws lambda create-function \
-                      --function-name ${{ parameters.LAMBDA_FUNCTION_NAME }} \
-                      --runtime ${{ parameters.LAMBDA_RUNTIME }} \
-                      --handler ${{ parameters.LAMBDA_HANDLER }} \
+                      --function-name $LAMBDA_FUNCTION_NAME \
+                      --runtime $LAMBDA_RUNTIME \
+                      --handler $LAMBDA_HANDLER \
                       --role "$LAMBDA_ROLE_ARN" \
-                      --zip-file fileb://$(Build.SourcesDirectory)/lambda-function.zip \
-                      --timeout ${{ parameters.LAMBDA_TIMEOUT }} \
-                      --memory-size ${{ parameters.LAMBDA_MEMORY_SIZE }} \
-                      --region $(AWS_REGION)
+                      --zip-file fileb://$BUILD_SOURCES_DIRECTORY/lambda-function.zip \
+                      --timeout $LAMBDA_TIMEOUT \
+                      --memory-size $LAMBDA_MEMORY_SIZE \
+                      --region $AWS_REGION_NAME
                   fi
                 else
-                  echo "ERROR: Lambda function ${{ parameters.LAMBDA_FUNCTION_NAME }} does not exist and CREATE_IF_MISSING is false"
+                  echo "ERROR: Lambda function $LAMBDA_FUNCTION_NAME does not exist and CREATE_IF_MISSING is false"
                   exit 1
                 fi
+              fi
+
               echo "Lambda function deployed successfully"
             displayName: 'Deploy Lambda Function via ZIP (Environment Variables)'
             condition: and(eq(variables['DEPLOY_STRATEGY'], 'zip'), eq(variables['AWS_SERVICE_CONNECTION'], ''))
+            # Every parameter and predefined variable this script reads arrives through
+            # `env:`. `${{ }}` is substituted into the YAML before the agent runs it, so a
+            # value carrying a quote used to close an `aws` argument and append a command --
+            # on the very step that deploys with this pipeline's AWS credentials.
+            env:
+              LAMBDA_FUNCTION_NAME: ${{ parameters.LAMBDA_FUNCTION_NAME }}
+              LAMBDA_ENV_VARS: ${{ parameters.LAMBDA_ENV_VARS }}
+              LAMBDA_TIMEOUT: ${{ parameters.LAMBDA_TIMEOUT }}
+              LAMBDA_MEMORY_SIZE: ${{ parameters.LAMBDA_MEMORY_SIZE }}
+              PARAM_CREATE_IF_MISSING: ${{ parameters.CREATE_IF_MISSING }}
+              LAMBDA_RUNTIME: ${{ parameters.LAMBDA_RUNTIME }}
+              LAMBDA_HANDLER: ${{ parameters.LAMBDA_HANDLER }}
+              AWS_REGION_NAME: $(AWS_REGION)
+              BUILD_SOURCES_DIRECTORY: $(Build.SourcesDirectory)
 
           # SAM Deployment Strategy
           - task: 'AWSShellScript@1'
@@ -285,11 +300,11 @@ stages:
 
               # Build sam deploy command
               SAM_DEPLOY_CMD="sam deploy \
-                --template-file $(Build.SourcesDirectory)/packaged.yaml \
-                --config-env ${{ parameters.SAM_CONFIG_ENV }} \
+                --template-file $BUILD_SOURCES_DIRECTORY/packaged.yaml \
+                --config-env $PARAM_SAM_CONFIG_ENV \
                 --stack-name $(STACK_NAME) \
                 --no-confirm-changeset \
-                --region $(AWS_REGION)"
+                --region $AWS_REGION_NAME"
 
               # Add parameter overrides if they exist
               if [ -n "$(PARAMETER_OVERRIDES)" ]; then
@@ -299,3 +314,11 @@ stages:
               eval $SAM_DEPLOY_CMD
             displayName: 'Deploy Lambda Function via SAM (Environment Variables)'
             condition: and(eq(variables['DEPLOY_STRATEGY'], 'sam'), eq(variables['AWS_SERVICE_CONNECTION'], ''))
+            # Every parameter and predefined variable this script reads arrives through
+            # `env:`. `${{ }}` is substituted into the YAML before the agent runs it, so a
+            # value carrying a quote used to close a `sam` argument and append a command --
+            # on the very step that deploys with this pipeline's AWS credentials.
+            env:
+              PARAM_SAM_CONFIG_ENV: ${{ parameters.SAM_CONFIG_ENV }}
+              BUILD_SOURCES_DIRECTORY: $(Build.SourcesDirectory)
+              AWS_REGION_NAME: $(AWS_REGION)

--- a/azure-devops/java/stages/10-code-check/java.yaml
+++ b/azure-devops/java/stages/10-code-check/java.yaml
@@ -30,7 +30,10 @@ stages:
              # Guardsquare publishes no checksum manifest; this digest was
              # computed from the published artifact and is kept in step with
              # global/scripts/shared/pinned-versions.sh.
-             wget -q --https-only "https://github.com/Guardsquare/proguard/releases/download/v7.6.1/proguard-7.6.1.tar.gz" -O /tmp/proguard.tar.gz
+             # `--proto-redir '=https'` rather than a bare follow: the GitHub release URL
+             # redirects to its asset host, and this pins every hop of that chain to HTTPS
+             # so the archive ProGuard is run from cannot arrive over plain HTTP.
+             curl -fsSL --proto '=https' --proto-redir '=https' "https://github.com/Guardsquare/proguard/releases/download/v7.6.1/proguard-7.6.1.tar.gz" -o /tmp/proguard.tar.gz
              echo "672ef62a3154474a6172cbfde9a2f09da1642a17a80e1c7b79a6cc58953fbe06  /tmp/proguard.tar.gz" | sha256sum -c - || { rm -f /tmp/proguard.tar.gz; echo "ERROR - ProGuard checksum mismatch" >&2; exit 1; }
              tar xzf /tmp/proguard.tar.gz -C /tmp
              INPUT_JAR=$(find . -path "*/build/libs/*.jar" -not -name "*-sources.jar" -not -name "*-javadoc.jar" | head -1)

--- a/global/containers/bfg.latest/Dockerfile
+++ b/global/containers/bfg.latest/Dockerfile
@@ -6,7 +6,10 @@ ENV WORK_DIR /code
 
 VOLUME ["${WORK_DIR}"]
 
-RUN wget --quiet --https-only --output-document=/bfg.jar https://repo1.maven.org/maven2/com/madgag/bfg/${BFG_VERSION}/bfg-${BFG_VERSION}.jar
+# `--proto '=https' --proto-redir '=https'` rather than plain `wget`: Maven Central answers
+# this artifact URL directly, and pinning both the initial protocol and any redirect to HTTPS
+# keeps a redirect from ever downgrading the jar this image runs as code to plain HTTP.
+RUN curl -fsSL --proto '=https' --proto-redir '=https' --output /bfg.jar https://repo1.maven.org/maven2/com/madgag/bfg/${BFG_VERSION}/bfg-${BFG_VERSION}.jar
 
 RUN echo "#!/usr/bin/env sh" > /usr/bin/bfg \
     && echo "set -e" >> /usr/bin/bfg \

--- a/global/containers/golang.1.26-awscli/Dockerfile
+++ b/global/containers/golang.1.26-awscli/Dockerfile
@@ -9,11 +9,11 @@ RUN apt-get update && apt-get install --yes --no-install-recommends unzip \
 ARG TARGETARCH
 
 RUN AWS_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") \
-	&& cd /tmp && wget --https-only "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_ARCH}.zip" \
+	&& cd /tmp && curl -fsSLO --proto '=https' --proto-redir '=https' "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_ARCH}.zip" \
 	&& unzip "awscli-exe-linux-${AWS_ARCH}.zip" && ./aws/install \
 	&& rm -rf * && aws --version
 
 RUN SAM_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "x86_64") \
-	&& cd /tmp && wget --https-only "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-${SAM_ARCH}.zip" \
+	&& cd /tmp && curl -fsSLO --proto '=https' --proto-redir '=https' "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-${SAM_ARCH}.zip" \
 	&& unzip "aws-sam-cli-linux-${SAM_ARCH}.zip" -d "aws-sam-installation" && ./aws-sam-installation/install \
 	&& rm -rf * && sam --version

--- a/global/scripts/languages/dart/analyze/dart_analyze_report.py
+++ b/global/scripts/languages/dart/analyze/dart_analyze_report.py
@@ -109,13 +109,36 @@ def parse(stream) -> list[dict]:
     return diagnostics
 
 
+def within_workdir(raw: str, purpose: str) -> str:
+    """Resolve a command-line path and require it to stay inside the working tree.
+
+    The report directory arrives on argv, and this script CREATES it, so
+    "wherever you point me" is the wrong contract for a CI helper. `run.sh`
+    passes `$DART_TOOL_REPORT_PATH`, which `common.sh` builds from
+    `${PREFIX}${REPORT_PATH}` -- relative to the job's working directory in
+    every runner here -- so confining it costs nothing real and makes a
+    traversal (`dart_analyze_report.py ../../etc`) fail here rather than
+    somewhere surprising. Same shape as `within_workdir` in
+    tools/dependency-updates/check_updates.py.
+
+    Resolved with `realpath` first so a symlink cannot be used to step outside
+    after the check.
+    """
+    base = os.path.realpath(os.getcwd())
+    resolved = os.path.realpath(raw)
+    if resolved != base and not resolved.startswith(base + os.sep):
+        raise SystemExit(
+            "refusing to use '{raw}' as {purpose}: it resolves outside the working "
+            "directory '{base}'".format(raw=raw, purpose=purpose, base=base)
+        )
+    return resolved
+
+
 def report_path(report_dir: str, filename: str) -> str:
     """Join a report file name onto the report directory, refusing to escape it.
 
-    The directory itself is the CALLER's choice and may legitimately be absolute
-    -- `run.sh` passes `$DART_TOOL_REPORT_PATH`, and the validation suite passes
-    a temporary directory -- so this deliberately does not confine it to the
-    working tree. What it does confine is the part this script constructs: the
+    The directory is confined by `within_workdir` before anything is created
+    under it. What THIS confines is the part the script constructs: the
     resolved file must still sit inside the directory it was given, so a name
     carrying `..` cannot write somewhere the caller never named.
     """
@@ -190,7 +213,10 @@ def write_junit(diagnostics: list[dict], path: str, fatal: set[str]) -> None:
 
 
 def main() -> int:
-    report_dir = sys.argv[1] if len(sys.argv) > 1 else "build/reports/dart-analyze"
+    report_dir = within_workdir(
+        sys.argv[1] if len(sys.argv) > 1 else "build/reports/dart-analyze",
+        "the report directory",
+    )
     os.makedirs(report_dir, exist_ok=True)
 
     diagnostics = parse(sys.stdin)

--- a/global/scripts/languages/terraform/order-check/check_order.py
+++ b/global/scripts/languages/terraform/order-check/check_order.py
@@ -1020,12 +1020,36 @@ def run(repo: Path, cfg: Config, fix: bool) -> list[FileResult]:
 # --------------------------------------------------------------------------- #
 # JUnit + human output
 # --------------------------------------------------------------------------- #
-def write_junit(results: list[FileResult], report_dir: Path) -> None:
-    # `--report` may legitimately be absolute (the flag documents it), so the
-    # directory itself is not confined. The file name this function appends is,
-    # which is what keeps a constructed path from escaping the directory the
-    # caller actually named.
-    report_dir = Path(os.path.realpath(report_dir))
+def within_repo(raw: Path, repo: Path, purpose: str) -> Path:
+    """Resolve a command-line path and require it to stay inside the repository.
+
+    `--report` arrives on argv and this tool CREATES it, so "wherever you point
+    me" is the wrong contract for a CI checker. A relative `--report` already
+    resolves against `--repo-dir`, and every runner here passes a relative
+    `REPORT_PATH` (`build/reports`), so confining an absolute one to the same
+    tree costs nothing real and makes a traversal (`--report ../../etc`) fail
+    here rather than somewhere surprising. Same shape as `within_workdir` in
+    tools/dependency-updates/check_updates.py.
+
+    Resolved with `realpath` first so a symlink cannot be used to step outside
+    after the check.
+    """
+    base = Path(os.path.realpath(repo))
+    resolved = Path(os.path.realpath(raw))
+    if resolved != base and base not in resolved.parents:
+        raise SystemExit(
+            "refusing to use '{raw}' as {purpose}: it resolves outside the "
+            "repository '{base}'".format(raw=raw, purpose=purpose, base=base)
+        )
+    return resolved
+
+
+def write_junit(results: list[FileResult], report_dir: Path, repo: Path) -> None:
+    # The directory is confined to the repository before anything is created
+    # under it. The file name this function appends is confined too, which is
+    # what keeps a constructed path from escaping the directory the caller
+    # actually named.
+    report_dir = within_repo(report_dir, repo, "the report directory")
     report_dir.mkdir(parents=True, exist_ok=True)
     cases = []
     total = failures = 0
@@ -1077,7 +1101,7 @@ def main(argv: list[str]) -> int:
 
     results = run(repo, cfg, fix=args.fix)
     report_dir = (repo / args.report) if not os.path.isabs(args.report) else Path(args.report)
-    write_junit(results, report_dir)
+    write_junit(results, report_dir, repo)
 
     errors = warnings = fixed = 0
     for r in results:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,71 @@
+# SonarQube / SonarCloud configuration for this repository.
+#
+# `global/scripts/tools/sonarqube/run.sh` APPENDS to this file at scan time
+# (sonar.projectKey, sonar.projectName, sonar.projectVersion and the coverage
+# report paths), so every line here must stay a plain `key=value` pair.
+#
+# Everything below is an ACCEPTED finding: a review decision recorded in the
+# repository rather than clicked away in the SonarCloud UI, so the reason
+# travels with the code. Each entry is scoped to one rule AND one file --
+# never a whole rule, never a whole directory -- so the same rule keeps
+# reporting everywhere else. Fixes are preferred; these are the cases where
+# the fix would remove behaviour the file exists to provide.
+
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11
+
+# e1-e4 -- docker:S6471 "runs with root as the default user".
+# These four images are CI JOB containers and mounted-workspace tools, not
+# services. Azure Pipelines (`container:`) and GitLab (`image:`) create and
+# chown the workspace inside the container before the job's first step runs,
+# and BFG rewrites a git repository bind-mounted from the host at /code: a
+# fixed non-root UID in the image cannot own either, so the job fails on
+# permissions before any pipeline code executes. tor-proxy is the same story
+# from the other side -- its supervisord must start as root precisely so it
+# can drop tor to `user=tor` (see config/supervisord.conf).
+sonar.issue.ignore.multicriteria.e1.ruleKey=docker:S6471
+sonar.issue.ignore.multicriteria.e1.resourceKey=global/containers/golang.1.26-awscli/Dockerfile
+sonar.issue.ignore.multicriteria.e2.ruleKey=docker:S6471
+sonar.issue.ignore.multicriteria.e2.resourceKey=global/containers/awscli.latest/Dockerfile
+sonar.issue.ignore.multicriteria.e3.ruleKey=docker:S6471
+sonar.issue.ignore.multicriteria.e3.resourceKey=global/containers/bfg.latest/Dockerfile
+sonar.issue.ignore.multicriteria.e4.ruleKey=docker:S6471
+sonar.issue.ignore.multicriteria.e4.resourceKey=global/containers/tor-proxy.latest/Dockerfile
+
+# e5-e7 -- githubactions:S7634 "only pass required secrets to this step".
+# `toJSON(secrets)` is what the step is FOR: the caller names its build-time
+# secrets at runtime through the `build_env_secret_names` input, so the set
+# cannot be enumerated in the workflow. In a reusable workflow `secrets` holds
+# only what the caller chose to pass (declared secrets, or `secrets: inherit`),
+# the step resolves the names into `$GITHUB_ENV` and never prints a value, and
+# it already runs in the job that holds the deployment credentials -- so it
+# widens nothing it did not already have.
+sonar.issue.ignore.multicriteria.e5.ruleKey=githubactions:S7634
+sonar.issue.ignore.multicriteria.e5.resourceKey=.github/workflows/dart-cloudflare.yaml
+sonar.issue.ignore.multicriteria.e6.ruleKey=githubactions:S7634
+sonar.issue.ignore.multicriteria.e6.resourceKey=.github/workflows/npm-cloudflare.yaml
+sonar.issue.ignore.multicriteria.e7.ruleKey=githubactions:S7634
+sonar.issue.ignore.multicriteria.e7.resourceKey=.github/workflows/yarn-cloudflare.yaml
+
+# e8 -- yaml:S2068 "hard-coded credential" over the whole `run:` block of the
+# test-database step. There is no literal credential in it: the value is
+# generated per run by `openssl rand -hex 24`, is published only on loopback,
+# and dies with the container. What the analyzer matches is the shape
+# `POSTGRES_PASSWORD=<value>` -- and that variable NAME is the PostgreSQL
+# image's documented contract, so it cannot be renamed away.
+sonar.issue.ignore.multicriteria.e8.ruleKey=yaml:S2068
+sonar.issue.ignore.multicriteria.e8.resourceKey=github/golang/stages/30-tests/all/action.yaml
+
+# e9-e11 -- azurepipelines:S7637 "use a complete version number for the task".
+# `AWSShellScript@1` and `TerraformInstaller@1` come from marketplace
+# extensions (AWS Toolkit for Azure DevOps, Microsoft DevLabs Terraform), and
+# their minor/patch version is whatever version of the extension the CONSUMING
+# organization has installed. Pinning one here would resolve to "task not
+# found" in every organization that installed a different one, so the major
+# version is the only reference that is portable across the repositories that
+# consume these templates.
+sonar.issue.ignore.multicriteria.e9.ruleKey=azurepipelines:S7637
+sonar.issue.ignore.multicriteria.e9.resourceKey=azure-devops/golang/stages/40-delivery/lambda.yaml
+sonar.issue.ignore.multicriteria.e10.ruleKey=azurepipelines:S7637
+sonar.issue.ignore.multicriteria.e10.resourceKey=azure-devops/golang/stages/50-deployment/lambda.yaml
+sonar.issue.ignore.multicriteria.e11.ruleKey=azurepipelines:S7637
+sonar.issue.ignore.multicriteria.e11.resourceKey=azure-devops/terraform/abstracts/terra-terraform.yaml


### PR DESCRIPTION
## Why

The SonarCloud Quality Gate on `main` (`rios0rios0_pipelines`) is red:

- **Security Rating on New Code: E** (required A) — 40 open vulnerabilities, 27 of them BLOCKER.
- **Security Hotspots Reviewed: 0%** (required 100%) — 5 hotspots in `TO_REVIEW`.

Rating A requires *zero* open vulnerabilities, so every one of the 40 had to be either fixed
or accepted. This PR fixes 31 of them in code and records the remaining 9 (plus the 5 hotspots)
as scoped, explained acceptances.

## What changed

### `azurepipelines:S7630` — user-controlled data in a script block (27 × BLOCKER)

`azure-devops/golang/stages/50-deployment/lambda.yaml`, lines 166–289. The two `AWSShellScript@1`
steps in this file already passed their parameters through `env:`; the two plain `- script:` steps
next to them still interpolated `${{ parameters.* }}` directly into the shell. `${{ }}` is
substituted into the YAML *before* the agent runs it, so a parameter value carrying a quote closes
an `aws` argument and appends a command — on the very steps that deploy with the pipeline's AWS
credentials.

Both steps now read every parameter and predefined variable from `env:`, using the same variable
names as their `AWSShellScript@1` twins (`LAMBDA_FUNCTION_NAME`, `PARAM_CREATE_IF_MISSING`,
`AWS_REGION_NAME`, `BUILD_SOURCES_DIRECTORY`, …). Step names, conditions, parameter names and
ordering are unchanged, so no consumer has to change anything.

**Bug found on the way:** the `Deploy Lambda Function via ZIP (Environment Variables)` step was
missing a `fi` — `bash -n` on the block as it stands on `main` exits 2 with a syntax error, so that
step could never have run. The rewrite mirrors the working `AWSShellScript@1` twin and closes it.

### `S6506` — redirects not restricted (4 findings)

Replaced `wget` with the pattern already used elsewhere in this repository
(`azure-devops/terraform/abstracts/terra-terraform.yaml`, `global/containers/awscli.latest/`), which
Sonar does not flag:

| File | Download |
|------|----------|
| `azure-devops/java/stages/10-code-check/java.yaml:33` | ProGuard release tarball |
| `global/containers/golang.1.26-awscli/Dockerfile:12` | AWS CLI installer |
| `global/containers/golang.1.26-awscli/Dockerfile:17` | AWS SAM CLI installer |
| `global/containers/bfg.latest/Dockerfile:9` | BFG jar from Maven Central |

`--proto '=https' --proto-redir '=https'` pins the initial request *and every redirect hop* to
HTTPS, which is what `wget --https-only` did not give us. Redirects still work, which two of these
downloads need: `github.com/.../releases/latest/download/...` answers 302 twice before reaching the
asset host (verified). `-f` was added so an HTTP error fails the build instead of writing an error
page to disk. `curl` is present in all three base images (`golang:1.26` is buildpack-deps-based;
the Adoptium Ubuntu images install `curl` explicitly).

### `pythonsecurity:S8707` — path escape via CLI arguments (2 findings)

Both scripts created a report directory taken straight from `argv`. They now validate it before
creating anything, using the same shape as the existing `within_workdir` in
`global/scripts/tools/dependency-updates/check_updates.py` — which is the one script of the three
that Sonar does *not* flag, i.e. the sanitizer the rule recognises:

- `global/scripts/languages/terraform/order-check/check_order.py` — `--report` is confined to the
  repository given by `--repo-dir`. A relative `--report` already resolved against `--repo-dir`, so
  the normal path is unchanged; an absolute one now has to be inside that tree.
- `global/scripts/languages/dart/analyze/dart_analyze_report.py` — the report directory is confined
  to the working directory. `run.sh` passes `${PREFIX}${REPORT_PATH}/analyze`, which is relative in
  every runner here, so the normal path is unchanged.

Both resolve with `realpath` first, so a symlink cannot be used to step outside after the check.
**Behaviour change:** a `REPORT_PATH` / `--report` pointing outside those trees now fails loudly
instead of writing there. Two test call sites were adjusted to match (they used out-of-tree
`mktemp` directories); the assertions themselves are untouched.

## Accepted findings

Recorded in a new root `sonar-project.properties` as
`sonar.issue.ignore.multicriteria` entries `e1`–`e11`, each scoped to **one rule and one file** —
never a whole rule, never a directory — with the reason inline. The file is plain `key=value`
lines, so `global/scripts/tools/sonarqube/run.sh` can keep appending to it at scan time.

| Rule | Files | Reason |
|------|-------|--------|
| `docker:S6471` (root user) | `golang.1.26-awscli`, `awscli.latest`, `bfg.latest`, `tor-proxy.latest` Dockerfiles | The first three are CI **job containers** (`container:` in Azure, `image:` in GitLab) and mounted-workspace tools: the runner creates and chowns the workspace inside the container before the first step, and BFG rewrites a host-bind-mounted repo at `/code`. A fixed non-root UID cannot own either, so the job fails on permissions before any pipeline code runs. `tor-proxy`'s supervisord must start as root precisely so it can drop tor to `user=tor`. |
| `githubactions:S7634` (only required secrets) | `dart-`, `npm-`, `yarn-cloudflare.yaml` | `toJSON(secrets)` is what the step is *for*: the caller names its build-time secrets at runtime via the `build_env_secret_names` input, so the set cannot be enumerated in the workflow. In a reusable workflow `secrets` holds only what the caller passed; the step writes resolved names into `$GITHUB_ENV`, never prints a value, and already runs in the job holding the deployment credentials. |
| `yaml:S2068` (hard-coded credential) | `github/golang/stages/30-tests/all/action.yaml` | No literal credential exists: the value is generated per run by `openssl rand -hex 24`, published only on loopback, and dies with the container. The analyzer highlights the whole 72-line `run:` block; the shape it matches is `POSTGRES_PASSWORD=<value>`, and that variable **name** is the PostgreSQL image's documented contract. |
| `azurepipelines:S7637` (complete task version) — the 4 hotspots | `40-delivery/lambda.yaml`, `50-deployment/lambda.yaml`, `terraform/abstracts/terra-terraform.yaml` | `AWSShellScript@1` and `TerraformInstaller@1` come from marketplace extensions (AWS Toolkit for Azure DevOps, Microsoft DevLabs Terraform). Their minor/patch version is whatever extension version the **consuming** organization installed, so a full pin would resolve to "task not found" for anyone on a different one. The major version is the only portable reference. |

The fifth hotspot (`docker:S6471` on `tor-proxy.latest/Dockerfile`) is covered by the `e4` entry above.

## Verification

Run on the fix branch and, for every failure, re-run on a pristine `git archive` of `origin/main`
to separate pre-existing breakage from regressions.

- `make -k test` — all 34 targets executed. **25 passed**, including every target that touches these
  files: `test-lambda`, `test-order-check` (76/76), `test-azure-step-names`, `test-yaml-merge`,
  `test-sonarqube`, `test-supply-chain`, `test-workflow-composition`, `test-docker-multi-arch`.
- 9 targets failed — `test-dependency-track`, `test-go-script`, `test-cyclonedx-main`,
  `test-go-integration-scope`, `test-terraform-validate`, `test-basic-checks`,
  `test-dependency-check`, `test-deploy-providers`, `test-dart-pipeline`. **Every one of them fails
  identically on pristine `origin/main`** on the same machine (no Go / Terraform / Dart SDK, no
  semgrep). For `test-dart-pipeline` the failing assertion sets were compared line by line and are
  identical; the 11 assertions covering `dart_analyze_report.py` all pass.
- `azure-devops/golang/stages/50-deployment/lambda.yaml` parses with PyYAML, all six steps survive,
  and every script block passes `bash -n` (the ZIP-by-env-vars block does *not* on `main`).
- Both Python scripts smoke-tested directly: relative and inside-tree absolute report directories
  work, `../..` traversal and out-of-tree absolute paths are refused with exit 1.
- Redirect behaviour of all four download URLs checked over the network before choosing flags.

**SonarCloud on this PR — measured, not predicted:**

| Condition | Result |
|-----------|--------|
| `new_security_rating` | **A** (was E on `main`) |
| `new_security_hotspots_reviewed` | **100%** (was 0% on `main`) |
| `new_reliability_rating` / `new_maintainability_rating` / duplication | A / A / 0.0% |
| Quality Gate | **OK** |

Open vulnerabilities on the PR: **0**. Hotspots in `TO_REVIEW`: **0**. The four remaining issues are
pre-existing MINOR/MAJOR code smells on `bfg.latest/Dockerfile` (`S6570`, `S7026`, `S7031`) that are
already open on `main` at the same lines and only re-surface because the file is now touched;
maintainability stays at A.

**Worth knowing:**

- A PR analysis only evaluates the files the PR changes, so the exclusions covering *unchanged*
  files (the three cloudflare workflows, `tor-proxy.latest`/`awscli.latest` Dockerfiles, the Go
  tests action, `40-delivery/lambda.yaml`) were not exercised by this scan. Issue exclusions are
  applied scan-wide, and the one exclusion that does cover a changed file — `azurepipelines:S7637`
  on `50-deployment/lambda.yaml` — took effect, which is what moved hotspots-reviewed to 100%. That
  is good evidence the mechanism works for hotspots, but the `main` scan after merge is the
  confirmation.
- `make lint` and `make sast` do not exist in this repository's Makefile; only `make test` does.
- The container images were not built (no Docker here), so the `curl` substitutions are reasoned
  from the base images' contents rather than executed.
- Suppressing security *hotspots* through `sonar.issue.ignore.multicriteria` is the documented
  behaviour but was not confirmed against this project's scan; if the four `S7637` hotspots survive,
  they will need to be marked reviewed in the SonarCloud UI instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBkPLFLrWCPLaEKrS37ah5
