### PR TITLE
fix(sonar): removed the wholesale secrets pass-through and the credential-shaped test stage

### DIFF
--- a/.changes/unreleased/1788664491823483696-9a75.yaml
+++ b/.changes/unreleased/1788664491823483696-9a75.yaml
@@ -1,3 +1,4 @@
 kind: 'Security'
+breaking: true
 body: '**BREAKING CHANGE:** removed the `build_env_secret_names` input from `dart-cloudflare.yaml`, `npm-cloudflare.yaml` and `yarn-cloudflare.yaml`. It resolved `KEY=SECRET_NAME` lines against a whole-context dump of the `secrets` context, so one step was handed EVERY secret the caller passed in order to use two of them (SonarQube `githubactions:S7634`). Name the values through the `build_env_secrets` secret instead, which is masked the same way and passes only what the build needs'
 time: '2026-09-06T03:14:51.823379321Z'

--- a/.changes/unreleased/1788664491823483696-9a75.yaml
+++ b/.changes/unreleased/1788664491823483696-9a75.yaml
@@ -1,0 +1,3 @@
+kind: 'Security'
+body: '**BREAKING CHANGE:** removed the `build_env_secret_names` input from `dart-cloudflare.yaml`, `npm-cloudflare.yaml` and `yarn-cloudflare.yaml`. It resolved `KEY=SECRET_NAME` lines against a whole-context dump of the `secrets` context, so one step was handed EVERY secret the caller passed in order to use two of them (SonarQube `githubactions:S7634`). Name the values through the `build_env_secrets` secret instead, which is masked the same way and passes only what the build needs'
+time: '2026-09-06T03:14:51.823379321Z'

--- a/.changes/unreleased/1788664491834006508-05a9.yaml
+++ b/.changes/unreleased/1788664491834006508-05a9.yaml
@@ -1,0 +1,3 @@
+kind: 'Security'
+body: 'moved the Go test stage''s database provisioning out of `github/golang/stages/30-tests/all/action.yaml` and into `global/scripts/languages/golang/test/database.sh`. Inside a YAML block scalar the `POSTGRES_PASSWORD` line -- a name the PostgreSQL image fixes and that cannot be renamed away -- reads as a hard-coded credential in a configuration file (SonarQube `yaml:S2068`); in shell it is parsed as shell, where the value is visibly generated per run. The image name and the target variable now also cross into the script through `env:` instead of being substituted into its text'
+time: '2026-09-06T03:14:51.833921977Z'

--- a/.changes/unreleased/1788664491846046456-e084.yaml
+++ b/.changes/unreleased/1788664491846046456-e084.yaml
@@ -1,0 +1,3 @@
+kind: 'Changed'
+body: 'recorded in `sonar-project.properties` that the file is inert while the SonarCloud project runs Automatic Analysis, which reads only `.sonarcloud.properties` and supports no issue filters, so an accepted finding still has to be closed in the SonarCloud UI'
+time: '2026-09-06T03:14:51.84595005Z'

--- a/.github/workflows/dart-cloudflare.yaml
+++ b/.github/workflows/dart-cloudflare.yaml
@@ -139,22 +139,6 @@ on:
           that resolves to nothing fails the step, so a variable set on one environment and
           forgotten on the other is a named error rather than a bundle built against an empty
           string.
-      build_env_secret_names:
-        type: 'string'
-        required: false
-        default: ''
-        description: |
-          `KEY=SECRET_NAME` lines, resolved from whatever secrets reached this workflow and exported
-          like `build_env_secrets`, but MASKED.
-
-          For callers using `secrets: inherit`, which passes secrets under THEIR names and therefore
-          cannot populate a declared input like `build_env_secrets`. That only works inside one
-          organization; a cross-organization caller should use `build_env_secrets` instead.
-
-          **It cannot reach an environment-scoped secret**, because nothing can -- see
-          `build_env_vars` for the variable case, which does cross. Unlike `build_env_vars` an
-          unresolvable name is NOT a failure: a value like a Sentry DSN is legitimately optional and
-          the key is simply left unset.
       deployment_environment:
         type: 'string'
         required: false
@@ -196,10 +180,15 @@ on:
           secret keeps its masking when it is passed into a reusable workflow as a secret, and loses
           it when it is passed as an input.
 
-          This is the one to reach for. Its counterpart `build_env_secret_names` exists for a caller
-          using `secrets: inherit`, which passes secrets under THEIR names and so can never populate
-          a declared input -- but `inherit` only carries secrets within a single organization, and
-          this library is a different owner from most consumers. Explicit is what works.
+          This is the only route, and naming the values here is the point of it. A
+          `build_env_secret_names` input used to sit beside it for callers using `secrets: inherit`:
+          it took `KEY=SECRET_NAME` lines and picked them out of a whole-context `toJSON` dump of
+          the secrets inside the step, which handed that one step EVERY secret the caller had
+          passed in order to use two of them. It was removed -- a step gets the secrets it needs
+          and no others.
+
+          `inherit` was never the way in regardless: it only carries secrets within a single
+          organization, and this library is a different owner from most consumers.
 
 jobs:
   dart:
@@ -251,11 +240,11 @@ jobs:
         with:
           required_checks: '${{ inputs.deployment_required_checks }}'
 
-      # The three `build_env*` inputs all write to `$GITHUB_ENV`, which lives outside the workspace
+      # The `build_env*` values all write to `$GITHUB_ENV`, which lives outside the workspace
       # -- so they survive the deploy action's own checkout, and `build_command` sees them.
       #
       # **They are applied in this order and the LAST one wins**: `build_env`, then
-      # `build_env_vars`, then `build_env_secret_names`. That is deliberate and load-bearing for
+      # `build_env_secrets`, then `build_env_vars`. That is deliberate and load-bearing for
       # one shape in particular: a caller whose `build_env` also feeds the toolchain workflow's
       # test and build jobs (`yarn.yaml` takes the same input) passes a PLACEHOLDER API origin
       # there, because those jobs prove the bundle compiles and never publish it. The real,
@@ -311,55 +300,6 @@ jobs:
         env:
           ALL_VARS: ${{ toJSON(vars) }}
           BUILD_ENV_VARS: '${{ inputs.build_env_vars }}'
-
-      # Secrets named rather than declared, for callers using `secrets: inherit` -- which passes the
-      # caller's secrets under THEIR own names, so a declared `build_env_secrets` input is never
-      # populated by it. This reaches repository and organization secrets only; an ENVIRONMENT
-      # secret cannot cross a repository boundary by any route, unlike the variables above.
-      #
-      # `toJSON(secrets)` is a considered exception to "only pass required secrets to this step",
-      # not an oversight -- static analysis flags it and is right to in general. Selecting the
-      # named ones in the expression is impossible: an input carries a LIST of names and the
-      # `secrets` context cannot be iterated in a workflow expression, so either every requested
-      # secret is a separate declared input (which `inherit` cannot populate, which is the whole
-      # problem) or the selection happens in the step.
-      #
-      # What bounds it: the exposure is one step, running an inline script from this repository
-      # with no third-party action in it; the values go straight into `$GITHUB_ENV` and are never
-      # echoed; every one of them stays masked in the log; and the step is skipped entirely unless
-      # the caller asked for something. The job already holds the deployment credentials, so this
-      # widens nothing it did not already have. **Do not add a `print` of a resolved value here.**
-      - if: "inputs.build_env_secret_names != ''"
-        run: |
-          python3 - <<'RESOLVE'
-          import json
-          import os
-
-          available = json.loads(os.environ['ALL_SECRETS'])
-          resolved = []
-          skipped = []
-          for line in os.environ['BUILD_ENV_SECRET_NAMES'].splitlines():
-              line = line.strip()
-              if not line:
-                  continue
-              key, _, name = line.partition('=')
-              value = available.get(name.strip())
-              if not value:
-                  skipped.append(key.strip())
-                  continue
-              resolved.append('%s=%s' % (key.strip(), value))
-
-          if resolved:
-              with open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8') as handle:
-                  handle.write('\n'.join(resolved) + '\n')
-          print('resolved %d secret(s) for the build' % len(resolved))
-          if skipped:
-              print('left unset (not present for this environment): %s' % ', '.join(skipped))
-          RESOLVE
-        shell: 'bash'
-        env:
-          ALL_SECRETS: ${{ toJSON(secrets) }}
-          BUILD_ENV_SECRET_NAMES: '${{ inputs.build_env_secret_names }}'
 
       # Refused here rather than by `wrangler`, which reports a missing token as an authentication
       # failure against an account it could not identify.

--- a/.github/workflows/npm-cloudflare.yaml
+++ b/.github/workflows/npm-cloudflare.yaml
@@ -123,22 +123,6 @@ on:
           that resolves to nothing fails the step, so a variable set on one environment and
           forgotten on the other is a named error rather than a bundle built against an empty
           string.
-      build_env_secret_names:
-        type: 'string'
-        required: false
-        default: ''
-        description: |
-          `KEY=SECRET_NAME` lines, resolved from whatever secrets reached this workflow and exported
-          like `build_env_secrets`, but MASKED.
-
-          For callers using `secrets: inherit`, which passes secrets under THEIR names and therefore
-          cannot populate a declared input like `build_env_secrets`. That only works inside one
-          organization; a cross-organization caller should use `build_env_secrets` instead.
-
-          **It cannot reach an environment-scoped secret**, because nothing can -- see
-          `build_env_vars` for the variable case, which does cross. Unlike `build_env_vars` an
-          unresolvable name is NOT a failure: a value like a Sentry DSN is legitimately optional and
-          the key is simply left unset.
       deployment_environment:
         type: 'string'
         required: false
@@ -183,10 +167,15 @@ on:
           secret keeps its masking when it is passed into a reusable workflow as a secret, and loses
           it when it is passed as an input.
 
-          This is the one to reach for. Its counterpart `build_env_secret_names` exists for a caller
-          using `secrets: inherit`, which passes secrets under THEIR names and so can never populate
-          a declared input -- but `inherit` only carries secrets within a single organization, and
-          this library is a different owner from most consumers. Explicit is what works.
+          This is the only route, and naming the values here is the point of it. A
+          `build_env_secret_names` input used to sit beside it for callers using `secrets: inherit`:
+          it took `KEY=SECRET_NAME` lines and picked them out of a whole-context `toJSON` dump of
+          the secrets inside the step, which handed that one step EVERY secret the caller had
+          passed in order to use two of them. It was removed -- a step gets the secrets it needs
+          and no others.
+
+          `inherit` was never the way in regardless: it only carries secrets within a single
+          organization, and this library is a different owner from most consumers.
 
 jobs:
   npm:
@@ -233,11 +222,11 @@ jobs:
         with:
           required_checks: '${{ inputs.deployment_required_checks }}'
 
-      # The three `build_env*` inputs all write to `$GITHUB_ENV`, which lives outside the workspace
+      # The `build_env*` values all write to `$GITHUB_ENV`, which lives outside the workspace
       # -- so they survive the deploy action's own checkout, and `build_command` sees them.
       #
       # **They are applied in this order and the LAST one wins**: `build_env`, then
-      # `build_env_vars`, then `build_env_secret_names`. That is deliberate and load-bearing for
+      # `build_env_secrets`, then `build_env_vars`. That is deliberate and load-bearing for
       # one shape in particular: a caller whose `build_env` also feeds the toolchain workflow's
       # test and build jobs (`yarn.yaml` takes the same input) passes a PLACEHOLDER API origin
       # there, because those jobs prove the bundle compiles and never publish it. The real,
@@ -293,55 +282,6 @@ jobs:
         env:
           ALL_VARS: ${{ toJSON(vars) }}
           BUILD_ENV_VARS: '${{ inputs.build_env_vars }}'
-
-      # Secrets named rather than declared, for callers using `secrets: inherit` -- which passes the
-      # caller's secrets under THEIR own names, so a declared `build_env_secrets` input is never
-      # populated by it. This reaches repository and organization secrets only; an ENVIRONMENT
-      # secret cannot cross a repository boundary by any route, unlike the variables above.
-      #
-      # `toJSON(secrets)` is a considered exception to "only pass required secrets to this step",
-      # not an oversight -- static analysis flags it and is right to in general. Selecting the
-      # named ones in the expression is impossible: an input carries a LIST of names and the
-      # `secrets` context cannot be iterated in a workflow expression, so either every requested
-      # secret is a separate declared input (which `inherit` cannot populate, which is the whole
-      # problem) or the selection happens in the step.
-      #
-      # What bounds it: the exposure is one step, running an inline script from this repository
-      # with no third-party action in it; the values go straight into `$GITHUB_ENV` and are never
-      # echoed; every one of them stays masked in the log; and the step is skipped entirely unless
-      # the caller asked for something. The job already holds the deployment credentials, so this
-      # widens nothing it did not already have. **Do not add a `print` of a resolved value here.**
-      - if: "inputs.build_env_secret_names != ''"
-        run: |
-          python3 - <<'RESOLVE'
-          import json
-          import os
-
-          available = json.loads(os.environ['ALL_SECRETS'])
-          resolved = []
-          skipped = []
-          for line in os.environ['BUILD_ENV_SECRET_NAMES'].splitlines():
-              line = line.strip()
-              if not line:
-                  continue
-              key, _, name = line.partition('=')
-              value = available.get(name.strip())
-              if not value:
-                  skipped.append(key.strip())
-                  continue
-              resolved.append('%s=%s' % (key.strip(), value))
-
-          if resolved:
-              with open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8') as handle:
-                  handle.write('\n'.join(resolved) + '\n')
-          print('resolved %d secret(s) for the build' % len(resolved))
-          if skipped:
-              print('left unset (not present for this environment): %s' % ', '.join(skipped))
-          RESOLVE
-        shell: 'bash'
-        env:
-          ALL_SECRETS: ${{ toJSON(secrets) }}
-          BUILD_ENV_SECRET_NAMES: '${{ inputs.build_env_secret_names }}'
 
       # Refused here rather than by `wrangler`, which reports a missing token as an authentication
       # failure against an account it could not identify.

--- a/.github/workflows/yarn-cloudflare.yaml
+++ b/.github/workflows/yarn-cloudflare.yaml
@@ -134,22 +134,6 @@ on:
           that resolves to nothing fails the step, so a variable set on one environment and
           forgotten on the other is a named error rather than a bundle built against an empty
           string.
-      build_env_secret_names:
-        type: 'string'
-        required: false
-        default: ''
-        description: |
-          `KEY=SECRET_NAME` lines, resolved from whatever secrets reached this workflow and exported
-          like `build_env_secrets`, but MASKED.
-
-          For callers using `secrets: inherit`, which passes secrets under THEIR names and therefore
-          cannot populate a declared input like `build_env_secrets`. That only works inside one
-          organization; a cross-organization caller should use `build_env_secrets` instead.
-
-          **It cannot reach an environment-scoped secret**, because nothing can -- see
-          `build_env_vars` for the variable case, which does cross. Unlike `build_env_vars` an
-          unresolvable name is NOT a failure: a value like a Sentry DSN is legitimately optional and
-          the key is simply left unset.
       deployment_environment:
         type: 'string'
         required: false
@@ -194,10 +178,15 @@ on:
           secret keeps its masking when it is passed into a reusable workflow as a secret, and loses
           it when it is passed as an input.
 
-          This is the one to reach for. Its counterpart `build_env_secret_names` exists for a caller
-          using `secrets: inherit`, which passes secrets under THEIR names and so can never populate
-          a declared input -- but `inherit` only carries secrets within a single organization, and
-          this library is a different owner from most consumers. Explicit is what works.
+          This is the only route, and naming the values here is the point of it. A
+          `build_env_secret_names` input used to sit beside it for callers using `secrets: inherit`:
+          it took `KEY=SECRET_NAME` lines and picked them out of a whole-context `toJSON` dump of
+          the secrets inside the step, which handed that one step EVERY secret the caller had
+          passed in order to use two of them. It was removed -- a step gets the secrets it needs
+          and no others.
+
+          `inherit` was never the way in regardless: it only carries secrets within a single
+          organization, and this library is a different owner from most consumers.
 
 jobs:
   yarn:
@@ -245,11 +234,11 @@ jobs:
         with:
           required_checks: '${{ inputs.deployment_required_checks }}'
 
-      # The three `build_env*` inputs all write to `$GITHUB_ENV`, which lives outside the workspace
+      # The `build_env*` values all write to `$GITHUB_ENV`, which lives outside the workspace
       # -- so they survive the deploy action's own checkout, and `build_command` sees them.
       #
       # **They are applied in this order and the LAST one wins**: `build_env`, then
-      # `build_env_vars`, then `build_env_secret_names`. That is deliberate and load-bearing for
+      # `build_env_secrets`, then `build_env_vars`. That is deliberate and load-bearing for
       # one shape in particular: a caller whose `build_env` also feeds the toolchain workflow's
       # test and build jobs (`yarn.yaml` takes the same input) passes a PLACEHOLDER API origin
       # there, because those jobs prove the bundle compiles and never publish it. The real,
@@ -305,55 +294,6 @@ jobs:
         env:
           ALL_VARS: ${{ toJSON(vars) }}
           BUILD_ENV_VARS: '${{ inputs.build_env_vars }}'
-
-      # Secrets named rather than declared, for callers using `secrets: inherit` -- which passes the
-      # caller's secrets under THEIR own names, so a declared `build_env_secrets` input is never
-      # populated by it. This reaches repository and organization secrets only; an ENVIRONMENT
-      # secret cannot cross a repository boundary by any route, unlike the variables above.
-      #
-      # `toJSON(secrets)` is a considered exception to "only pass required secrets to this step",
-      # not an oversight -- static analysis flags it and is right to in general. Selecting the
-      # named ones in the expression is impossible: an input carries a LIST of names and the
-      # `secrets` context cannot be iterated in a workflow expression, so either every requested
-      # secret is a separate declared input (which `inherit` cannot populate, which is the whole
-      # problem) or the selection happens in the step.
-      #
-      # What bounds it: the exposure is one step, running an inline script from this repository
-      # with no third-party action in it; the values go straight into `$GITHUB_ENV` and are never
-      # echoed; every one of them stays masked in the log; and the step is skipped entirely unless
-      # the caller asked for something. The job already holds the deployment credentials, so this
-      # widens nothing it did not already have. **Do not add a `print` of a resolved value here.**
-      - if: "inputs.build_env_secret_names != ''"
-        run: |
-          python3 - <<'RESOLVE'
-          import json
-          import os
-
-          available = json.loads(os.environ['ALL_SECRETS'])
-          resolved = []
-          skipped = []
-          for line in os.environ['BUILD_ENV_SECRET_NAMES'].splitlines():
-              line = line.strip()
-              if not line:
-                  continue
-              key, _, name = line.partition('=')
-              value = available.get(name.strip())
-              if not value:
-                  skipped.append(key.strip())
-                  continue
-              resolved.append('%s=%s' % (key.strip(), value))
-
-          if resolved:
-              with open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8') as handle:
-                  handle.write('\n'.join(resolved) + '\n')
-          print('resolved %d secret(s) for the build' % len(resolved))
-          if skipped:
-              print('left unset (not present for this environment): %s' % ', '.join(skipped))
-          RESOLVE
-        shell: 'bash'
-        env:
-          ALL_SECRETS: ${{ toJSON(secrets) }}
-          BUILD_ENV_SECRET_NAMES: '${{ inputs.build_env_secret_names }}'
 
       # Refused here rather than by `wrangler`, which reports a missing token as an authentication
       # failure against an account it could not identify.

--- a/github/golang/stages/30-tests/all/action.yaml
+++ b/github/golang/stages/30-tests/all/action.yaml
@@ -34,82 +34,30 @@ runs:
     - name: 'Checkout code'
       uses: 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1' # v7.0.1
 
+    # Hoisted above the database step, which runs one of the scripts it fetches.
+    # `SCRIPTS_DIR` is written to `$GITHUB_ENV`, so it is only readable from the
+    # steps that come AFTER this one.
+    - uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
+
     # Started here with `docker run` rather than declared as a job-level `services:` block,
     # because a service block cannot be omitted by expression -- declaring one unconditionally
     # would force a database on every consumer that does not want one.
+    #
+    # The script rather than an inline `run:` block: the provisioning has to name
+    # `POSTGRES_PASSWORD`, which is the PostgreSQL image's documented contract and cannot be
+    # renamed away, and inside a YAML block scalar that name reads as a hard-coded credential
+    # in a configuration file to every analyser that parses YAML. In shell it is parsed as
+    # shell, where the value is plainly generated rather than written down.
+    #
+    # Both inputs cross through `env:` rather than being substituted into the script's text,
+    # so a consumer's image name is data to the shell and never a fragment of it.
     - name: 'Start the test database'
       if: "inputs.database_image != ''"
       shell: 'bash'
-      run: |
-        set -euo pipefail
-
-        if [ -z "${{ inputs.database_url_env }}" ]; then
-          echo "::error::database_image is set but database_url_env is empty; nothing would read the database"
-          exit 1
-        fi
-
-        # A hosted runner is discarded after the job, but a self-hosted one is not: a container
-        # left behind by a cancelled or crashed run still holds the name, and `docker run`
-        # refuses to start a second one with it.
-        docker rm --force 'pipelines-test-db' >/dev/null 2>&1 || true
-
-        # `127.0.0.1::5432` rather than `5432:5432`: the empty host port asks Docker for a free
-        # ephemeral one, so a machine already running PostgreSQL on 5432 -- the normal state of
-        # a developer box or a long-lived self-hosted runner -- does not collide; and binding
-        # the published port to loopback keeps the database off every other interface, since
-        # the default `0.0.0.0` would put an instance with well-known credentials on the
-        # network the runner sits in.
-        # Generated per run rather than a literal. The old hard-coded value was
-        # only ever reachable on loopback, so this is not a leaked credential --
-        # but a well-known password is still a well-known password, and every
-        # secret scanner reads one in a template as a finding it cannot tell
-        # apart from a real one. A random value costs nothing here because
-        # nothing outside this step ever needs to know it.
-        db_password="$(openssl rand -hex 24 2>/dev/null \
-          || head -c 24 /dev/urandom | od -An -tx1 | tr -d ' \n')"
-        if [ -z "$db_password" ]; then
-          echo '::error::could not generate a password for the test database'
-          exit 1
-        fi
-
-        docker run --detach --name 'pipelines-test-db' \
-          --env POSTGRES_USER='pipelines' \
-          --env POSTGRES_PASSWORD="$db_password" \
-          --env POSTGRES_DB='pipelines_test' \
-          --publish '127.0.0.1::5432' \
-          --health-cmd 'pg_isready -U pipelines' \
-          --health-interval '5s' \
-          --health-timeout '5s' \
-          --health-retries '20' \
-          '${{ inputs.database_image }}'
-
-        for _ in $(seq 1 60); do
-          state="$(docker inspect --format '{{.State.Health.Status}}' 'pipelines-test-db' 2>/dev/null || echo 'starting')"
-          [ "$state" = 'healthy' ] && break
-          sleep 2
-        done
-
-        if [ "$(docker inspect --format '{{.State.Health.Status}}' 'pipelines-test-db')" != 'healthy' ]; then
-          echo '::error::the test database never became healthy'
-          docker logs 'pipelines-test-db' || true
-          exit 1
-        fi
-
-        # Read the port Docker actually assigned. `docker port` answers `127.0.0.1:49163`, and
-        # an IPv6 host would answer `[::1]:49163`, so take the field after the LAST colon.
-        host_port="$(docker port 'pipelines-test-db' '5432/tcp' | head -n 1)"
-        host_port="${host_port##*:}"
-        if [ -z "$host_port" ]; then
-          echo '::error::could not resolve the published port of the test database'
-          exit 1
-        fi
-
-        # printf rather than interpolation: the Gitleaks "Password in URL" rule matches the
-        # literal `://<something>:<something>@` shape, and an interpolated user:password@ still
-        # reads as that shape even though it holds no credential. A format string does not.
-        url="$(printf 'postgres://%s:%s@%s:%s/%s?sslmode=disable' \
-          'pipelines' "$db_password" '127.0.0.1' "$host_port" 'pipelines_test')"
-        echo "${{ inputs.database_url_env }}=${url}" >> "$GITHUB_ENV"
+      run: '$SCRIPTS_DIR/global/scripts/languages/golang/test/database.sh'
+      env:
+        DATABASE_IMAGE: '${{ inputs.database_image }}'
+        DATABASE_URL_ENV: '${{ inputs.database_url_env }}'
 
     - name: 'Setup Go'
       id: 'setup-go'
@@ -168,8 +116,6 @@ runs:
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-test-tools-
           ${{ runner.os }}-${{ runner.arch }}-go-test-tools-
-
-    - uses: 'rios0rios0/pipelines/github/global/abstracts/scripts-repo@main'
 
     - run: $SCRIPTS_DIR/global/scripts/languages/golang/test/run.sh
       shell: 'bash'

--- a/global/scripts/languages/golang/test/database.sh
+++ b/global/scripts/languages/golang/test/database.sh
@@ -25,22 +25,25 @@ CONTAINER_NAME='pipelines-test-db'
 DB_USER='pipelines'
 DB_NAME='pipelines_test'
 
-# `::error::` lines stay on STDOUT deliberately, here and below. They are
-# GitHub Actions workflow commands, and the runner parses those from stdout
-# only -- redirected to stderr they lose the annotation and print as literal
-# text. That is why they do not follow the usual "errors go to stderr" rule.
-#
-# Both messages name the environment variable AND the action input that sets
-# it. The variable is what this script reads; the input is what the person
-# reading the failed log actually wrote, in `github/golang/stages/30-tests/all`.
-if [ -z "${DATABASE_IMAGE:-}" ]; then
-  echo "::error::DATABASE_IMAGE is empty (the 'database_image' input); nothing to provision"
+# Every exit goes through here, which is also why the one line that breaks the
+# usual "diagnostics go to stderr" rule only has to be explained once:
+# `::error::` is a GitHub Actions workflow COMMAND, not a message, and the
+# runner parses workflow commands from stdout. Redirected to stderr it stops
+# being an annotation and prints as literal text.
+fail() {
+  echo "::error::$1"
   exit 1
+}
+
+# Both messages name the environment variable AND the action input that sets it.
+# The variable is what this script reads; the input is what the person reading
+# the failed log actually wrote, in `github/golang/stages/30-tests/all`.
+if [ -z "${DATABASE_IMAGE:-}" ]; then
+  fail "DATABASE_IMAGE is empty (the 'database_image' input); nothing to provision"
 fi
 
 if [ -z "${DATABASE_URL_ENV:-}" ]; then
-  echo "::error::DATABASE_IMAGE is set but DATABASE_URL_ENV (the 'database_url_env' input) is empty; nothing would read the database"
-  exit 1
+  fail "DATABASE_IMAGE is set but DATABASE_URL_ENV (the 'database_url_env' input) is empty; nothing would read the database"
 fi
 
 # A hosted runner is discarded after the job, but a self-hosted one is not: a container
@@ -56,8 +59,7 @@ docker rm --force "$CONTAINER_NAME" >/dev/null 2>&1 || true
 POSTGRES_PASSWORD="$(openssl rand -hex 24 2>/dev/null \
   || head -c 24 /dev/urandom | od -An -tx1 | tr -d ' \n')"
 if [ -z "$POSTGRES_PASSWORD" ]; then
-  echo '::error::could not generate a credential for the test database'
-  exit 1
+  fail 'could not generate a credential for the test database'
 fi
 export POSTGRES_PASSWORD
 
@@ -89,9 +91,8 @@ for _ in $(seq 1 60); do
 done
 
 if [ "$(docker inspect --format '{{.State.Health.Status}}' "$CONTAINER_NAME")" != 'healthy' ]; then
-  echo '::error::the test database never became healthy'
   docker logs "$CONTAINER_NAME" || true
-  exit 1
+  fail 'the test database never became healthy'
 fi
 
 # Read the port Docker actually assigned. `docker port` answers `127.0.0.1:49163`, and
@@ -99,8 +100,7 @@ fi
 host_port="$(docker port "$CONTAINER_NAME" '5432/tcp' | head -n 1)"
 host_port="${host_port##*:}"
 if [ -z "$host_port" ]; then
-  echo '::error::could not resolve the published port of the test database'
-  exit 1
+  fail 'could not resolve the published port of the test database'
 fi
 
 # printf rather than interpolation: the Gitleaks "Password in URL" rule matches the

--- a/global/scripts/languages/golang/test/database.sh
+++ b/global/scripts/languages/golang/test/database.sh
@@ -30,8 +30,11 @@ DB_NAME='pipelines_test'
 # `::error::` is a GitHub Actions workflow COMMAND, not a message, and the
 # runner parses workflow commands from stdout. Redirected to stderr it stops
 # being an annotation and prints as literal text.
+# `local` is deliberately absent: this is POSIX `sh`, where it is not a keyword
+# (shellcheck SC3043), and no other script in this tree uses it.
 fail() {
-  echo "::error::$1"
+  fail_message="$1"
+  echo "::error::$fail_message"
   exit 1
 }
 

--- a/global/scripts/languages/golang/test/database.sh
+++ b/global/scripts/languages/golang/test/database.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env sh
+# Provision the throwaway PostgreSQL the Go integration tests run against, and
+# export its connection URL under the name the caller asked for.
+#
+# WHY THIS IS A SCRIPT AND NOT AN INLINE `run:` BLOCK
+#
+# It used to live inside `github/golang/stages/30-tests/all/action.yaml`. A YAML
+# block scalar is opaque to every analyser that reads YAML: the whole script is
+# one string, so `POSTGRES_PASSWORD=...` inside it reads as a hard-coded
+# credential in a configuration file (SonarQube `yaml:S2068`) no matter what the
+# right-hand side actually is. Here the same lines are shell, parsed as shell,
+# and the value is visibly a command substitution rather than a literal.
+#
+# It is also the shape the rest of this library already uses -- every non-trivial
+# step calls `$SCRIPTS_DIR/global/scripts/...` -- so this is one fewer step whose
+# behaviour can only be read out of a workflow file.
+#
+# Inputs (all through the environment, never interpolated into the text):
+#   DATABASE_IMAGE   -- PostgreSQL-compatible image to run. Required.
+#   DATABASE_URL_ENV -- name of the variable the composed URL is exported into.
+#   GITHUB_ENV       -- file the export is appended to, provided by the runner.
+set -eu
+
+CONTAINER_NAME='pipelines-test-db'
+DB_USER='pipelines'
+DB_NAME='pipelines_test'
+
+if [ -z "${DATABASE_IMAGE:-}" ]; then
+  echo "::error::DATABASE_IMAGE is empty; nothing to provision"
+  exit 1
+fi
+
+if [ -z "${DATABASE_URL_ENV:-}" ]; then
+  echo "::error::database_image is set but database_url_env is empty; nothing would read the database"
+  exit 1
+fi
+
+# A hosted runner is discarded after the job, but a self-hosted one is not: a container
+# left behind by a cancelled or crashed run still holds the name, and `docker run`
+# refuses to start a second one with it.
+docker rm --force "$CONTAINER_NAME" >/dev/null 2>&1 || true
+
+# Generated per run rather than a literal. The old hard-coded value was only ever
+# reachable on loopback, so it was not a leaked credential -- but a well-known
+# value is still a well-known value, and every scanner reads one in a template as
+# a finding it cannot tell apart from a real one. A random value costs nothing
+# here because nothing outside this job ever needs to know it.
+POSTGRES_PASSWORD="$(openssl rand -hex 24 2>/dev/null \
+  || head -c 24 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+if [ -z "$POSTGRES_PASSWORD" ]; then
+  echo '::error::could not generate a credential for the test database'
+  exit 1
+fi
+export POSTGRES_PASSWORD
+
+# `--env POSTGRES_PASSWORD` without a value: Docker copies it from this process's
+# environment, so the generated value never appears in the argument vector -- and
+# `ps` on a shared self-hosted runner cannot read it out of the `docker run` line.
+#
+# `127.0.0.1::5432` rather than `5432:5432`: the empty host port asks Docker for a free
+# ephemeral one, so a machine already running PostgreSQL on 5432 -- the normal state of
+# a developer box or a long-lived self-hosted runner -- does not collide; and binding
+# the published port to loopback keeps the database off every other interface, since
+# the default `0.0.0.0` would put an instance with well-known credentials on the
+# network the runner sits in.
+docker run --detach --name "$CONTAINER_NAME" \
+  --env "POSTGRES_USER=$DB_USER" \
+  --env POSTGRES_PASSWORD \
+  --env "POSTGRES_DB=$DB_NAME" \
+  --publish '127.0.0.1::5432' \
+  --health-cmd "pg_isready -U $DB_USER" \
+  --health-interval '5s' \
+  --health-timeout '5s' \
+  --health-retries '20' \
+  "$DATABASE_IMAGE"
+
+for _ in $(seq 1 60); do
+  state="$(docker inspect --format '{{.State.Health.Status}}' "$CONTAINER_NAME" 2>/dev/null || echo 'starting')"
+  [ "$state" = 'healthy' ] && break
+  sleep 2
+done
+
+if [ "$(docker inspect --format '{{.State.Health.Status}}' "$CONTAINER_NAME")" != 'healthy' ]; then
+  echo '::error::the test database never became healthy'
+  docker logs "$CONTAINER_NAME" || true
+  exit 1
+fi
+
+# Read the port Docker actually assigned. `docker port` answers `127.0.0.1:49163`, and
+# an IPv6 host would answer `[::1]:49163`, so take the field after the LAST colon.
+host_port="$(docker port "$CONTAINER_NAME" '5432/tcp' | head -n 1)"
+host_port="${host_port##*:}"
+if [ -z "$host_port" ]; then
+  echo '::error::could not resolve the published port of the test database'
+  exit 1
+fi
+
+# printf rather than interpolation: the Gitleaks "Password in URL" rule matches the
+# literal `://<something>:<something>@` shape, and an interpolated user:secret@ still
+# reads as that shape even though it holds no committed credential. A format string
+# does not.
+url="$(printf 'postgres://%s:%s@%s:%s/%s?sslmode=disable' \
+  "$DB_USER" "$POSTGRES_PASSWORD" '127.0.0.1' "$host_port" "$DB_NAME")"
+echo "${DATABASE_URL_ENV}=${url}" >> "$GITHUB_ENV"

--- a/global/scripts/languages/golang/test/database.sh
+++ b/global/scripts/languages/golang/test/database.sh
@@ -25,13 +25,21 @@ CONTAINER_NAME='pipelines-test-db'
 DB_USER='pipelines'
 DB_NAME='pipelines_test'
 
+# `::error::` lines stay on STDOUT deliberately, here and below. They are
+# GitHub Actions workflow commands, and the runner parses those from stdout
+# only -- redirected to stderr they lose the annotation and print as literal
+# text. That is why they do not follow the usual "errors go to stderr" rule.
+#
+# Both messages name the environment variable AND the action input that sets
+# it. The variable is what this script reads; the input is what the person
+# reading the failed log actually wrote, in `github/golang/stages/30-tests/all`.
 if [ -z "${DATABASE_IMAGE:-}" ]; then
-  echo "::error::DATABASE_IMAGE is empty; nothing to provision"
+  echo "::error::DATABASE_IMAGE is empty (the 'database_image' input); nothing to provision"
   exit 1
 fi
 
 if [ -z "${DATABASE_URL_ENV:-}" ]; then
-  echo "::error::database_image is set but database_url_env is empty; nothing would read the database"
+  echo "::error::DATABASE_IMAGE is set but DATABASE_URL_ENV (the 'database_url_env' input) is empty; nothing would read the database"
   exit 1
 fi
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,14 +4,26 @@
 # (sonar.projectKey, sonar.projectName, sonar.projectVersion and the coverage
 # report paths), so every line here must stay a plain `key=value` pair.
 #
+# READ THIS BEFORE ADDING AN ENTRY: nothing in this file is in effect today.
+# The SonarCloud project `rios0rios0_pipelines` runs AUTOMATIC ANALYSIS, which
+# reads `.sonarcloud.properties` and not `sonar-project.properties`, and which
+# supports only sonar.sources / sonar.tests / sonar.{,test.}{inclusions,
+# exclusions} / sonar.cpd.exclusions / sonar.sourceEncoding -- no issue filters
+# at all. So an accepted finding recorded here still shows up on the dashboard
+# and still fails the Quality Gate; it has to ALSO be marked Accepted (issue)
+# or Safe (hotspot) in the SonarCloud UI, and the entry here is the reason to
+# paste when doing it. This file becomes live the day the project switches to
+# CI-based analysis (project Administration > Analysis Method > turn Automatic
+# Analysis off, then pass `sonar_host`/`sonar_token` to the reusable workflow).
+#
 # Everything below is an ACCEPTED finding: a review decision recorded in the
-# repository rather than clicked away in the SonarCloud UI, so the reason
+# repository rather than only clicked away in the SonarCloud UI, so the reason
 # travels with the code. Each entry is scoped to one rule AND one file --
 # never a whole rule, never a whole directory -- so the same rule keeps
 # reporting everywhere else. Fixes are preferred; these are the cases where
 # the fix would remove behaviour the file exists to provide.
 
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7
 
 # e1-e4 -- docker:S6471 "runs with root as the default user".
 # These four images are CI JOB containers and mounted-workspace tools, not
@@ -22,6 +34,11 @@ sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11
 # permissions before any pipeline code executes. tor-proxy is the same story
 # from the other side -- its supervisord must start as root precisely so it
 # can drop tor to `user=tor` (see config/supervisord.conf).
+# The same reasoning, and the list of which images DO drop root, is in the
+# comment at the bottom of global/containers/mssql-tools18.latest/Dockerfile.
+# A Dockerfile cannot carry a `# NOSONAR` marker -- Docker has no end-of-line
+# comments, so the Docker analyzer does not implement one -- which is why
+# these four can only be closed in the UI.
 sonar.issue.ignore.multicriteria.e1.ruleKey=docker:S6471
 sonar.issue.ignore.multicriteria.e1.resourceKey=global/containers/golang.1.26-awscli/Dockerfile
 sonar.issue.ignore.multicriteria.e2.ruleKey=docker:S6471
@@ -31,41 +48,21 @@ sonar.issue.ignore.multicriteria.e3.resourceKey=global/containers/bfg.latest/Doc
 sonar.issue.ignore.multicriteria.e4.ruleKey=docker:S6471
 sonar.issue.ignore.multicriteria.e4.resourceKey=global/containers/tor-proxy.latest/Dockerfile
 
-# e5-e7 -- githubactions:S7634 "only pass required secrets to this step".
-# `toJSON(secrets)` is what the step is FOR: the caller names its build-time
-# secrets at runtime through the `build_env_secret_names` input, so the set
-# cannot be enumerated in the workflow. In a reusable workflow `secrets` holds
-# only what the caller chose to pass (declared secrets, or `secrets: inherit`),
-# the step resolves the names into `$GITHUB_ENV` and never prints a value, and
-# it already runs in the job that holds the deployment credentials -- so it
-# widens nothing it did not already have.
-sonar.issue.ignore.multicriteria.e5.ruleKey=githubactions:S7634
-sonar.issue.ignore.multicriteria.e5.resourceKey=.github/workflows/dart-cloudflare.yaml
-sonar.issue.ignore.multicriteria.e6.ruleKey=githubactions:S7634
-sonar.issue.ignore.multicriteria.e6.resourceKey=.github/workflows/npm-cloudflare.yaml
-sonar.issue.ignore.multicriteria.e7.ruleKey=githubactions:S7634
-sonar.issue.ignore.multicriteria.e7.resourceKey=.github/workflows/yarn-cloudflare.yaml
-
-# e8 -- yaml:S2068 "hard-coded credential" over the whole `run:` block of the
-# test-database step. There is no literal credential in it: the value is
-# generated per run by `openssl rand -hex 24`, is published only on loopback,
-# and dies with the container. What the analyzer matches is the shape
-# `POSTGRES_PASSWORD=<value>` -- and that variable NAME is the PostgreSQL
-# image's documented contract, so it cannot be renamed away.
-sonar.issue.ignore.multicriteria.e8.ruleKey=yaml:S2068
-sonar.issue.ignore.multicriteria.e8.resourceKey=github/golang/stages/30-tests/all/action.yaml
-
-# e9-e11 -- azurepipelines:S7637 "use a complete version number for the task".
+# e5-e7 -- azurepipelines:S7637 "use a complete version number for the task".
 # `AWSShellScript@1` and `TerraformInstaller@1` come from marketplace
 # extensions (AWS Toolkit for Azure DevOps, Microsoft DevLabs Terraform), and
 # their minor/patch version is whatever version of the extension the CONSUMING
-# organization has installed. Pinning one here would resolve to "task not
-# found" in every organization that installed a different one, so the major
-# version is the only reference that is portable across the repositories that
-# consume these templates.
-sonar.issue.ignore.multicriteria.e9.ruleKey=azurepipelines:S7637
-sonar.issue.ignore.multicriteria.e9.resourceKey=azure-devops/golang/stages/40-delivery/lambda.yaml
-sonar.issue.ignore.multicriteria.e10.ruleKey=azurepipelines:S7637
-sonar.issue.ignore.multicriteria.e10.resourceKey=azure-devops/golang/stages/50-deployment/lambda.yaml
-sonar.issue.ignore.multicriteria.e11.ruleKey=azurepipelines:S7637
-sonar.issue.ignore.multicriteria.e11.resourceKey=azure-devops/terraform/abstracts/terra-terraform.yaml
+# organization has installed. Azure Pipelines does accept `Task@major.minor.
+# patch`, but only for a version that is ALREADY INSTALLED in the organization
+# running the pipeline -- it never fetches an older one from the Marketplace,
+# and Microsoft documents full pinning as a temporary workaround rather than a
+# practice. Pinning one here would therefore resolve to "task not found" in
+# every organization that installed a different one, so the major version is
+# the only reference that is portable across the repositories that consume
+# these templates.
+sonar.issue.ignore.multicriteria.e5.ruleKey=azurepipelines:S7637
+sonar.issue.ignore.multicriteria.e5.resourceKey=azure-devops/golang/stages/40-delivery/lambda.yaml
+sonar.issue.ignore.multicriteria.e6.ruleKey=azurepipelines:S7637
+sonar.issue.ignore.multicriteria.e6.resourceKey=azure-devops/golang/stages/50-deployment/lambda.yaml
+sonar.issue.ignore.multicriteria.e7.ruleKey=azurepipelines:S7637
+sonar.issue.ignore.multicriteria.e7.resourceKey=azure-devops/terraform/abstracts/terra-terraform.yaml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -52,14 +52,14 @@ sonar.issue.ignore.multicriteria.e4.resourceKey=global/containers/tor-proxy.late
 # `AWSShellScript@1` and `TerraformInstaller@1` come from marketplace
 # extensions (AWS Toolkit for Azure DevOps, Microsoft DevLabs Terraform), and
 # their minor/patch version is whatever version of the extension the CONSUMING
-# organization has installed. Azure Pipelines does accept `Task@major.minor.
-# patch`, but only for a version that is ALREADY INSTALLED in the organization
-# running the pipeline -- it never fetches an older one from the Marketplace,
-# and Microsoft documents full pinning as a temporary workaround rather than a
-# practice. Pinning one here would therefore resolve to "task not found" in
-# every organization that installed a different one, so the major version is
-# the only reference that is portable across the repositories that consume
-# these templates.
+# organization has installed. Azure Pipelines does accept a full
+# `Task@major.minor.patch`, but only for a version that is ALREADY INSTALLED in
+# the organization running the pipeline -- it never fetches an older one from
+# the Marketplace, and Microsoft documents full pinning as a temporary
+# workaround rather than a practice. Pinning one here would therefore resolve
+# to "task not found" in every organization that installed a different one, so
+# the major version is the only reference that is portable across the
+# repositories that consume these templates.
 sonar.issue.ignore.multicriteria.e5.ruleKey=azurepipelines:S7637
 sonar.issue.ignore.multicriteria.e5.resourceKey=azure-devops/golang/stages/40-delivery/lambda.yaml
 sonar.issue.ignore.multicriteria.e6.ruleKey=azurepipelines:S7637


### PR DESCRIPTION
Closes the SonarCloud findings on `main` that can be closed in code, and says precisely what is left and why it can only be closed in the SonarCloud UI.

The Quality Gate on `main` is `ERROR` on two conditions: `new_security_rating` (3, needs 1 = no open vulnerabilities in new code) and `new_security_hotspots_reviewed` (0%, needs 100%). The New Code period is `previous_version` with a baseline of **2024-09-27**, and the project reports no version — so "new code" is effectively the whole repository and every finding below counts against the gate.

## Fixed here

### `githubactions:S7634` ×3 — "Only pass required secrets to this step"
`.github/workflows/{dart,npm,yarn}-cloudflare.yaml`, at the `ALL_SECRETS: ${{ toJSON(secrets) }}` line of the `build_env_secret_names` step.

The step took `KEY=SECRET_NAME` lines and picked them out of a dump of the whole `secrets` context — so one step was handed **every** secret the caller passed in order to use two of them. There is no expression that narrows it: the `secrets` context cannot be iterated, so the selection has to happen inside the step, which means the whole context has to reach the step.

The input is therefore **removed**, along with the step and the passed-in context. `build_env_secrets` already carries the same values as a declared secret, is masked identically, and names only what the build needs — the workflows' own documentation already called it "the one to reach for". `build_env_secret_names` existed only for callers using `secrets: inherit`, which does not cross an owner boundary and so never worked for most consumers anyway.

Nothing calls it: a GitHub-wide code search for `build_env_secret_names` returns only this repository (the three workflows, `CHANGELOG.md` and `sonar-project.properties`).

**BREAKING CHANGE:** a caller that used `build_env_secret_names` should pass the same values through the `build_env_secrets` secret instead.

### `yaml:S2068` ×1 — `"password" detected here`
`github/golang/stages/30-tests/all/action.yaml`, over the whole `run:` block of the "Start the test database" step (lines 43–114).

The value was already generated per run (`openssl rand -hex 24`), so there was no credential to remove. What the analyzer matches is the `POSTGRES_PASSWORD` line inside a YAML **block scalar**: the whole script is one opaque string to anything reading the file as YAML, and `POSTGRES_PASSWORD` is the PostgreSQL image's documented contract, so it cannot be renamed away.

The provisioning therefore moved into `global/scripts/languages/golang/test/database.sh`, which is the shape the rest of this library already uses (`$SCRIPTS_DIR/global/scripts/...`). There the same lines are shell, parsed as shell, and the value is visibly a command substitution rather than a literal. Three things improved on the way:

- `database_image` and `database_url_env` cross into the script through `env:` instead of being substituted into its text, so a consumer's image name is data to the shell and never a fragment of it;
- the generated value reaches `docker run` through the environment (`--env POSTGRES_PASSWORD`, no `=`), so it is no longer in the argument vector where `ps` on a shared self-hosted runner could read it;
- the `scripts-repo` step is hoisted above the database step, which now runs one of the scripts it fetches.

Behaviour is otherwise identical: same container name, same ephemeral loopback port, same health-check loop, same composed URL exported under the caller's variable name.

## Not fixable in code — these need a click in SonarCloud

Both groups below are decisions this repository has already made and recorded; the blocker is purely that **`sonar-project.properties` is not read**. The project runs SonarCloud **Automatic Analysis**, which reads `.sonarcloud.properties` and supports only `sonar.sources` / `sonar.tests` / `sonar.{,test.}{inclusions,exclusions}` / `sonar.cpd.exclusions` / `sonar.sourceEncoding` — **no issue filters at all**. The `sonar.issue.ignore.multicriteria` block added in #661 has never had any effect. This PR says so at the top of the file so the next reader does not assume those findings are handled.

### `docker:S6471` ×4 — "runs with root as the default user"
`global/containers/{golang.1.26-awscli,awscli.latest,bfg.latest}/Dockerfile` (reported as vulnerabilities) and `global/containers/tor-proxy.latest/Dockerfile` (reported as a hotspot).

`golang.1.26-awscli` is an Azure Pipelines `container:` and a GitLab `image:`; `awscli.latest` is a GitLab `image:`; `bfg` rewrites a git repository bind-mounted at `/code`; `tor-proxy`'s supervisord must start as root precisely so it can drop tor to `user=tor`. A fixed non-root UID breaks each of them, which is the reasoning already written into `global/containers/mssql-tools18.latest/Dockerfile` — the one image in the set that *did* drop root, because it only calls `sqlcmd` against a remote server.

A Dockerfile cannot carry a `# NOSONAR` marker either: Docker has no end-of-line comments, so the Docker analyzer does not implement one ([Sonar documents this](https://docs.sonarsource.com/sonarqube-cloud/analyzing-source-code/languages/docker)). **These four can only be closed by marking them Accepted / Safe in the SonarCloud UI.**

### `azurepipelines:S7637` ×4 — "Use complete version number for the task"
`azure-devops/golang/stages/40-delivery/lambda.yaml:93`, `azure-devops/golang/stages/50-deployment/lambda.yaml:59` and `:255` (`AWSShellScript@1`), `azure-devops/terraform/abstracts/terra-terraform.yaml:2` (`TerraformInstaller@1`).

Azure Pipelines does accept `Task@major.minor.patch` — but Microsoft documents it as a temporary workaround, and it resolves only against a version **already installed in the organization running the pipeline**; it never fetches an older one from the Marketplace. Both tasks come from marketplace extensions (AWS Toolkit for Azure DevOps, Microsoft DevLabs Terraform), so their minor/patch version is whatever each consuming organization installed. Pinning one here would mean "task not found" everywhere else. The major version is the only portable reference. **These are hotspots: they need Review → Safe in the UI.**

### One-line alternative worth considering
The New Code definition is `previous_version` against a 2024-09-27 baseline and the project publishes no version, so every pre-existing finding in the repository is permanently "new code". Switching New Code to "Number of days" (30, say) in the project settings would drop all eight remaining findings out of the gate's scope without pretending they are not there — and would keep the gate honest about code actually written from now on.

## Verification

- `make test` — every target that passes on `main` in this environment still passes; nothing regressed. The suite cannot run to completion on this machine (Termux/arm64): `test-dependency-track`, `test-go-script`, `test-basic-checks`, `test-dependency-check`, `test-terraform-validate`, `test-terraform-provider-mirror`, `test-deploy-providers` and `test-dart-pipeline` fail identically on `origin/main` (hard-coded `/tmp` paths, and no terraform / dart / docker available). Every other target, including `test-workflow-composition`, `test-supply-chain`, `test-azure-step-names`, `test-yaml-merge` and `test-sonarqube`, passes on this branch.
- SonarCloud on this PR: **Quality Gate passed**, 0 new security hotspots, and the four findings above are gone from the files they were on. One new issue remains, `shelldre:S7677` on `database.sh` — "Redirect this error message to stderr". It is the `echo "::error::$fail_message"` inside the script's single `fail` helper, and it has to stay on stdout: `::error::` is a GitHub Actions **workflow command**, and the runner parses those from stdout only — redirected to stderr it stops being an annotation and prints as literal text. The script says so at that line. Everything else the analyser raised on the new file was fixed (five call sites collapsed into one helper, and its positional parameter named).

- `make lint` and `make sast` are not targets in this repository's `Makefile` — it defines only the container and per-test targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qfvbj7zeQrFnzV8tsu38oE
