### PR TITLE
fix(deps): re-resolved the two rebuilt container image digests

### DIFF
--- a/.changes/unreleased/1788663656053600004-e2bf.yaml
+++ b/.changes/unreleased/1788663656053600004-e2bf.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'fixed the two container image digests the Dependency Updates gate still reported as stale after the previous bump: `awscli:latest` and `golang:1.26-awscli` are built by this repository, and the `containers.yaml` runs that followed the bump merge rebuilt and republished both, so the digests pinned by `gitlab/global/stages/50-deployment/sam.yaml` and `gitlab/golang/stages/40-delivery/sam.yaml` were already superseded by the time they landed on `main` -- re-resolved both from the registry so the gate reports every pin current'
+time: '2026-09-06T03:00:56.053600004Z'

--- a/gitlab/global/stages/50-deployment/sam.yaml
+++ b/gitlab/global/stages/50-deployment/sam.yaml
@@ -2,7 +2,7 @@ include:
   - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/abstracts/aws-scripts.yaml'
 
 deployment:qa:
-  image: 'ghcr.io/rios0rios0/pipelines/awscli:latest@sha256:9259135b12e92e522f8d9d1ca82721271cbe31a01a5012a3bb10cd04a930fb61'
+  image: 'ghcr.io/rios0rios0/pipelines/awscli:latest@sha256:b18dafea813a3e23a6abc8bc55728d1a6a4f149d5c4d540dca43c3e907759e2f'
   stage: 'deployment'
   environment:
     name: 'qa'

--- a/gitlab/golang/stages/40-delivery/sam.yaml
+++ b/gitlab/golang/stages/40-delivery/sam.yaml
@@ -2,7 +2,7 @@ include:
   - remote: 'https://raw.githubusercontent.com/rios0rios0/pipelines/main/gitlab/global/stages/40-delivery/sam.yaml'
 
 .delivery:
-  image: 'ghcr.io/rios0rios0/pipelines/golang:1.26-awscli@sha256:ea5a9bf32d1860f616e87874b0f20416549101820778800ef1c8d46de799e50a'
+  image: 'ghcr.io/rios0rios0/pipelines/golang:1.26-awscli@sha256:e94477b4584d71e847170c4524f9efa6115252ce8fbffd05a5df60f36ee20c1b'
   script:
     - '[[ -f config.sh ]] && ./config.sh'
     - export BUILD_FLAGS="-ldflags='-w -s'"


### PR DESCRIPTION
## Why

The `Dependency Updates` gate has failed on every run since 2026-08-20. PR #659 bumped all 27 stale pins and merged at 01:51 UTC, but the gate **still failed** when dispatched afterwards (run [34007680093](https://github.com/rios0rios0/pipelines/actions/runs/34007680093)) with two remaining updates:

| image | pinned | current |
|---|---|---|
| `ghcr.io/rios0rios0/pipelines/awscli:latest` | `sha256:9259135b…` | `sha256:b18dafea…` |
| `ghcr.io/rios0rios0/pipelines/golang:1.26-awscli` | `sha256:ea5a9bf3…` | `sha256:e94477b4…` |

Not a missed bump — a **race**. Both images are built *by this repository*, and the `containers.yaml` runs triggered by the merges that followed rebuilt and republished exactly those two:

- [run 34004977060](https://github.com/rios0rios0/pipelines/actions/runs/34004977060) (01:51 UTC, after #659) — `Build & Push awscli:latest` succeeded
- [run 34005527371](https://github.com/rios0rios0/pipelines/actions/runs/34005527371) (02:04 UTC, after #661) — `Build & Push golang:1.26-awscli` succeeded

So the digests #659 pinned were superseded minutes after they landed on `main`. Any bump of a self-built image has this property: pinning it is only correct until the next merge that touches its Dockerfile.

## What

Re-resolved both digests from GHCR and updated the two pins. Verified independently against the registry manifest API (`docker-content-digest` for the OCI index) — the values match what the checker reported.

## Verification

- `global/scripts/tools/dependency-updates/run.sh --repo-dir .` locally: **"Every pinned dependency is current."** (86 checked, 0 outdated)
- `.github/tests/test-supply-chain.sh` — 27/27 pass
- `.github/tests/test-dependency-updates.sh` — 40/40 pass
- `.github/tests/test-lambda-templates.sh` — 5/5 pass
- `.github/tests/test-deploy-providers.sh` — 185 pass / 10 fail, **identical on clean `origin/main`**; pre-existing and unrelated to this change (`require-checks` JSON-refusal assertions, environment-dependent)
- Gate re-dispatched on this branch: run [34007982954](https://github.com/rios0rios0/pipelines/actions/runs/34007982954)

## Note on concurrent work

Another branch (`fix/sonar-new-code-findings`) is editing Dockerfiles under `global/containers/`, including `golang.1.26-awscli`. **No file in this PR overlaps it** — both pins live under `gitlab/`. But if that branch merges, `containers.yaml` will rebuild and republish `golang:1.26-awscli` again and re-stale the pin this PR sets, exactly as happened above. Whichever of the two merges second should re-run the gate and re-resolve if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qfvbj7zeQrFnzV8tsu38oE