### PR TITLE
fix(dart): worded the coverage comment's file section for a change with no instrumented file

### DIFF
--- a/.changes/unreleased/1788829646742421652-5208.yaml
+++ b/.changes/unreleased/1788829646742421652-5208.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'fixed the wording of the coverage comment''s file section when a pull request touches no instrumented source: a docs-only change read "0 changed file(s)" above "6 more changed file(s) are not in the tracefile", as if six were listed. The summary now counts the instrumented files against all the changed ones ("1 of 2 changed file(s)", "none of the 6 changed file(s) ... is instrumented", "no file changed"), and the explanation no longer says "more" over an empty table'
+time: '2026-09-08T01:07:26.742324881Z'

--- a/.github/tests/test-dart-pipeline.sh
+++ b/.github/tests/test-dart-pipeline.sh
@@ -637,7 +637,29 @@ assert_true "markdown: an instrumented file the change did not touch is not list
 assert_true "markdown: a repository path is mapped onto the package's (the 'app/' prefix is stripped)" \
   "! grep -q 'app/lib/main.dart' '$MD_REPO/app/changed.md'"
 assert_true "markdown: a changed file outside the tracefile is counted, and one outside the package is not" \
-  "grep -q '^1 more changed file(s) are not in the tracefile' '$MD_REPO/app/changed.md'"
+  "grep -q '^1 other changed file(s) are not in the tracefile' '$MD_REPO/app/changed.md'"
+assert_true "markdown: the summary counts the instrumented files against all the changed ones" \
+  "grep -q 'File coverage &mdash; 1 of 2 changed file(s) since' '$MD_REPO/app/changed.md'"
+
+# A change that touches no instrumented source -- a docs or test-only pull
+# request -- must say so, not "0 changed file(s)" over "N more ... are not in
+# the tracefile", as if N were listed above.
+printf '// covers answer() and util(), twice\n' > "$MD_REPO/app/test/main_test.dart"
+# Only the test file: `add -A` would sweep the renderer's own outputs above into
+# this commit and the diff would count them as the change under test.
+md_git add app/test/main_test.dart
+md_git commit --quiet -m 'tests only'
+MD_TESTS_ONLY_BASE="$(md_git rev-parse HEAD~1)"
+(cd "$MD_REPO/app" && DART_COVERAGE_DIFF_BASE="$MD_TESTS_ONLY_BASE" \
+  python3 "$MD" lcov.info testsonly.md > /dev/null 2>&1)
+assert_true "markdown: a change with no instrumented file says so in the summary" \
+  "grep -q 'File coverage &mdash; none of the 1 changed file(s) since' '$MD_REPO/app/testsonly.md'"
+assert_true "markdown: ...and explains it without claiming anything was listed" \
+  "grep -q '^Nothing to list: tests, assets' '$MD_REPO/app/testsonly.md' && ! grep -q 'other changed file' '$MD_REPO/app/testsonly.md'"
+(cd "$MD_REPO/app" && DART_COVERAGE_DIFF_BASE="$(md_git rev-parse HEAD)" \
+  python3 "$MD" lcov.info nochange.md > /dev/null 2>&1)
+assert_true "markdown: a base equal to HEAD reads as no file changed" \
+  "grep -q 'File coverage &mdash; no file changed since' '$MD_REPO/app/nochange.md'"
 
 # Listing the files is the one step that can fail for reasons that have nothing
 # to do with the code -- no network for the fetch, a base the checkout never

--- a/global/scripts/languages/dart/test/lcov_to_markdown.py
+++ b/global/scripts/languages/dart/test/lcov_to_markdown.py
@@ -244,22 +244,33 @@ def render_files(
         ]
 
     by_path = {entry.path: entry for entry in files}
+    total = len(set(changed))
     touched = sorted(path for path in set(changed) if path in by_path)
-    unmeasured = len(set(changed)) - len(touched)
+    unmeasured = total - len(touched)
 
-    out = [
-        "",
-        "<details>",
-        "<summary>File coverage &mdash; {} changed file(s) since <code>{}</code></summary>".format(
-            len(touched), short_base
-        ),
-        "",
-    ]
-    if unmeasured:
+    # The summary counts the instrumented files AGAINST all the changed ones, and
+    # the explanation never says "more" over an empty table: a docs-only pull
+    # request once read "0 changed file(s)" above "6 more changed file(s) are
+    # not in the tracefile", as if six were listed.
+    if not total:
+        summary = "no file changed since <code>{}</code>".format(short_base)
+    elif touched:
+        summary = "{} of {} changed file(s) since <code>{}</code>".format(
+            len(touched), total, short_base
+        )
+    else:
+        summary = "none of the {} changed file(s) since <code>{}</code> is instrumented".format(
+            total, short_base
+        )
+    not_measured = (
+        "tests, assets, excluded generated sources and anything outside the "
+        "instrumented directories are not measured"
+    )
+
+    out = ["", "<details>", "<summary>File coverage &mdash; {}</summary>".format(summary), ""]
+    if touched and unmeasured:
         out += [
-            "{} more changed file(s) are not in the tracefile: tests, assets, excluded "
-            "generated sources and anything outside the instrumented directories are "
-            "not measured.".format(unmeasured),
+            "{} other changed file(s) are not in the tracefile: {}.".format(unmeasured, not_measured),
             "",
         ]
     if touched:
@@ -284,8 +295,12 @@ def render_files(
             out.append(
                 "| ... and {} more file(s) | | | | |".format(len(touched) - FILE_ROWS_MAX)
             )
+    elif total:
+        out.append(
+            "Nothing to list: {}, and this change touches nothing else.".format(not_measured)
+        )
     else:
-        out.append("No changed file is instrumented, so there is nothing to list.")
+        out.append("Nothing to list.")
     out += ["", "</details>"]
     return out
 


### PR DESCRIPTION
## What

A wording defect the first live coverage comment exposed. On medhub-life/frontend-dart#90, a docs-only pull request, the file section read:

> File coverage — 0 changed file(s) since `30052a5`
> 6 more changed file(s) are not in the tracefile: …
> No changed file is instrumented, so there is nothing to list.

"6 more" over an empty table reads as if six were listed above it. The section now counts the instrumented files against all the changed ones, in three shapes:

| Change | Summary line | Body |
|---|---|---|
| some instrumented | `File coverage — 1 of 2 changed file(s) since …` | the table, then "1 other changed file(s) are not in the tracefile: …" |
| none instrumented | `File coverage — none of the 6 changed file(s) since … is instrumented` | "Nothing to list: tests, assets, … are not measured, and this change touches nothing else." |
| nothing changed | `File coverage — no file changed since …` | "Nothing to list." |

## Verification

`make test-dart-pipeline` gains four assertions covering the three shapes (a tests-only commit and a base equal to `HEAD` join the existing monorepo fixture); the pass set is otherwise `main`'s. Renderer totals are untouched. Independent of rios0rios0/pipelines#675; the two touch different hunks of the same files and merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXTHnyrvDc6H8edB7jhAYv
