### PR TITLE
fix(containers): skipped deleted or renamed folders in the image build matrix

### DIFF
--- a/.changes/unreleased/1788670537694912119-5e97.yaml
+++ b/.changes/unreleased/1788670537694912119-5e97.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'stopped the Container Images workflow from trying to build folders that a push deleted or renamed: the change detection now lives in `global/scripts/tools/containers/detect-changed-folders.sh`, only emits folders that still exist at the pushed commit, and fails a manual dispatch that names a missing folder with the list of valid ones. The merge that renamed `python.3.10-pdm-bullseye` and `python.3.13-pdm-bullseye` to their bookworm folders listed both paths in the diff, so the run tried to build the deleted folders and failed with `unable to prepare context: path ... not found`. Covered by the new `make test-containers-detect` suite'
+time: '2026-09-06T04:55:37.694796598Z'

--- a/.changes/unreleased/1788670537709151806-a8fa.yaml
+++ b/.changes/unreleased/1788670537709151806-a8fa.yaml
@@ -1,0 +1,3 @@
+kind: 'Changed'
+body: 'repinned `ghcr.io/rios0rios0/pipelines/python:3.10-pdm-bookworm` in `gitlab/python/abstracts/pdm.yaml` to the digest published by the `main` rebuild after #664, so the dependency-updates gate stays green on its next scheduled run'
+time: '2026-09-06T04:55:37.709054462Z'

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,6 +23,7 @@ This repository provides comprehensive SDLC pipeline templates for GitHub Action
 - `make test-terraform-validate` - Test the root-module `terraform validate` tier specifically
 - `make test-terraform-provider-mirror` - Test the local Terraform provider mirror specifically
 - `make test-docker-multi-arch` - Test 40-delivery/docker multi-arch contract specifically
+- `make test-containers-detect` - Test the Container Images change detection (deleted/renamed folders, dispatch inputs) specifically
 - `make test-basic-checks` - Test basic-checks changelog validation (chlog fragments + legacy CHANGELOG.md) specifically
 - `make test-gitignore` - Test the shared `.gitignore` block generator specifically
 - `make test-dependency-check` - Test the OWASP Dependency-Check NVD cache / API-key contract specifically
@@ -805,6 +806,7 @@ make test-var-catalog
 make test-terraform-validate
 make test-terraform-provider-mirror
 make test-docker-multi-arch
+make test-containers-detect
 make test-basic-checks
 make test-gitignore
 make test-dependency-check

--- a/.github/tests/test-containers-detect.sh
+++ b/.github/tests/test-containers-detect.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -e
+
+# Regression test for `global/scripts/tools/containers/detect-changed-folders.sh`,
+# the matrix builder behind the Container Images workflow.
+#
+# Why it exists: the merge that renamed `python.3.10-pdm-bullseye` to
+# `python.3.10-pdm-bookworm` listed BOTH paths in `git diff`, the deleted folder
+# reached the build matrix, and `docker buildx build` failed with
+# `unable to prepare context: path "global/containers/python.3.10-pdm-bullseye"
+# not found`. The script must only ever emit folders that exist at the commit
+# being built, and a manual dispatch naming a missing folder must fail fast.
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$SCRIPTS_DIR/global/scripts/tools/containers/detect-changed-folders.sh"
+
+PASS=0
+FAIL=0
+pass() { echo "[test-containers-detect] PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "[test-containers-detect] FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# given: a repository with two image folders, then a push that renames one of them
+cd "$WORK"
+git init --quiet .
+git config user.email test@example.com
+git config user.name test
+mkdir -p global/containers/python.3.10-pdm-bullseye global/containers/tor-proxy.latest
+echo 'FROM scratch' > global/containers/python.3.10-pdm-bullseye/Dockerfile
+echo 'FROM scratch' > global/containers/tor-proxy.latest/Dockerfile
+git add -A && git commit --quiet -m 'initial'
+BEFORE="$(git rev-parse HEAD)"
+git mv global/containers/python.3.10-pdm-bullseye global/containers/python.3.10-pdm-bookworm
+echo '# rebuilt' >> global/containers/tor-proxy.latest/Dockerfile
+git add -A && git commit --quiet -m 'rename'
+AFTER="$(git rev-parse HEAD)"
+
+# when: the push path runs
+OUT="$(EVENT_NAME=push BEFORE="$BEFORE" AFTER="$AFTER" "$SCRIPT" 2>/dev/null)"
+
+# then: the deleted folder is absent, the renamed and modified ones are present
+if echo "$OUT" | grep -q '"tag":"3.10-pdm-bullseye"'; then
+  fail "push: deleted folder python.3.10-pdm-bullseye leaked into the matrix"
+else
+  pass "push: deleted folder is excluded from the matrix"
+fi
+if echo "$OUT" | grep -q '{"name":"python","tag":"3.10-pdm-bookworm"}' && echo "$OUT" | grep -q '{"name":"tor-proxy","tag":"latest"}'; then
+  pass "push: renamed and modified folders are built"
+else
+  fail "push: expected python:3.10-pdm-bookworm and tor-proxy:latest, got: $OUT"
+fi
+if echo "$OUT" | grep -q '^has_changes=true$'; then
+  pass "push: has_changes is true when folders remain"
+else
+  fail "push: has_changes should be true, got: $OUT"
+fi
+
+# given: a push that only deletes a folder
+git rm -r --quiet global/containers/python.3.10-pdm-bookworm
+git commit --quiet -m 'delete'
+BEFORE2="$AFTER"
+AFTER2="$(git rev-parse HEAD)"
+# when
+OUT2="$(EVENT_NAME=push BEFORE="$BEFORE2" AFTER="$AFTER2" "$SCRIPT" 2>/dev/null)"
+# then: nothing to build, and the output is still valid JSON for the workflow
+if echo "$OUT2" | grep -q '^has_changes=false$' && echo "$OUT2" | grep -q '^matrix={"include":\[\]}$'; then
+  pass "push: a deletion-only push produces an empty matrix"
+else
+  fail "push: deletion-only push should produce an empty matrix, got: $OUT2"
+fi
+
+# given: a manual dispatch naming a folder that does not exist
+# when
+if EVENT_NAME=workflow_dispatch INPUT_FOLDER=python.3.10-pdm-bullseye "$SCRIPT" >/dev/null 2>"$WORK/err.txt"; then
+  fail "dispatch: a missing folder should fail fast"
+else
+  # then: the error names the folder and lists the valid ones
+  if grep -q "python.3.10-pdm-bullseye' does not exist" "$WORK/err.txt" && grep -q 'tor-proxy.latest' "$WORK/err.txt"; then
+    pass "dispatch: a missing folder fails fast and lists the valid folders"
+  else
+    fail "dispatch: unexpected error output: $(cat "$WORK/err.txt")"
+  fi
+fi
+
+# given: a manual dispatch with an empty folder input
+# when
+OUT3="$(EVENT_NAME=workflow_dispatch INPUT_FOLDER='' "$SCRIPT" 2>/dev/null)"
+# then: every existing folder is built
+if echo "$OUT3" | grep -q '{"name":"tor-proxy","tag":"latest"}' && ! echo "$OUT3" | grep -q 'python'; then
+  pass "dispatch: empty input builds every existing folder and nothing else"
+else
+  fail "dispatch: expected only tor-proxy:latest, got: $OUT3"
+fi
+
+# given: a first push of a branch (GitHub reports an all-zero `before`)
+# when
+OUT4="$(EVENT_NAME=push BEFORE=0000000000000000000000000000000000000000 AFTER="$AFTER2" "$SCRIPT" 2>/dev/null)"
+# then: everything that exists is built
+if echo "$OUT4" | grep -q '{"name":"tor-proxy","tag":"latest"}'; then
+  pass "push: an initial push builds every existing folder"
+else
+  fail "push: initial push should build tor-proxy:latest, got: $OUT4"
+fi
+
+echo "[test-containers-detect] $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -57,61 +57,16 @@ jobs:
 
       - name: 'Detect changed container folders'
         id: 'set-matrix'
+        # The logic lives in a script so `.github/tests/test-containers-detect.sh`
+        # can exercise it; it drops folders that were deleted or renamed in the
+        # push, which otherwise fail the build with a missing-context error.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_FOLDER: ${{ github.event.inputs.container_folder }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
         run: |
-          INPUT_FOLDER="${{ github.event.inputs.container_folder }}"
-
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            # Manual trigger: use the provided folder or enumerate all
-            if [ -n "$INPUT_FOLDER" ]; then
-              CHANGED_DIRS="$INPUT_FOLDER"
-            else
-              CHANGED_DIRS=$(ls -d global/containers/*/ 2>/dev/null | \
-                awk -F'/' '{print $3}' | sort -u)
-            fi
-          else
-            # Push trigger: detect changes via git diff
-            BEFORE="${{ github.event.before }}"
-            AFTER="${{ github.sha }}"
-
-            # Handle initial push where 'before' is all zeros
-            if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-              # Initial push: build all containers rather than relying on a missing parent commit
-              CHANGED_DIRS=$(ls -d global/containers/*/ 2>/dev/null | \
-                awk -F'/' '{print $3}' | sort -u)
-            else
-              CHANGED_DIRS=$(git diff --name-only "$BEFORE" "$AFTER" -- 'global/containers/' | \
-                awk -F'/' '{if ($3 != "") print $3}' | sort -u)
-            fi
-          fi
-
-          if [ -z "$CHANGED_DIRS" ]; then
-            echo "No container changes detected."
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "has_changes=true" >> "$GITHUB_OUTPUT"
-
-          # Build the matrix JSON from folder names (convention: NAME.TAG)
-          MATRIX_JSON='{"include":['
-          FIRST=true
-          for DIR in $CHANGED_DIRS; do
-            # Split on the first dot: everything before is NAME, everything after is TAG
-            NAME="${DIR%%.*}"
-            TAG="${DIR#*.}"
-
-            if [ "$FIRST" = true ]; then
-              FIRST=false
-            else
-              MATRIX_JSON+=','
-            fi
-            MATRIX_JSON+="{\"name\":\"${NAME}\",\"tag\":\"${TAG}\"}"
-          done
-          MATRIX_JSON+=']}'
-
-          echo "matrix=${MATRIX_JSON}" >> "$GITHUB_OUTPUT"
-          echo "Detected container changes: ${MATRIX_JSON}"
+          ./global/scripts/tools/containers/detect-changed-folders.sh >> "$GITHUB_OUTPUT"
 
   build-and-push:
     name: 'Build & Push ${{ matrix.name }}:${{ matrix.tag }}'

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TAG := latest
 ROOT := global/containers
 CONTAINER_REGISTRY = ghcr.io/rios0rios0/pipelines
 
-.PHONY: login setup-buildx build build-and-push test-dependency-track test-go-script test-cyclonedx-main test-go-cache-trim test-go-tmpdir-modcache test-go-integration-scope test-lambda test-yaml-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-var-catalog test-terraform-validate test-terraform-provider-mirror test-docker-multi-arch test-basic-checks test-gitignore test-dependency-check test-goreleaser-prepare test-release-version-extraction test-release-reconcile test-deploy-providers test-memory-detection test-dart-pipeline test-javascript-pipeline test-terra-pipeline test-workflow-composition test-supply-chain test-runner-cache-gating test-azure-step-names test-dependency-updates test-go-module-toolchain check-dependency-updates test
+.PHONY: login setup-buildx build build-and-push test-dependency-track test-go-script test-cyclonedx-main test-go-cache-trim test-go-tmpdir-modcache test-go-integration-scope test-lambda test-yaml-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-var-catalog test-terraform-validate test-terraform-provider-mirror test-docker-multi-arch test-containers-detect test-basic-checks test-gitignore test-dependency-check test-goreleaser-prepare test-release-version-extraction test-release-reconcile test-deploy-providers test-memory-detection test-dart-pipeline test-javascript-pipeline test-terra-pipeline test-workflow-composition test-supply-chain test-runner-cache-gating test-azure-step-names test-dependency-updates test-go-module-toolchain check-dependency-updates test
 
 login:
 	docker login $(CONTAINER_REGISTRY)
@@ -104,6 +104,10 @@ test-docker-multi-arch:
 	@echo "Running 40-delivery/docker multi-arch contract validation..."
 	@./.github/tests/test-docker-multi-arch.sh
 
+test-containers-detect:
+	@echo "Running Container Images change-detection validation..."
+	@./.github/tests/test-containers-detect.sh
+
 test-basic-checks:
 	@echo "Running basic-checks changelog validation..."
 	@./.github/tests/test-basic-checks.sh
@@ -182,5 +186,5 @@ test-go-module-toolchain:
 	@echo "Running Go module/builder toolchain agreement validation..."
 	@./.github/tests/test-go-module-toolchain.sh
 
-test: test-dependency-track test-go-module-toolchain test-go-script test-cyclonedx-main test-go-cache-trim test-go-tmpdir-modcache test-go-integration-scope test-go-tool-staleness test-lambda test-yaml-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-var-catalog test-terraform-validate test-terraform-provider-mirror test-docker-multi-arch test-basic-checks test-gitignore test-dependency-check test-goreleaser-prepare test-release-version-extraction test-release-reconcile test-deploy-providers test-memory-detection test-dart-pipeline test-javascript-pipeline test-terra-pipeline test-workflow-composition test-supply-chain test-runner-cache-gating test-azure-step-names test-dependency-updates
+test: test-dependency-track test-go-module-toolchain test-go-script test-cyclonedx-main test-go-cache-trim test-go-tmpdir-modcache test-go-integration-scope test-go-tool-staleness test-lambda test-yaml-merge test-sonarqube test-release-tag-idempotency test-tftest-gen test-order-check test-var-catalog test-terraform-validate test-terraform-provider-mirror test-docker-multi-arch test-basic-checks test-gitignore test-dependency-check test-goreleaser-prepare test-release-version-extraction test-release-reconcile test-deploy-providers test-memory-detection test-dart-pipeline test-javascript-pipeline test-terra-pipeline test-workflow-composition test-supply-chain test-runner-cache-gating test-azure-step-names test-dependency-updates test-containers-detect
 	@echo "All tests completed successfully!"

--- a/gitlab/python/abstracts/pdm.yaml
+++ b/gitlab/python/abstracts/pdm.yaml
@@ -1,5 +1,5 @@
 .pdm:
-  image: 'ghcr.io/rios0rios0/pipelines/python:3.10-pdm-bookworm@sha256:3e2399d0308598c03856faa3e13429485531be409ce240a0c6d3fa64aec1cc92'
+  image: 'ghcr.io/rios0rios0/pipelines/python:3.10-pdm-bookworm@sha256:b97e547f1be082d057b5e41533cb08b292ca5def63e0222570cdda87ac0096b0'
   cache: # relative to the project directory ($CI_PROJECT_DIR)
     key: "$CI_JOB_NAME"
     paths:

--- a/global/scripts/tools/containers/detect-changed-folders.sh
+++ b/global/scripts/tools/containers/detect-changed-folders.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Decide which `global/containers/<NAME>.<TAG>` folders the Container Images
+# workflow must build, and emit the job matrix for them.
+#
+# Inputs (environment):
+#   EVENT_NAME    GitHub event name (`push` or `workflow_dispatch`).
+#   INPUT_FOLDER  `workflow_dispatch` only: one folder name, or empty for all.
+#   BEFORE/AFTER  `push` only: the commit range GitHub reported for the push.
+#   CONTAINERS_DIR  Folder holding the image folders (default `global/containers`).
+#
+# Outputs, one `key=value` per line on stdout (the workflow appends them to
+# `$GITHUB_OUTPUT`): `has_changes=true|false` and `matrix=<json>`.
+#
+# A folder is only ever built if it EXISTS at the commit being built. A push that
+# deletes or renames a folder still lists the old path in `git diff`, and building
+# it fails with `unable to prepare context: path ... not found`; that is exactly
+# what happened when `python.3.10-pdm-bullseye` became `python.3.10-pdm-bookworm`.
+# A dispatch naming a folder that does not exist fails fast with a clear message
+# instead of a buildx context error.
+set -euo pipefail
+
+CONTAINERS_DIR="${CONTAINERS_DIR:-global/containers}"
+EVENT_NAME="${EVENT_NAME:-push}"
+INPUT_FOLDER="${INPUT_FOLDER:-}"
+BEFORE="${BEFORE:-}"
+AFTER="${AFTER:-HEAD}"
+
+list_all_folders() {
+  find "${CONTAINERS_DIR}" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' 2>/dev/null | sort -u
+}
+
+if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+  if [ -n "${INPUT_FOLDER}" ]; then
+    if [ ! -d "${CONTAINERS_DIR}/${INPUT_FOLDER}" ]; then
+      echo "ERROR: '${CONTAINERS_DIR}/${INPUT_FOLDER}' does not exist; pick one of:" >&2
+      list_all_folders | sed 's/^/  - /' >&2
+      exit 1
+    fi
+    CHANGED_DIRS="${INPUT_FOLDER}"
+  else
+    CHANGED_DIRS="$(list_all_folders)"
+  fi
+elif [ -z "${BEFORE}" ] || [ "${BEFORE}" = "0000000000000000000000000000000000000000" ]; then
+  # First push of a branch: there is no parent to diff against, build everything.
+  CHANGED_DIRS="$(list_all_folders)"
+else
+  CHANGED_DIRS="$(git diff --name-only "${BEFORE}" "${AFTER}" -- "${CONTAINERS_DIR}/" \
+    | awk -F'/' '{if ($3 != "") print $3}' | sort -u)"
+fi
+
+# Drop folders that no longer exist (deleted or renamed in this push).
+EXISTING_DIRS=""
+for DIR in ${CHANGED_DIRS}; do
+  if [ -d "${CONTAINERS_DIR}/${DIR}" ]; then
+    EXISTING_DIRS="${EXISTING_DIRS}${DIR}"$'\n'
+  else
+    echo "Skipping '${DIR}': folder no longer exists at ${AFTER}." >&2
+  fi
+done
+CHANGED_DIRS="$(printf '%s' "${EXISTING_DIRS}" | sed '/^$/d')"
+
+if [ -z "${CHANGED_DIRS}" ]; then
+  echo "No container changes detected." >&2
+  echo "has_changes=false"
+  echo 'matrix={"include":[]}'
+  exit 0
+fi
+
+# Folder naming convention is NAME.TAG: everything before the first dot is the
+# image name, everything after it is the tag.
+MATRIX_JSON='{"include":['
+FIRST=true
+for DIR in ${CHANGED_DIRS}; do
+  NAME="${DIR%%.*}"
+  TAG="${DIR#*.}"
+  if [ "${FIRST}" = true ]; then FIRST=false; else MATRIX_JSON+=','; fi
+  MATRIX_JSON+="{\"name\":\"${NAME}\",\"tag\":\"${TAG}\"}"
+done
+MATRIX_JSON+=']}'
+
+echo "Detected container changes: ${MATRIX_JSON}" >&2
+echo "has_changes=true"
+echo "matrix=${MATRIX_JSON}"


### PR DESCRIPTION
## Summary
Two follow-ups to #664, found on the first `main` run after the merge (https://github.com/rios0rios0/pipelines/actions/runs/34011920778).

## Fixed: deleted folders reached the build matrix
Renaming `python.3.10-pdm-bullseye` and `python.3.13-pdm-bullseye` listed both the old and the new paths in `git diff`, so the matrix contained the deleted folders and their jobs failed with `unable to prepare context: path "global/containers/python.3.10-pdm-bullseye" not found`. The detection now lives in `global/scripts/tools/containers/detect-changed-folders.sh`, emits only folders that exist at the pushed commit, and fails a manual dispatch that names a missing folder with the list of valid ones. `make test-containers-detect` (7 cases: rename, deletion-only push, missing dispatch folder, empty dispatch, initial push) covers it.

## Changed: repinned `python:3.10-pdm-bookworm`
The `main` rebuild produced a new digest, so the pin in `gitlab/python/abstracts/pdm.yaml` moved from `3e2399d0…` to `b97e547f…`. `check_updates.py` now reports every pinned dependency current.

## Verification
`make test-containers-detect` 7/7, `make test-workflow-composition`, `make test-supply-chain`, `make test-dependency-updates`, `make test-docker-multi-arch` all pass locally; shellcheck clean on both new scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)